### PR TITLE
Cambios en las vistas anteriores

### DIFF
--- a/Vistas/frmAdvertencia.Designer.cs
+++ b/Vistas/frmAdvertencia.Designer.cs
@@ -1,0 +1,179 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmAdvertencia
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmAdvertencia));
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.lbl_Mensaje = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.btn_Si = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.btn_No = new Bunifu.Framework.UI.BunifuFlatButton();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.BackColor = System.Drawing.Color.Transparent;
+            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
+            this.pictureBox1.Location = new System.Drawing.Point(119, 27);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(102, 90);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox1.TabIndex = 0;
+            this.pictureBox1.TabStop = false;
+            // 
+            // lbl_Mensaje
+            // 
+            this.lbl_Mensaje.AutoEllipsis = true;
+            this.lbl_Mensaje.Font = new System.Drawing.Font("Roboto", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_Mensaje.Location = new System.Drawing.Point(27, 171);
+            this.lbl_Mensaje.Name = "lbl_Mensaje";
+            this.lbl_Mensaje.Size = new System.Drawing.Size(281, 60);
+            this.lbl_Mensaje.TabIndex = 6;
+            this.lbl_Mensaje.Text = "Mensaje";
+            this.lbl_Mensaje.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label1
+            // 
+            this.label1.Font = new System.Drawing.Font("Roboto Light", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(120)))), ((int)(((byte)(120)))), ((int)(((byte)(120)))));
+            this.label1.Location = new System.Drawing.Point(12, 216);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(306, 82);
+            this.label1.TabIndex = 7;
+            this.label1.Text = "¿Está seguro que quiere realizar esta acción?";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // btn_Si
+            // 
+            this.btn_Si.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(172)))), ((int)(((byte)(192)))), ((int)(((byte)(39)))));
+            this.btn_Si.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_Si.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_Si.BorderRadius = 4;
+            this.btn_Si.ButtonText = "Sí";
+            this.btn_Si.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_Si.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_Si.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_Si.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_Si.Iconimage = null;
+            this.btn_Si.Iconimage_right = null;
+            this.btn_Si.Iconimage_right_Selected = null;
+            this.btn_Si.Iconimage_Selected = null;
+            this.btn_Si.IconMarginLeft = 0;
+            this.btn_Si.IconMarginRight = 0;
+            this.btn_Si.IconRightVisible = true;
+            this.btn_Si.IconRightZoom = 0D;
+            this.btn_Si.IconVisible = true;
+            this.btn_Si.IconZoom = 90D;
+            this.btn_Si.IsTab = false;
+            this.btn_Si.Location = new System.Drawing.Point(60, 318);
+            this.btn_Si.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btn_Si.Name = "btn_Si";
+            this.btn_Si.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_Si.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(172)))), ((int)(((byte)(192)))), ((int)(((byte)(39)))));
+            this.btn_Si.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_Si.selected = false;
+            this.btn_Si.Size = new System.Drawing.Size(100, 33);
+            this.btn_Si.TabIndex = 8;
+            this.btn_Si.Text = "Sí";
+            this.btn_Si.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_Si.Textcolor = System.Drawing.Color.White;
+            this.btn_Si.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_Si.Click += new System.EventHandler(this.btn_Si_Click);
+            // 
+            // btn_No
+            // 
+            this.btn_No.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(210)))), ((int)(((byte)(71)))), ((int)(((byte)(63)))));
+            this.btn_No.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(241)))), ((int)(((byte)(82)))), ((int)(((byte)(73)))));
+            this.btn_No.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_No.BorderRadius = 4;
+            this.btn_No.ButtonText = "No";
+            this.btn_No.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_No.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_No.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_No.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_No.Iconimage = null;
+            this.btn_No.Iconimage_right = null;
+            this.btn_No.Iconimage_right_Selected = null;
+            this.btn_No.Iconimage_Selected = null;
+            this.btn_No.IconMarginLeft = 0;
+            this.btn_No.IconMarginRight = 0;
+            this.btn_No.IconRightVisible = true;
+            this.btn_No.IconRightZoom = 0D;
+            this.btn_No.IconVisible = true;
+            this.btn_No.IconZoom = 90D;
+            this.btn_No.IsTab = false;
+            this.btn_No.Location = new System.Drawing.Point(181, 318);
+            this.btn_No.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btn_No.Name = "btn_No";
+            this.btn_No.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(241)))), ((int)(((byte)(82)))), ((int)(((byte)(73)))));
+            this.btn_No.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(210)))), ((int)(((byte)(71)))), ((int)(((byte)(63)))));
+            this.btn_No.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_No.selected = false;
+            this.btn_No.Size = new System.Drawing.Size(100, 33);
+            this.btn_No.TabIndex = 9;
+            this.btn_No.Text = "No";
+            this.btn_No.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_No.Textcolor = System.Drawing.Color.White;
+            this.btn_No.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_No.Click += new System.EventHandler(this.btn_No_Click);
+            // 
+            // frmAdvertencia
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("$this.BackgroundImage")));
+            this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.ClientSize = new System.Drawing.Size(335, 403);
+            this.Controls.Add(this.btn_No);
+            this.Controls.Add(this.btn_Si);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.lbl_Mensaje);
+            this.Controls.Add(this.pictureBox1);
+            this.DoubleBuffered = true;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Name = "frmAdvertencia";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "frmAdvertencia";
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Label lbl_Mensaje;
+        private System.Windows.Forms.Label label1;
+        private Bunifu.Framework.UI.BunifuFlatButton btn_Si;
+        private Bunifu.Framework.UI.BunifuFlatButton btn_No;
+    }
+}

--- a/Vistas/frmAdvertencia.cs
+++ b/Vistas/frmAdvertencia.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace VistasMrTiendita
+{
+    public partial class frmAdvertencia : Form
+    {
+        public frmAdvertencia(string mensaje)
+        {
+            InitializeComponent();
+            lbl_Mensaje.Text = mensaje;
+        }
+
+        private void btn_Si_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.OK;
+        }
+
+        private void btn_No_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.Cancel;
+        }
+    }
+}

--- a/Vistas/frmAdvertencia.resx
+++ b/Vistas/frmAdvertencia.resx
@@ -1,0 +1,303 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAM8AAADFCAYAAADzGqY5AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAADwtJREFUeF7tnc9uHMcRxoU8geIXsPICAl8ggB4gQHTXQbpGh0TH5GLpmFPEk3OJ
+        YF1yDKhDcgxEIFcbNIJEkWBFpGRLik3FqyWX3F1yVpMqqjdaD2t3p2e6+u/3AT/ITqzh7kx97O6qmu4L
+        kDuNx+NL0+n06snJyQ368w79+Rlzenr6sKqq3Tn07/UyFv6bHeIhsUXX2DTXu0E/48poNNowPxKC0tLc
+        JBzQHNzrDKEIG2yLPwd/HpgKikp1XV/k3/aTyeQWByoxMIEbK/z5HvLn5c9tvgYE+RH/Bjdm4WlT7GZp
+        w5mZMDJBKuLf0ry2CDgF8wJ9x11eh2FUgnppbhgKqhxGF2vmRsKIBLUSr2EocG4TvNgWg6pEjJE4m3fJ
+        3CoIei8eZShIUljwB4dHI0zroAucwqWA4IW/GChgJTs8GplbCZUgnppxdin3xb8v5lM6c3uhXGVSzJia
+        KQATZSp+qBhp/AATZSKTCMCaJgBsIqS5ExStay7RA+TsmfhggT/IRJydQ4o7BWFdEyUDfi7mEUGxiX7D
+        bdBDwhQtYngqh1EoMtGD4a4A8YGBKLltHh0USmZtg9EmQTAKBRTWNlmAtZBPmebNu42HANLmLj9X84gh
+        DfE0DcXOPME0TlGm4IlpWsawgeiX41XzyCEXohuLbFpZIBvnQnQjsb4pExioq0xiAC02ZbOFRIKljHHw
+        KjRgdpBIaClk1EATZOJaCMYBy4CBVgjGAeuAgQRla5zpfl3953Y9e/KT+t0/fuQV/pnV19fr0+On8mdL
+        FBhoQdkah4I2hGma8GfI0UAUN2Vn4fgG0M3IMqs227sqBnMIZl9t1NPpVPycCbNTtIHoBuRZxxl9LgZx
+        SEbf/SVHA22ZUCpL9MWzbbmp3twTAzgk4xe/qYfDYY4GumtCqgzRF866Vy1W87x9+zZXA5XRylNVFW9x
+        K92AbKi+/5MYwCE5evX7M/NkbKC898/ONrPW5PipGMAhGX375/+bJ1MDDbJNYXNmpJgi6GRfDOCQNM2T
+        o4GyTWHTlyvq1YJ3jz4SgzgUwzd/P2eeHA1E5JVAMJt1SF80W2aPwxdIF5GMMyc3A2WzqQivc+gLFff6
+        9Gzv52IQh2D26MeiaRZhA9G0R/wuCZLH+qeYdU6D2YvrYiCH4PTJZdEwTQ4ODnIy0EMTgmmKvkCxew9U
+        rz8RAzkEp1/9VDSLRE4GoqnoHROKaclM18QvVQIxFUonz66JRllGTgai75HeMSelTtfmxFQonXcX2JCR
+        gdKavpWYXTtHRIXS429+KxpkHbkYKJnsW6nZtXNEVCgdvf6jaI42ZGKgNLJvdKPvCx++SGIplErdBTZk
+        YqC4X1+gG8wHTEkfvEhiKZQe7v9NNIUNmRgo3ubR0pMETWIplA4Hz0VD2JKBgeJMHtBNvSF82KKJpVAq
+        GaErqRuI49SEbDzCqHOeGAql1eNLogn6kLKB6HPvmpCNQxh1ZGIolNp0F9iQsoGiSl1j1FnC8K9iQPvk
+        5N8/E4PfBQkbaBDFez8YdVYQQaHUtjXHllQNFMXog1FnBREUSru05tiSooHo84Zd+2DUWU/oQmnX1hxb
+        UjTQdDoNd4QjfQCcobMG3q1TCmpf9GnNsSVBA4Wp+4zfH7ArfSCwQOhCad/WHFsSNJD/rgO6Qehha0Ho
+        QumyjT80ScxAfnveSn/RzYbQhVIpuH2QkIH8pq3ppiBR0JKQhdI2G39okoqBvL6ujfS0BQELpW03/tAk
+        EQPtmNDWFd0IvHZgQ8BCqVZrji2JGEg/cUA3AYkCGwIWSjVbc2yJ3UD02TZNiOsJUzZ7QhVKJ89vioEc
+        isgNNDAhriPUdroRqlDqozXHlsgNpDd1w5StG6EKpYtn8sRErAZSnbphytaNUIVS390FNsRoIPo8Os2i
+        dGFk2ToSqlDqYuMPTSI1kPsdRrGRYXdCFUpDtObYEpuBVN7zoQs/bP4g0JJAhVIpWGMkMgO577QWfgho
+        S4BCqcbGH5pEZCC3vW5IUfdHCnBNYmjNsSUiA7lLWWO90x/fu4fG0ppjSwwGcrruoQtivdMT34VS7Y0/
+        NAltoOl0+sCEfn/RBXHqQU98F0pj7C6wIbCB3LTq0BdAfccB1ctfikGuha+NPzQJaSAnR5JUVXVVujiw
+        o/r2d2KQa+Fz4w9NQhnIyc46/JaddHFgh+9CacytObaEMJCTt0t58SRdHFjiuVAae2uOLb4N5CRpQBfC
+        3mwu8FwodXUmT0wcHh7K91YBMmr/JlHpwqAbUpBrIQVfDoxGI/HeamAs0E3kPmTaHOKrUJpaa44tvgzU
+        K+OGthy3+CqUptpdYIMPA/XKuNHIg/3ZHOKrUBrTxh+aaBuI499YwV5IU7vFV6E0to0/NNE0UK90NTlv
+        U7oo6IavQmnqrTm2aBmI4v8zYwV7ocbjFl+F0lg3/tBEw0C9zEMXQDe1SzwVSnPqLrDBtYHIPNvGCvai
+        C6BA6hJPhdJSzcO4NBCZp3uhlP7ynnRR0B0p2F2TwsYfmrgyEMwTGT4KpVJAlYYLA/Uyj3RB0A/tQmno
+        M3liwoWBjBXsJV0M9EN799AUN/7QpK+BjBXsJV0M9EO7UFpCa44tR0dH4rNog7GCvaSLgX5oF0pLac2x
+        5fj4WHwe6zBWsJd0MdAP7UJpSa05tnQxkLGCvaSLgZ6MPheD3hWltebYYmsgYwV7SRcDPVEulJbYmmOL
+        jYGMFeyFOo8OUtC7ouTuAhvaGAhF0gjRLJTmtvGHJusMBPNEiGahNMeNPzRZY6AdYwV70V9GV7UCmoVS
+        KUDAapYZiAaP7l3V9JdxgK8CWoXS3Df+0EQyUK+922AeHbQKpegu6EfTQBT/3U/Hxh4GOmgVSmGe/iwa
+        qO8eBtg9RwOlQmnKZ/LExNxAHP/GCvbCCQlKKBVK0V3gDmOg7scr8o6J5x48cIIU/H3J4UyeWBgOhzzy
+        bBgrdJP04EF/Zs+uiAboA7oL3MGnMhgLdBe5D4VSBVwnDap/fSwGAegGjTzdC6RzYe82PWavPxGNYAsb
+        p/RNP1xD5ul/Pg/S1crs/+EsxSyZYh2zxx/X4xe/roffoyXHNWSe/ifDIeOmz2QyOVugSg8RhIHWPP3P
+        JEXGzQ80wp9tViE9SOAfehb9Mm1z0cMdNB820IHrCxiFwkL3f2BCv7+QNPALRqHgdO+mborm5Lekhwx0
+        wSgUhsFgcMuEfn/Rg8TxioHgUQgG8guZp3tbTlN1XV+kB4l1T0B44z7pQQP3mLB3J3qAeKs0MBiF9KFR
+        x916Zy6se5SZ7tenb+7Vs6+v17OnG/Xs0UcfiqH0z/y/VfT/ne7fq0eHr8QHD/rjdL0zF3eYig8d9OP4
+        6dlr2YtmacNk91o9/C9aclzjdL2zKDSJOoRGmurlr0Rj2DB+fhM75rij+1ZT60TmwenYLqDRZvbE3d5t
+        vPEHRqH+0Hqy+wG+60QPHinrvhx+4dQ4c9hAB9jwsBc0Zevfz7ZKFABIWXfF8YjTBCNQP8g8F02Y6whT
+        t47QGkfTOHPODIQ1kDVknP7v76wTBQKmbh1wkRxoCycRpAAByyHzdN8px0YUDDvN4AArUD5WRALTNyvc
+        dVGv0xRvl1pRKR/iK4ET4tqjmmVrCr1uFkz2xeDWho+Ux9qnHWqF0WXCOz7t0D6DdBU4Ja4VeoXRZaLA
+        QOKgBSGmbHOw/e56vCUKmqLgQKf1GjQPslrH6ZPLYsCAD5B5Lplw9ivsrLOed5YNny7hdY8UMOA9XhMF
+        kshAu1LQgPdIQe0TKWjAe4KNOnPhPZ/VSAHtEyloQASjDgtp69Vg2hYnwUeduU5OTjD6LAEJg/iIYtRZ
+        FNY+MponX68DqWqZaEaduWj0wRGMAkGLpC8/FYOnZKIbdeaiYEHdpwm35wRa96A95zzRjTpzUbCg60CA
+        N/iQglsTTNnOQ8bpf2yIpihYtprBUzpViFcScNhVE/89bLaq65qPJEHqusHM4+gzef4LKXiKhkadMD1s
+        tkLqWoDXPj5ew+YjFnFS3A+INkmwTBQwSB40OJu+aW4AgrNJJXajTRIsE40+2GFUoDr8QsVAbJyD77D1
+        VJNkpmtN4XVtGdcjEEYcGTLOpgnFNEXBgumbBK2BXCQRODmANY5I/Nm1dUL2bTU8Ctm28Mz+ebGe7N3E
+        aLOE4XBIg05i65xlQvZtPRVv/M5HjJCRuJmUDbJolurJ5Xr67Fp9/OpTjDRrIPO4PyYkpChAsNNoS3CI
+        VXfovqW9zpHE7/2g87o9MJA9o9Fol+PMhFxewvrHDhjIit3xeJzHOmeZKCjQPGoBrRfrg4MDKViAgX/B
+        HB0d6R4PEosoKFD/sQAGWg2ZJ+5uadeioEACwQI2EM3pxeApmUHsrxloiYICry9YAgN9gEbjLRNK5Ykz
+        IxQQOK7EEhjojB0adfLMrLUVUtjdoAWyFFClkF6ntJY4hQ0D2VOogWCcpmCgbhRmIBhnmWCgbhRiIBhn
+        nWCgbmRuIBinrdhAFBDIwlmSqYFgHFuRgTiNjTqQJePxWArAVOF0NIzTVRQQaOWxJBMDbZFxyq7juBAF
+        BAxkCRso1Y5sMk1+7+SEVFVVV5FIsCPFVxrIOHm9BRqLkImzJyEDcWJgwzxqSEMmkYCObAtiNxCZZptA
+        YsCXzKYieCu1JbEaCNO0QMI0zo7IDIRpWgyiwEA2riUxGIhMs0kgDR2LMAq1J6CBeLS5Yh4ZFJuwFmqH
+        ZwORZwp9XTo18ShEJrovBQ34gKeNRbhTAJm01ETBsYGp3Gq0DESG4fQzpmipiwLkBky0HDaQw30RdsmM
+        aZ6JAy0XTLSaPgYiwwxoDYWaTe6CiZZjayAyzC79nVvc+WFuL1SC2ETEl1IQlcy6l+pMlm6bRpsytriF
+        losC5gqZCNm5BSQD8dSMeDAej5EIgH4ok+LGlM7ABuJRhv7cIe5gaga1Eplog0ejgo00oO/P3esYZaDu
+        4gAqwUj0HfdgGEhNFFwbk8nkFv253Qy+BOHRZdt8H3Q4Q35FAXhlwUyx99QNptPpA/689M9XsIaBohL/
+        Bqfp3VUK0jscqPTvQVLh9HP3+Ofz5+DPk/2Rg1C+YlNRUPPa6QYHNP25acy1TXxJ8Hpjr2mCReb/jWGb
+        /v59A1+Ps4QwCQRBEARBEARBEKSsCxf+BxiWF0DV3tP2AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="$this.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAVUAAAGZCAYAAAA5JqLhAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAGL1JREFUeF7t3U+vJUd5x3Ew916b+FrEIoxBGglHGhNsS7CAMPYiGClbtih5OZYs
+        sWGBAP95GckiSNmxSFZmEYzyPqyIBawyqaf9PE11nb7j6eqrKFI+X+lL9+mu7nNmPPz0VHd19ReCn//8
+        569++OGHv/nggw8+bcsnJMld/+mjjz56tcXmF9NLIlAjTD/+lx8/+ePvbp/8938+R5IcjHz83b/+fQTr
+        p++9995rb7zxxs277777XIvRbbi2QP3nT1rDvZOQJLd+/OsfP/nlL3/5by0+v9J8McK1Lf8crlHS/vF3
+        L+4eTJLcGnn5/vvv/1eLz7gM8KD5UvO6GcH6WajuHUiS3Ddys8Xnd5uPbm9vv9aWX25+qSlUSfKoGapv
+        3dzcfKctv/nyyy9/5Uc/+tGVUCXJCSM3r66ufnh9ff23LUa/1fzqo0ePnm/L54QqSR40K9UfNn/Q/Jvb
+        29sHr7766gtClSQnrFBtlepbbfm6UCXJEw6h+saLL774SlsKVZKcMUP1nQjVm5ubN9r6Kw8fPowRAEKV
+        JI8auXl1dfVOC9EI1dfbMsarqlRJcsaqVJuPm0ul2oxQ/aJQJcmDVqjWNdVmVapClSSPmqEaQ6rc/SfJ
+        s0Zu5jXV6v4/MPifJCftK9W8UVV3/3X/SfKoGarL3f9mf01VpUqSR+0r1eYbcU1VqJLkpJGbMaFKhGp1
+        /4UqSU6aoboOqeoeU3VNlSSPWpVqhaohVSR5wsjNFqDrONWm7j9JzlqVaoVqdP9VqiQ56VCp9s/+C1WS
+        PGqF6vX19eOa+k+okuSkXaW6hKruP0mesKtU60aVWapIctauUnVNlSTPGrk5PFEVlarXqZDkjFmpLlP/
+        uVFFkifNSnXz4j+hSpKTZqW6XlP17D9JnrAq1Rai0f33mCpJnjEr1f7Ff977T5KzZqW66f4LVZKcNCvV
+        cUiV7j9Jzpih2r+jyjVVkpy1r1Sby9R/QpUkJ43czLv/yzhVE6qQ5Am7SvVxU6VKkmfsK9VmDf53958k
+        Z6xKtR5TNaSKJE9Yodqsu/8PMlQ9pkqSR81Qre5//5iqUCXJow6h2k+oovtPkkfNUK3XqRj8T5JnrEp1
+        mE/VjSqSnLGvVOPZf4P/SfKEkZs1838L0qpUnxeqJDlhVaotWN/O7r9Zqkhy1grVpiFVJHnWDFVT/5Hk
+        fdhXqtH9v7299d5/kpy1D9WmWapI8oyRm/07qprGqZLkrBmqm2uqJlQhyUkjN1uALqHaPVGl+0+SM1al
+        WoP/XVMlyRNWqLYQHYdU6f6T5FEjN1uArkOqhCpJnrBCtSZUaevGqZLkrJGbOaQq3qYalapn/0ly1qxU
+        40aVV1ST5FkzVPtrqipVkpy1C9WlUm2qVEly1gzVGFJVoapSJclZIzdznOpyoyquqeZjqkKVJI9alWr3
+        OhVDqkhy1grVZo1TjWuqJlQhyRkjN3OcalSqfaiqVEnyqFWp1hNVMfO/V1ST5KQZqlWp9q9T0f0nyaP2
+        oVrXVFWqJDlp5OYdU/8JVZI8aobqMktVC9Llmmpb6v6T5IyRmy1AN0OqdP9JctKsVN9pvt2CtJ9QRaVK
+        kkcdKtU321KlSpKzVqUaodqsIVUqVZKcMUN1bz5VoUqSRx0r1S5Udf9J8qiRmy1Al0mqs1KtcaoqVZI8
+        aoZqP/Wfwf8kOWuFanMZ/N8UqiQ5a4ZqPVG1zPxvSBVJTtpVqnFNNSrVB16nQpKTVqXaPVGl+0+Ss/aV
+        avN13X+SPGFVqhGqw5AqoUqSR61KNV+nIlRJ8oyRm/0TVbr/JHnCrFTXSaqbFaqeqCLJo2alGqEaN6qW
+        7r9KlSQnzUpV958k78MM1XpF9dL9N/ifJCeN3IwbVTvXVIUqSR61r1TjMVUz/5PkCTNUzVJFkvdhX6k2
+        +3dUCVWSPGrkZg3+z1mqqlLV/SfJo2aluj6mGkOq8u6/UCXJo1aoNpdrqhGqbWlIFUnOmKG6XlPNUHVN
+        lSRnHCpVs1SR5BkjN+PZ/wjVYeo/11RJ8qhZqa7d/6YhVSQ5a1+pRqjGOFXP/pPkpFWp5rP/rqmS5Bkr
+        VJvLi/+ahlSR5KwZqv3df9dUSXLWyM2a+q/u/pv6jyQnzVAdu/9ClSRnjNxsAbo3SbVxqiR51KxU45rq
+        45qlSvefJCfNStU4VZK8D7NS3YRqW6pUSXLGDNV1SJVZqkjyhJGbLUCXStXM/yR50gzVuvvvMVWSPGOF
+        arO/pupGFUnO2IdqdP9dUyXJE46VatM1VZKcNXKzH1IVoWrwP0lOekel6poqSc6YobqZpFqlSpKTdqEa
+        s1T1T1S5pkqSR43crAlVmsvg/3z2X6iS5FEzVPvu/wPdf5KcNHKzBWiNU3VNlSTPmJVqdf/r7r9QJckZ
+        s1LdjFNtClWSnPGOUDVOlSRnzFCNWaridSpvZqgaUkWSM1aoNlWqJHnWIVRjnKrXqZDkrHdUqkKVJGfM
+        UK3XqfSh6poqSR61QrWeqMpJql1TJckZM1TXd1SZ+Z8kTxi52b+iurnt/pMkj9kC9O4nqgAAz85OqG7n
+        UwUAPDsZqptrqptZqgAAz85Opbq9+w8AeHaEKgDcIxmq693/7h1VQhUAjtKH6s3NzfKOqgxVN6oA4CiR
+        mzVOdfcxVQDAs9NXqk13/wHgDGOoNt2oAoBZhCoA3CMVqjH4P6+puvsPALPsVKpCFQBm6UO17v4/fPgw
+        uv/u/gPAUVSqAHCPRG5eXV2tj6l6ogoATpChurn7b5wqAEwSudkCNEL1cfPyFdUAgGenQvX6+vpx3ahS
+        qQLAJBmqyzVVoQoAJ+lDtbl0/zNUDakCgKOMoXrximoAwLMzhmo3pEqlCgBHidzsx6lGpZpPVKlUAeAo
+        Q6Xa36hSqQLAUSpU6xXVEapNoQoAM3ShuoxTdaMKAE6QobqZpco4VQCYJHJzePbfY6oAMEtWqpu7/21p
+        PlUAmKEq1ebb1f1vqlQBYIasVNfuvxtVAHCCPlSzUq1n/4UqABwlQ3UzTlWoAsAkFarNtfvvxX8AMEmG
+        aj+kymOqADBL5KZxqgBwT2SlGt3/eEeVa6oAcIYM1U33vylUAWCGqlRzQpU3I1RVqgAwSVep1ttUXVMF
+        gFn6UG323X93/wHgKJGb8TqVHPy/vPjPkCoAmCQr1c3rVJq6/wAwQ4Zq3f1fKlUv/gOASXYqVTeqAGCW
+        yM3hiSrdfwCYpa9Ub25uXheqAHCCCtW4+2/mfwA4SV+pNs38DwBniNzMa6ox+L+6/+7+A8AMWalublSZ
+        pBoAJslQ7af+qyFVQhUAjhK5mY+pevYfAM5SlWre/Y9rqgb/A8AsGarv1JCqvPvvRhUAzBC5GXf/df8B
+        4B7ISrWeqOpvVKlUAeAoValGqDaXWaqEKgBM0leqEapN76gCgFn6SrWe/TefKgBMslepNlWqADBDhqpr
+        qgBwH/ShmoP/DakCgFm6UI33/r9+e3vr2X8AmCVDtZ9QRfcfAGapSjUeU41Q9ZgqAJxgDNWmUAWAWSI3
+        Y+q/FqJLqOY1VaEKADNkpbqGatM1VQCYJUN1b5yqu/8AcJQhVJdZqjymCgCTdKG6DqnKCVVUqgBwlMjN
+        ulFVE6o0VaoAMEMXqvFEVd39d6MKAGaI3GwBOg7+F6oAMENXqdaEKipVAJglQ3W9+69SBYATRG62AK1Z
+        qoQqAJxhrFSbuv8AMMtOqKpUAWCWyM0WoHH3vwb/q1QBYJYM1ZpQpV6nYvA/AMwQuRnd/6xUvaMKAM6Q
+        leomVPPZf5UqABylKtUWom5UAcBZ+lCtcaoqVQCYJHKzBegy+L8Zofr1towbVa6pAsBRKlRjQpWapUql
+        CgCTdJWq+VQB4CyRm1dXVz+sqf8yVFWqADBDhWoL0X7qP5UqAMwQudkCdA3VbpYqN6oA4CgZquvM/01D
+        qgBglsjN6v5nqLr7DwCzVKXahaobVQAwi1AFgHskQ3XT/W96ogoAZqhKtWapyrv/hlQBwAx9pXpzc/Nm
+        W7r7DwCzVKV6dXX1dlu6pgoAZ6hQba6D/1WqADBJhmp1/41TBYAz9JVq091/ADjDGKrds/8qVQA4Sobq
+        3jhVoQoAR6lQrZn/VaoAcILIzX5ClXidilAFgEkyVMdrqrr/ADBD5GYL0P6a6isPHz4UqgAwQ4ZqVKrL
+        s/9CFQBOUJVq3ahq6+7+A8AskZt5oyoq1aX733SjCgBmyEp1eUdVPPvfhaonqgDgKFWpevEfANwDQ6Vq
+        8D8AnCEr1fUV1capAsAJslLtp/6rUHVNFQCO0odqsw9VlSoAHGWoVN39B4AzVKjmNdXldSqPHj16vq2r
+        VAHgKJGbcaOqub74z2OqADBJVarNpVKNqf+MUwWASSpUa0iVUAWAE4yhavA/AJwgQ3V9oqqtu6YKALNE
+        bsaNqhaiNaTK61QAYJaqVJvj1H/GqQLAUSpU65pqsypVoQoAR8lQNaQKAO6DyM28plrd/weeqAKASfpK
+        tZ79z7v/uv8AcJQM1fW9/013/wFglr5SbS5PVAlVAJgkcvPqs7epjlP/CVUAOEqG6vg6FUOqAGCGqlRN
+        qAIA90DkZgvQdZxqU/cfAGapSrVCNbr/KlUAmGSoVPtn/4UqABylQvX6+vpxTf0nVAFgkq5SXUJV9x8A
+        TtBVqnWjyixVADBLV6m6pgoAZ4ncHJ6oikrV61QAYIasVJep/9yoAoCTZKW6efGfUAWASbJSXa+pevYf
+        AE5QlWoL0ej+e0wVAM6QlWr/4j/v/QeAWbJS3XT/hSoATJKV6jikSvcfAGbIUO3fUeWaKgDM0leqzWXq
+        P6EKAJNEbubd/2WcqglVAOAEXaX6uKlSBYAz9JVqswb/u/sPADNUpVqPqRpSBQAnqFBt1t3/BxmqHlMF
+        gKNkqFb3v39MVagCwFGGUO0nVNH9B4CjZKjW61QM/geAM1SlOsyn6kYVAMzQV6rx7L/B/wBwgsjNmvm/
+        BWlVqs8LVQCYoCrVFqxvZ/ffLFUAMEuFatOQKgA4S4aqqf8A4D7oK9Xo/t/e3nrvPwDM0odq0yxVAHCG
+        yM3+HVVN41QBYJYM1c01VROqAMAkkZstQJdQ7Z6o0v0HgBmqUq3B/66pAsAJKlRbiI5DqnT/AeAokZst
+        QNchVUIVAE5QoVoTqrR141QBYJbIzRxSFW9TjUrVs/8AMEtWqnGjyiuqAeAsGar9NVWVKgDM0oXqUqk2
+        VaoAMEuGagypqlBVqQLALJGbOU51uVEV11TzMVWhCgBHqUq1e52KIVUAMEuFarPGqcY1VROqAMAMkZs5
+        TjUq1T5UVaoAcJSqVOuJqpj53yuqAWCSDNWqVPvXqej+A8BR+lCta6oqVQCYJHLzjqn/hCoAHCVDdZml
+        qgXpck21LXX/AWCGyM0WoJshVbr/ADBJVqrvNN9uQdpPqKJSBYCjDJXqm22pUgWAWapSjVBt1pAqlSoA
+        zJChujefqlAFgKOMlWoXqrr/AHCUyM0WoMsk1Vmp1jhVlSoAHCVDtZ/6z+B/AJilQrW5DP5vClUAmCVD
+        tZ6oWmb+N6QKACbpKtW4phqV6gOvUwGASapS7Z6o0v0HgFn6SrX5uu4/AJygKtUI1WFIlVAFgKNUpZqv
+        UxGqAHCGyM3+iSrdfwA4QVaq6yTVzQpVT1QBwFGyUo1QjRtVS/dfpQoAk2SlqvsPAPdBhmq9onrp/hv8
+        DwCTRG7Gjaqda6pCFQCO0leq8Ziqmf8B4AQZqmapAoD7oK9Um/07qoQqABwlcrMG/+csVVWp6v4DwFGy
+        Ul0fU40hVXn3X6gCwFEqVJvLNdUI1bY0pAoAZshQXa+pZqi6pgoAMwyVqlmqAOAMkZvx7H+E6jD1n2uq
+        AHCUrFTX7n/TkCoAmKWvVCNUY5yqZ/8BYJKqVPPZf9dUAeAMFarN5cV/TUOqAGCWDNX+7r9rqgAwS+Rm
+        Tf1Xd/9N/QcAk2Sojt1/oQoAM0RutgDdm6TaOFUAOEpWqnFN9XHNUqX7DwCTZKVqnCoA3AdZqW5CtS1V
+        qgAwQ4bqOqTKLFUAcILIzRagS6Vq5n8AOEmGat3995gqAJyhQrXZX1N1owoAZuhDNbr/rqkCwAnGSrXp
+        mioAzBK52Q+pilA1+B8AJrmjUnVNFQBmyFDdTFKtUgWASbpQjVmq+ieqXFMFgKNEbtaEKs1l8H8++y9U
+        AeAoGap99/+B7j8ATBK52QK0xqm6pgoAZ8hKtbr/dfdfqALADFmpbsapNoUqAMxwR6gapwoAM2SoxixV
+        8TqVNzNUDakCgBkqVJsqVQA4yxCqMU7V61QAYJY7KlWhCgAzZKjW61T6UHVNFQCOUqFaT1TlJNWuqQLA
+        DBmq6zuqzPwPACeI3OxfUd3U/QeAWbJS9UQVANwHO6H65/lUP/jgg0//9Kc/ZVMAwNOIvMxQ3VxTXWep
+        +uijj37z8ccfZ3MAwNP45JNPnvz0pz/99xagVanW4P/P7v7/6le/+uuWup/+/ve/XxIYAHBJ5ONvf/vb
+        Jy0z//DWW2/9QwvQCNWa+f/P3f/4n/fee++1X/ziF7+OkpYkeen777//h5/97Gf/8fjx439suRl3/iNU
+        v9987aWXXvpqWz7fXEI1uHn55Ze/0pavNr/TfLv5d804KKwTLMZrBGI4QQ4p2OzrXLZH29pWx8S2fntz
+        Pcewr9+++Z7h+HD8HXvfX9uX35Dr6/7PM46p87Xlcp7aPraJ/bVe+5rr98X+XI5t+s/VZrMct+d6HbOs
+        1+dq0+8va1+uXxxzl127Wn9q+z3rHJ1xjvG3rv9e9vblcrU/Z3fcxb5+W7Urc9/yW+pzv68tL86b7n3f
+        5jd3bTZtn8Wu/cWfOz187mg3HFPnHr9j8zmPi2Ni+52/J5Z53sU6Jrb125vrOYZ9/fbN9wzHh+Pv2Pv+
+        2j7+eZ/JOKbO15aRj5GT333hhRe+2ZaRn9fNz/jJT37ypbb4i2YMC3h0fX393baMBH4cU1vl8q1Yr89p
+        XE/oPy/bsk0t+3OsZtsf5DK2Ledqy3Vbfa72ta/7vLZr9r9v/V1xTNdu7/deOJw3jOPq9/Xnvti242bf
+        Xtv4vrD213pz83dZ5r5da3/fbti2+1vH9tW2LZ/6++tzd8zmv1+6HjMev2eep1+/OKb7vs22trz4/mp3
+        R/ty93eNx3bL/s89/puNZZ2vbxeun7vt/XfH33n/b762X3y+o02dvz/nYrQru+2bf2+x7I+tfbEt1ru2
+        a/vBOt963n5ZZtv1761tq+8e/y7/L/7/P37H99t65ORrOfA/8jNy9DOePHkSJetN87b5IJP3Wzc3N3Gt
+        4PVY1vrneVfb/lzjtr31/vPTtnXLGNaw2T5a5+j2f3tYru36z81v33XOcjjvnY5txuNqvbbvfU7XP29Z
+        +8bt/b5xf/u8/tn7fd365u+m947zPXVbv6/btnxHtevbjD5l//g713P2y7LOU/b7Zrzr/OO2neXFv634
+        3LepdmObcb0t9861bhv3ldFm+HyxvOvY0bva9ucat+2t95+ftq1b/m/+/z/av9aMnIxrqbff+973rt99
+        993n2vqG2BDl64vNv2x+Ld9lHSn8Skvjr9f68PnrmdSxrbavxufaX21qvXdn+3L+PN+47+J7anvn8t2x
+        Huce2vfb1mP2Pke7tr4sa732Vbvc1lv7198wOG67+DvKz9VubT+0W7bncnOO/LzZ3+1bzlP783O/v2+/
+        rnfnq3a1Xm0367Gvbxv78hzV5uJ8sa3OmW1j/3rO0e7Yiz//XetxvjxnObbZ+7w4fMf4/cv5cttmmdb3
+        1b7F2pfW53V/tK9247Za7/e19WpfbTbL2L7T/qLtTpu9z2u7WOb21fhc+6tNrffubF/On+cb9118T23v
+        XL471uPcQ/t+23rM3udo19aXZa03H7z00kt/1ZbR5Y8KNXIz8nO9nlrEhjBK2OsccxXGMIHP84V853V8
+        wZdzfbHfPmx7qne1ie3Puq/W+2Wu7/7O/DNvjhnXP89vfOMbF+eObf25y75N7I/PtS2WTzsml+v+8bdX
+        u+bFOcqd8y+f49j4zd05NtZx/f5cv/iuOs/OuerfzCF3vnPv3Lvtemtb/fd6mjvHv3DX38Hed6UX/wbG
+        /2b9vs/blsvd48f1/ph+X98m15/6e57i/7f//0e7uCkVYRp5uRuoPRWuz2U5uxjreZmgTrDuC2Nft3/T
+        po4t63N//nTdFst+PfbF+t53dNvW76j1ahPWOWN7nbv2175qe5fVpr6zO279XMvh+2tZ673j/v7zsuy/
+        b2d7td37XWvbbrnur/a5b/P3csc5lvX63u749VyxrP398bEtP6/L/vjO8djlnHVMevFn7NpsHL5jPT63
+        b35Tf75cjp+X5dBu3Rfb47zDd/aOx/fb1z9D7a/fWPuG826O6bfXtqH9uj+Wz7K/tg1tL46JfcO51vU6
+        tqzP/fnTdVss+/XYF+t739FtW7+j1qtNWOeM7XXu2l/7qu1dVpvuO9qi5wtf+B9WlVLYQcskAwAAAABJ
+        RU5ErkJggg==
+</value>
+  </data>
+</root>

--- a/Vistas/frmCAlmacen.cs
+++ b/Vistas/frmCAlmacen.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace VistasMrTiendita
+{
+    public partial class frmCAlmacen : Form
+    {
+        public frmCAlmacen()
+        {
+            InitializeComponent();
+
+            //tablaProductos.Rows.Add("661440000953", "10", "Azúcar Zulka baja en calorías", "30.50");
+            widthColumnas();
+            tablaProductos.AllowUserToAddRows = false;
+
+            //frmCAlmacenController controlador = new frmCAlmacenController(this);
+        }
+
+        public void widthColumnas()
+        {
+            tablaProductos.Columns[0].Width = 120;
+            tablaProductos.Columns[1].Width = 75;
+            tablaProductos.Columns[2].Width = 245;
+        }
+    }
+}

--- a/Vistas/frmCAlmacen.designer.cs
+++ b/Vistas/frmCAlmacen.designer.cs
@@ -1,0 +1,971 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmCAlmacen
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmCAlmacen));
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.lbl_Titulo = new System.Windows.Forms.Label();
+            this.pb_linea = new System.Windows.Forms.PictureBox();
+            this.pb_buscar = new System.Windows.Forms.PictureBox();
+            this.lbl_buscar = new System.Windows.Forms.Label();
+            this.pb_lupa = new System.Windows.Forms.PictureBox();
+            this.tb_busqueda = new System.Windows.Forms.TextBox();
+            this.tablaProductos = new System.Windows.Forms.DataGridView();
+            this.codigo_barras = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.cantidad_actual = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.descripcion = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.precio_compra = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.pictureBox2 = new System.Windows.Forms.PictureBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.btn_nuevaEntrada = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.lbl_nuevaEntrada = new System.Windows.Forms.Label();
+            this.pb_buscar2 = new System.Windows.Forms.PictureBox();
+            this.pb_lupa2 = new System.Windows.Forms.PictureBox();
+            this.lbl_buscarProducto = new System.Windows.Forms.Label();
+            this.pb_cantidad = new System.Windows.Forms.PictureBox();
+            this.pb_totalPagar = new System.Windows.Forms.PictureBox();
+            this.lbl_totalPagar = new System.Windows.Forms.Label();
+            this.button1 = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.pnl_nuevaEntradaActiva = new System.Windows.Forms.Panel();
+            this.lbl_total = new System.Windows.Forms.Label();
+            this.tb_cantidad = new System.Windows.Forms.TextBox();
+            this.tb_codigo = new System.Windows.Forms.TextBox();
+            this.tb_busqueda2 = new System.Windows.Forms.TextBox();
+            this.btn_registrarEntrada = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.label11 = new System.Windows.Forms.Label();
+            this.pictureBox6 = new System.Windows.Forms.PictureBox();
+            this.pictureBox8 = new System.Windows.Forms.PictureBox();
+            this.pictureBox4 = new System.Windows.Forms.PictureBox();
+            this.label10 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.pb_buscarProducto = new System.Windows.Forms.PictureBox();
+            this.pictureBox3 = new System.Windows.Forms.PictureBox();
+            this.pnl_nuevaEntradaInactiva = new System.Windows.Forms.Panel();
+            this.pictureBox7 = new System.Windows.Forms.PictureBox();
+            this.tb_descripcion = new System.Windows.Forms.TextBox();
+            this.label9 = new System.Windows.Forms.Label();
+            this.lbl_cantidad = new System.Windows.Forms.Label();
+            this.label8 = new System.Windows.Forms.Label();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.label12 = new System.Windows.Forms.Label();
+            this.pictureBox5 = new System.Windows.Forms.PictureBox();
+            this.btn_cancelar = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.bunifuFlatButton1 = new Bunifu.Framework.UI.BunifuFlatButton();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_linea)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_buscar)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_lupa)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tablaProductos)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_buscar2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_lupa2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_cantidad)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_totalPagar)).BeginInit();
+            this.pnl_nuevaEntradaActiva.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox6)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox8)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_buscarProducto)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
+            this.pnl_nuevaEntradaInactiva.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox7)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox5)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // lbl_Titulo
+            // 
+            this.lbl_Titulo.AutoSize = true;
+            this.lbl_Titulo.Font = new System.Drawing.Font("Roboto", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_Titulo.Location = new System.Drawing.Point(27, 27);
+            this.lbl_Titulo.Name = "lbl_Titulo";
+            this.lbl_Titulo.Size = new System.Drawing.Size(135, 36);
+            this.lbl_Titulo.TabIndex = 0;
+            this.lbl_Titulo.Text = "Almacén";
+            // 
+            // pb_linea
+            // 
+            this.pb_linea.Image = ((System.Drawing.Image)(resources.GetObject("pb_linea.Image")));
+            this.pb_linea.Location = new System.Drawing.Point(32, 55);
+            this.pb_linea.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_linea.Name = "pb_linea";
+            this.pb_linea.Size = new System.Drawing.Size(109, 2);
+            this.pb_linea.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_linea.TabIndex = 1;
+            this.pb_linea.TabStop = false;
+            // 
+            // pb_buscar
+            // 
+            this.pb_buscar.Image = ((System.Drawing.Image)(resources.GetObject("pb_buscar.Image")));
+            this.pb_buscar.Location = new System.Drawing.Point(32, 127);
+            this.pb_buscar.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_buscar.Name = "pb_buscar";
+            this.pb_buscar.Size = new System.Drawing.Size(413, 39);
+            this.pb_buscar.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_buscar.TabIndex = 2;
+            this.pb_buscar.TabStop = false;
+            // 
+            // lbl_buscar
+            // 
+            this.lbl_buscar.AutoSize = true;
+            this.lbl_buscar.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_buscar.Location = new System.Drawing.Point(28, 103);
+            this.lbl_buscar.Name = "lbl_buscar";
+            this.lbl_buscar.Size = new System.Drawing.Size(140, 20);
+            this.lbl_buscar.TabIndex = 3;
+            this.lbl_buscar.Text = "Buscar producto:";
+            // 
+            // pb_lupa
+            // 
+            this.pb_lupa.Image = ((System.Drawing.Image)(resources.GetObject("pb_lupa.Image")));
+            this.pb_lupa.Location = new System.Drawing.Point(41, 132);
+            this.pb_lupa.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_lupa.Name = "pb_lupa";
+            this.pb_lupa.Size = new System.Drawing.Size(25, 25);
+            this.pb_lupa.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_lupa.TabIndex = 4;
+            this.pb_lupa.TabStop = false;
+            // 
+            // tb_busqueda
+            // 
+            this.tb_busqueda.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_busqueda.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_busqueda.Location = new System.Drawing.Point(75, 134);
+            this.tb_busqueda.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_busqueda.Name = "tb_busqueda";
+            this.tb_busqueda.Size = new System.Drawing.Size(357, 21);
+            this.tb_busqueda.TabIndex = 5;
+            // 
+            // tablaProductos
+            // 
+            this.tablaProductos.AllowUserToOrderColumns = true;
+            this.tablaProductos.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.tablaProductos.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
+            this.tablaProductos.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.tablaProductos.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tablaProductos.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.SingleHorizontal;
+            this.tablaProductos.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+            this.tablaProductos.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.tablaProductos.ColumnHeadersVisible = false;
+            this.tablaProductos.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.codigo_barras,
+            this.cantidad_actual,
+            this.descripcion,
+            this.precio_compra});
+            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle5.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle5.Padding = new System.Windows.Forms.Padding(2);
+            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(245)))), ((int)(((byte)(158)))));
+            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.tablaProductos.DefaultCellStyle = dataGridViewCellStyle5;
+            this.tablaProductos.GridColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(215)))), ((int)(((byte)(215)))));
+            this.tablaProductos.Location = new System.Drawing.Point(32, 239);
+            this.tablaProductos.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tablaProductos.Name = "tablaProductos";
+            this.tablaProductos.ReadOnly = true;
+            this.tablaProductos.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+            this.tablaProductos.RowHeadersVisible = false;
+            this.tablaProductos.RowHeadersWidth = 51;
+            this.tablaProductos.RowTemplate.Height = 24;
+            this.tablaProductos.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
+            this.tablaProductos.Size = new System.Drawing.Size(661, 476);
+            this.tablaProductos.TabIndex = 6;
+            // 
+            // codigo_barras
+            // 
+            this.codigo_barras.HeaderText = "Código de barras";
+            this.codigo_barras.MinimumWidth = 6;
+            this.codigo_barras.Name = "codigo_barras";
+            this.codigo_barras.ReadOnly = true;
+            // 
+            // cantidad_actual
+            // 
+            this.cantidad_actual.HeaderText = "Cantidad";
+            this.cantidad_actual.MinimumWidth = 6;
+            this.cantidad_actual.Name = "cantidad_actual";
+            this.cantidad_actual.ReadOnly = true;
+            // 
+            // descripcion
+            // 
+            this.descripcion.HeaderText = "Descripción";
+            this.descripcion.MinimumWidth = 6;
+            this.descripcion.Name = "descripcion";
+            this.descripcion.ReadOnly = true;
+            // 
+            // precio_compra
+            // 
+            this.precio_compra.HeaderText = "Precio";
+            this.precio_compra.MinimumWidth = 6;
+            this.precio_compra.Name = "precio_compra";
+            this.precio_compra.ReadOnly = true;
+            // 
+            // pictureBox2
+            // 
+            this.pictureBox2.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox2.Image")));
+            this.pictureBox2.Location = new System.Drawing.Point(32, 196);
+            this.pictureBox2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox2.Name = "pictureBox2";
+            this.pictureBox2.Size = new System.Drawing.Size(661, 44);
+            this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox2.TabIndex = 7;
+            this.pictureBox2.TabStop = false;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label1.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.ForeColor = System.Drawing.Color.White;
+            this.label1.Location = new System.Drawing.Point(35, 208);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(64, 20);
+            this.label1.TabIndex = 8;
+            this.label1.Text = "Código";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label2.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.ForeColor = System.Drawing.Color.White;
+            this.label2.Location = new System.Drawing.Point(187, 208);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(77, 20);
+            this.label2.TabIndex = 9;
+            this.label2.Text = "Cantidad";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label3.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label3.ForeColor = System.Drawing.Color.White;
+            this.label3.Location = new System.Drawing.Point(289, 208);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(99, 20);
+            this.label3.TabIndex = 10;
+            this.label3.Text = "Descripción";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label4.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.ForeColor = System.Drawing.Color.White;
+            this.label4.Location = new System.Drawing.Point(617, 208);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(58, 20);
+            this.label4.TabIndex = 11;
+            this.label4.Text = "Precio";
+            // 
+            // btn_nuevaEntrada
+            // 
+            this.btn_nuevaEntrada.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_nuevaEntrada.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_nuevaEntrada.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_nuevaEntrada.BorderRadius = 7;
+            this.btn_nuevaEntrada.ButtonText = "Agregar entrada";
+            this.btn_nuevaEntrada.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_nuevaEntrada.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_nuevaEntrada.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_nuevaEntrada.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(78)))), ((int)(((byte)(89)))), ((int)(((byte)(8)))));
+            this.btn_nuevaEntrada.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_nuevaEntrada.Iconimage = null;
+            this.btn_nuevaEntrada.Iconimage_right = null;
+            this.btn_nuevaEntrada.Iconimage_right_Selected = null;
+            this.btn_nuevaEntrada.Iconimage_Selected = null;
+            this.btn_nuevaEntrada.IconMarginLeft = 0;
+            this.btn_nuevaEntrada.IconMarginRight = 0;
+            this.btn_nuevaEntrada.IconRightVisible = true;
+            this.btn_nuevaEntrada.IconRightZoom = 0D;
+            this.btn_nuevaEntrada.IconVisible = true;
+            this.btn_nuevaEntrada.IconZoom = 90D;
+            this.btn_nuevaEntrada.IsTab = false;
+            this.btn_nuevaEntrada.Location = new System.Drawing.Point(713, 127);
+            this.btn_nuevaEntrada.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.btn_nuevaEntrada.Name = "btn_nuevaEntrada";
+            this.btn_nuevaEntrada.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_nuevaEntrada.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_nuevaEntrada.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_nuevaEntrada.selected = false;
+            this.btn_nuevaEntrada.Size = new System.Drawing.Size(163, 39);
+            this.btn_nuevaEntrada.TabIndex = 13;
+            this.btn_nuevaEntrada.Text = "Agregar entrada";
+            this.btn_nuevaEntrada.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_nuevaEntrada.Textcolor = System.Drawing.Color.White;
+            this.btn_nuevaEntrada.TextFont = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            // 
+            // lbl_nuevaEntrada
+            // 
+            this.lbl_nuevaEntrada.AutoSize = true;
+            this.lbl_nuevaEntrada.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.lbl_nuevaEntrada.Font = new System.Drawing.Font("Roboto Medium", 13.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_nuevaEntrada.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(165)))), ((int)(((byte)(176)))), ((int)(((byte)(191)))));
+            this.lbl_nuevaEntrada.Location = new System.Drawing.Point(24, 15);
+            this.lbl_nuevaEntrada.Name = "lbl_nuevaEntrada";
+            this.lbl_nuevaEntrada.Size = new System.Drawing.Size(182, 29);
+            this.lbl_nuevaEntrada.TabIndex = 14;
+            this.lbl_nuevaEntrada.Text = "Nueva entrada";
+            // 
+            // pb_buscar2
+            // 
+            this.pb_buscar2.Image = ((System.Drawing.Image)(resources.GetObject("pb_buscar2.Image")));
+            this.pb_buscar2.Location = new System.Drawing.Point(29, 82);
+            this.pb_buscar2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_buscar2.Name = "pb_buscar2";
+            this.pb_buscar2.Size = new System.Drawing.Size(363, 39);
+            this.pb_buscar2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_buscar2.TabIndex = 15;
+            this.pb_buscar2.TabStop = false;
+            // 
+            // pb_lupa2
+            // 
+            this.pb_lupa2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(215)))), ((int)(((byte)(215)))));
+            this.pb_lupa2.Image = ((System.Drawing.Image)(resources.GetObject("pb_lupa2.Image")));
+            this.pb_lupa2.Location = new System.Drawing.Point(38, 87);
+            this.pb_lupa2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_lupa2.Name = "pb_lupa2";
+            this.pb_lupa2.Size = new System.Drawing.Size(25, 25);
+            this.pb_lupa2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_lupa2.TabIndex = 16;
+            this.pb_lupa2.TabStop = false;
+            // 
+            // lbl_buscarProducto
+            // 
+            this.lbl_buscarProducto.AutoSize = true;
+            this.lbl_buscarProducto.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.lbl_buscarProducto.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_buscarProducto.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(215)))), ((int)(((byte)(215)))));
+            this.lbl_buscarProducto.Location = new System.Drawing.Point(25, 59);
+            this.lbl_buscarProducto.Name = "lbl_buscarProducto";
+            this.lbl_buscarProducto.Size = new System.Drawing.Size(140, 20);
+            this.lbl_buscarProducto.TabIndex = 21;
+            this.lbl_buscarProducto.Text = "Buscar producto:";
+            // 
+            // pb_cantidad
+            // 
+            this.pb_cantidad.Image = ((System.Drawing.Image)(resources.GetObject("pb_cantidad.Image")));
+            this.pb_cantidad.Location = new System.Drawing.Point(230, 261);
+            this.pb_cantidad.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_cantidad.Name = "pb_cantidad";
+            this.pb_cantidad.Size = new System.Drawing.Size(162, 39);
+            this.pb_cantidad.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_cantidad.TabIndex = 29;
+            this.pb_cantidad.TabStop = false;
+            // 
+            // pb_totalPagar
+            // 
+            this.pb_totalPagar.Image = ((System.Drawing.Image)(resources.GetObject("pb_totalPagar.Image")));
+            this.pb_totalPagar.Location = new System.Drawing.Point(29, 382);
+            this.pb_totalPagar.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_totalPagar.Name = "pb_totalPagar";
+            this.pb_totalPagar.Size = new System.Drawing.Size(363, 39);
+            this.pb_totalPagar.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_totalPagar.TabIndex = 30;
+            this.pb_totalPagar.TabStop = false;
+            // 
+            // lbl_totalPagar
+            // 
+            this.lbl_totalPagar.AutoSize = true;
+            this.lbl_totalPagar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.lbl_totalPagar.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_totalPagar.ForeColor = System.Drawing.Color.White;
+            this.lbl_totalPagar.Location = new System.Drawing.Point(32, 393);
+            this.lbl_totalPagar.Name = "lbl_totalPagar";
+            this.lbl_totalPagar.Size = new System.Drawing.Size(112, 20);
+            this.lbl_totalPagar.TabIndex = 31;
+            this.lbl_totalPagar.Text = "Total a pagar:";
+            // 
+            // button1
+            // 
+            this.button1.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.button1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.button1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.button1.BorderRadius = 7;
+            this.button1.ButtonText = "Registrar entrada";
+            this.button1.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.button1.DisabledColor = System.Drawing.Color.Gray;
+            this.button1.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.button1.ForeColor = System.Drawing.Color.White;
+            this.button1.Iconcolor = System.Drawing.Color.Transparent;
+            this.button1.Iconimage = null;
+            this.button1.Iconimage_right = null;
+            this.button1.Iconimage_right_Selected = null;
+            this.button1.Iconimage_Selected = null;
+            this.button1.IconMarginLeft = 0;
+            this.button1.IconMarginRight = 0;
+            this.button1.IconRightVisible = true;
+            this.button1.IconRightZoom = 0D;
+            this.button1.IconVisible = true;
+            this.button1.IconZoom = 90D;
+            this.button1.IsTab = false;
+            this.button1.Location = new System.Drawing.Point(29, 469);
+            this.button1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.button1.Name = "button1";
+            this.button1.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.button1.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.button1.OnHoverTextColor = System.Drawing.Color.White;
+            this.button1.selected = false;
+            this.button1.Size = new System.Drawing.Size(176, 39);
+            this.button1.TabIndex = 32;
+            this.button1.Text = "Registrar entrada";
+            this.button1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.button1.Textcolor = System.Drawing.Color.White;
+            this.button1.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            // 
+            // pnl_nuevaEntradaActiva
+            // 
+            this.pnl_nuevaEntradaActiva.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("pnl_nuevaEntradaActiva.BackgroundImage")));
+            this.pnl_nuevaEntradaActiva.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.bunifuFlatButton1);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.lbl_total);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.tb_cantidad);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.tb_descripcion);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.tb_codigo);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.tb_busqueda2);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.btn_registrarEntrada);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.label11);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.pictureBox6);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.pictureBox8);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.pictureBox7);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.pictureBox4);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.label9);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.label10);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.label6);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.pb_buscarProducto);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.label5);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.label7);
+            this.pnl_nuevaEntradaActiva.Controls.Add(this.pictureBox3);
+            this.pnl_nuevaEntradaActiva.Location = new System.Drawing.Point(713, 196);
+            this.pnl_nuevaEntradaActiva.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pnl_nuevaEntradaActiva.Name = "pnl_nuevaEntradaActiva";
+            this.pnl_nuevaEntradaActiva.Size = new System.Drawing.Size(419, 519);
+            this.pnl_nuevaEntradaActiva.TabIndex = 33;
+            this.pnl_nuevaEntradaActiva.Visible = false;
+            // 
+            // lbl_total
+            // 
+            this.lbl_total.AutoSize = true;
+            this.lbl_total.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.lbl_total.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_total.ForeColor = System.Drawing.Color.White;
+            this.lbl_total.Location = new System.Drawing.Point(275, 393);
+            this.lbl_total.Name = "lbl_total";
+            this.lbl_total.Size = new System.Drawing.Size(53, 20);
+            this.lbl_total.TabIndex = 44;
+            this.lbl_total.Text = "$0.00";
+            // 
+            // tb_cantidad
+            // 
+            this.tb_cantidad.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_cantidad.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_cantidad.Location = new System.Drawing.Point(241, 268);
+            this.tb_cantidad.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_cantidad.Name = "tb_cantidad";
+            this.tb_cantidad.Size = new System.Drawing.Size(140, 21);
+            this.tb_cantidad.TabIndex = 43;
+            // 
+            // tb_codigo
+            // 
+            this.tb_codigo.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_codigo.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_codigo.Location = new System.Drawing.Point(40, 268);
+            this.tb_codigo.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_codigo.Name = "tb_codigo";
+            this.tb_codigo.Size = new System.Drawing.Size(166, 21);
+            this.tb_codigo.TabIndex = 41;
+            // 
+            // tb_busqueda2
+            // 
+            this.tb_busqueda2.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_busqueda2.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_busqueda2.Location = new System.Drawing.Point(71, 90);
+            this.tb_busqueda2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_busqueda2.Name = "tb_busqueda2";
+            this.tb_busqueda2.Size = new System.Drawing.Size(311, 21);
+            this.tb_busqueda2.TabIndex = 36;
+            // 
+            // btn_registrarEntrada
+            // 
+            this.btn_registrarEntrada.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.btn_registrarEntrada.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_registrarEntrada.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_registrarEntrada.BorderRadius = 7;
+            this.btn_registrarEntrada.ButtonText = "Registrar entrada";
+            this.btn_registrarEntrada.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_registrarEntrada.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_registrarEntrada.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_registrarEntrada.ForeColor = System.Drawing.Color.White;
+            this.btn_registrarEntrada.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_registrarEntrada.Iconimage = null;
+            this.btn_registrarEntrada.Iconimage_right = null;
+            this.btn_registrarEntrada.Iconimage_right_Selected = null;
+            this.btn_registrarEntrada.Iconimage_Selected = null;
+            this.btn_registrarEntrada.IconMarginLeft = 0;
+            this.btn_registrarEntrada.IconMarginRight = 0;
+            this.btn_registrarEntrada.IconRightVisible = true;
+            this.btn_registrarEntrada.IconRightZoom = 0D;
+            this.btn_registrarEntrada.IconVisible = true;
+            this.btn_registrarEntrada.IconZoom = 90D;
+            this.btn_registrarEntrada.IsTab = false;
+            this.btn_registrarEntrada.Location = new System.Drawing.Point(29, 469);
+            this.btn_registrarEntrada.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.btn_registrarEntrada.Name = "btn_registrarEntrada";
+            this.btn_registrarEntrada.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_registrarEntrada.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_registrarEntrada.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_registrarEntrada.selected = false;
+            this.btn_registrarEntrada.Size = new System.Drawing.Size(176, 39);
+            this.btn_registrarEntrada.TabIndex = 36;
+            this.btn_registrarEntrada.Text = "Registrar entrada";
+            this.btn_registrarEntrada.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_registrarEntrada.Textcolor = System.Drawing.Color.White;
+            this.btn_registrarEntrada.TextFont = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            // 
+            // label11
+            // 
+            this.label11.AutoSize = true;
+            this.label11.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label11.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label11.ForeColor = System.Drawing.Color.White;
+            this.label11.Location = new System.Drawing.Point(32, 393);
+            this.label11.Name = "label11";
+            this.label11.Size = new System.Drawing.Size(112, 20);
+            this.label11.TabIndex = 37;
+            this.label11.Text = "Total a pagar:";
+            // 
+            // pictureBox6
+            // 
+            this.pictureBox6.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox6.Image")));
+            this.pictureBox6.Location = new System.Drawing.Point(230, 261);
+            this.pictureBox6.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox6.Name = "pictureBox6";
+            this.pictureBox6.Size = new System.Drawing.Size(162, 39);
+            this.pictureBox6.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox6.TabIndex = 39;
+            this.pictureBox6.TabStop = false;
+            // 
+            // pictureBox8
+            // 
+            this.pictureBox8.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox8.Image")));
+            this.pictureBox8.Location = new System.Drawing.Point(29, 382);
+            this.pictureBox8.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox8.Name = "pictureBox8";
+            this.pictureBox8.Size = new System.Drawing.Size(363, 39);
+            this.pictureBox8.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox8.TabIndex = 36;
+            this.pictureBox8.TabStop = false;
+            // 
+            // pictureBox4
+            // 
+            this.pictureBox4.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox4.Image")));
+            this.pictureBox4.Location = new System.Drawing.Point(29, 260);
+            this.pictureBox4.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox4.Name = "pictureBox4";
+            this.pictureBox4.Size = new System.Drawing.Size(188, 39);
+            this.pictureBox4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox4.TabIndex = 39;
+            this.pictureBox4.TabStop = false;
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.label10.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label10.ForeColor = System.Drawing.Color.Black;
+            this.label10.Location = new System.Drawing.Point(226, 238);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(81, 20);
+            this.label10.TabIndex = 36;
+            this.label10.Text = "Cantidad:";
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.label6.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label6.ForeColor = System.Drawing.Color.Black;
+            this.label6.Location = new System.Drawing.Point(25, 59);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(140, 20);
+            this.label6.TabIndex = 38;
+            this.label6.Text = "Buscar producto:";
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.label7.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label7.ForeColor = System.Drawing.Color.Black;
+            this.label7.Location = new System.Drawing.Point(25, 238);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(144, 20);
+            this.label7.TabIndex = 37;
+            this.label7.Text = "Código de barras:";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.label5.Font = new System.Drawing.Font("Roboto Medium", 13.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label5.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label5.Location = new System.Drawing.Point(24, 15);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(182, 29);
+            this.label5.TabIndex = 34;
+            this.label5.Text = "Nueva entrada";
+            // 
+            // pb_buscarProducto
+            // 
+            this.pb_buscarProducto.BackColor = System.Drawing.Color.White;
+            this.pb_buscarProducto.Image = ((System.Drawing.Image)(resources.GetObject("pb_buscarProducto.Image")));
+            this.pb_buscarProducto.Location = new System.Drawing.Point(38, 87);
+            this.pb_buscarProducto.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_buscarProducto.Name = "pb_buscarProducto";
+            this.pb_buscarProducto.Size = new System.Drawing.Size(25, 25);
+            this.pb_buscarProducto.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_buscarProducto.TabIndex = 37;
+            this.pb_buscarProducto.TabStop = false;
+            // 
+            // pictureBox3
+            // 
+            this.pictureBox3.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox3.Image")));
+            this.pictureBox3.Location = new System.Drawing.Point(29, 82);
+            this.pictureBox3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox3.Name = "pictureBox3";
+            this.pictureBox3.Size = new System.Drawing.Size(363, 39);
+            this.pictureBox3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox3.TabIndex = 36;
+            this.pictureBox3.TabStop = false;
+            // 
+            // pnl_nuevaEntradaInactiva
+            // 
+            this.pnl_nuevaEntradaInactiva.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("pnl_nuevaEntradaInactiva.BackgroundImage")));
+            this.pnl_nuevaEntradaInactiva.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.btn_cancelar);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.pictureBox5);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.label12);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.pictureBox1);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.label8);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.pb_lupa2);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.lbl_nuevaEntrada);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.button1);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.pb_buscar2);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.lbl_totalPagar);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.pb_totalPagar);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.lbl_buscarProducto);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.pb_cantidad);
+            this.pnl_nuevaEntradaInactiva.Controls.Add(this.lbl_cantidad);
+            this.pnl_nuevaEntradaInactiva.Location = new System.Drawing.Point(713, 196);
+            this.pnl_nuevaEntradaInactiva.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pnl_nuevaEntradaInactiva.Name = "pnl_nuevaEntradaInactiva";
+            this.pnl_nuevaEntradaInactiva.Size = new System.Drawing.Size(419, 519);
+            this.pnl_nuevaEntradaInactiva.TabIndex = 35;
+            // 
+            // pictureBox7
+            // 
+            this.pictureBox7.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox7.Image")));
+            this.pictureBox7.Location = new System.Drawing.Point(29, 174);
+            this.pictureBox7.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox7.Name = "pictureBox7";
+            this.pictureBox7.Size = new System.Drawing.Size(363, 39);
+            this.pictureBox7.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox7.TabIndex = 38;
+            this.pictureBox7.TabStop = false;
+            // 
+            // tb_descripcion
+            // 
+            this.tb_descripcion.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_descripcion.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_descripcion.Location = new System.Drawing.Point(36, 181);
+            this.tb_descripcion.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_descripcion.Name = "tb_descripcion";
+            this.tb_descripcion.Size = new System.Drawing.Size(346, 21);
+            this.tb_descripcion.TabIndex = 42;
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.label9.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label9.ForeColor = System.Drawing.Color.Black;
+            this.label9.Location = new System.Drawing.Point(25, 150);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(103, 20);
+            this.label9.TabIndex = 37;
+            this.label9.Text = "Descripción:";
+            // 
+            // lbl_cantidad
+            // 
+            this.lbl_cantidad.AutoSize = true;
+            this.lbl_cantidad.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.lbl_cantidad.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_cantidad.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(215)))), ((int)(((byte)(215)))));
+            this.lbl_cantidad.Location = new System.Drawing.Point(226, 238);
+            this.lbl_cantidad.Name = "lbl_cantidad";
+            this.lbl_cantidad.Size = new System.Drawing.Size(81, 20);
+            this.lbl_cantidad.TabIndex = 23;
+            this.lbl_cantidad.Text = "Cantidad:";
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.label8.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label8.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(215)))), ((int)(((byte)(215)))));
+            this.label8.Location = new System.Drawing.Point(25, 238);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(144, 20);
+            this.label8.TabIndex = 33;
+            this.label8.Text = "Código de barras:";
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
+            this.pictureBox1.Location = new System.Drawing.Point(29, 261);
+            this.pictureBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(188, 39);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox1.TabIndex = 34;
+            this.pictureBox1.TabStop = false;
+            // 
+            // label12
+            // 
+            this.label12.AutoSize = true;
+            this.label12.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.label12.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label12.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(215)))), ((int)(((byte)(215)))));
+            this.label12.Location = new System.Drawing.Point(25, 150);
+            this.label12.Name = "label12";
+            this.label12.Size = new System.Drawing.Size(144, 20);
+            this.label12.TabIndex = 35;
+            this.label12.Text = "Código de barras:";
+            // 
+            // pictureBox5
+            // 
+            this.pictureBox5.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox5.Image")));
+            this.pictureBox5.Location = new System.Drawing.Point(29, 174);
+            this.pictureBox5.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox5.Name = "pictureBox5";
+            this.pictureBox5.Size = new System.Drawing.Size(363, 39);
+            this.pictureBox5.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox5.TabIndex = 36;
+            this.pictureBox5.TabStop = false;
+            // 
+            // btn_cancelar
+            // 
+            this.btn_cancelar.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.btn_cancelar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.btn_cancelar.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_cancelar.BorderRadius = 7;
+            this.btn_cancelar.ButtonText = "Cancelar";
+            this.btn_cancelar.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_cancelar.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_cancelar.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_cancelar.ForeColor = System.Drawing.Color.White;
+            this.btn_cancelar.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_cancelar.Iconimage = null;
+            this.btn_cancelar.Iconimage_right = null;
+            this.btn_cancelar.Iconimage_right_Selected = null;
+            this.btn_cancelar.Iconimage_Selected = null;
+            this.btn_cancelar.IconMarginLeft = 0;
+            this.btn_cancelar.IconMarginRight = 0;
+            this.btn_cancelar.IconRightVisible = true;
+            this.btn_cancelar.IconRightZoom = 0D;
+            this.btn_cancelar.IconVisible = true;
+            this.btn_cancelar.IconZoom = 90D;
+            this.btn_cancelar.IsTab = false;
+            this.btn_cancelar.Location = new System.Drawing.Point(230, 469);
+            this.btn_cancelar.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.btn_cancelar.Name = "btn_cancelar";
+            this.btn_cancelar.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.btn_cancelar.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.btn_cancelar.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_cancelar.selected = false;
+            this.btn_cancelar.Size = new System.Drawing.Size(162, 39);
+            this.btn_cancelar.TabIndex = 37;
+            this.btn_cancelar.Text = "Cancelar";
+            this.btn_cancelar.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_cancelar.Textcolor = System.Drawing.Color.White;
+            this.btn_cancelar.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            // 
+            // bunifuFlatButton1
+            // 
+            this.bunifuFlatButton1.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.bunifuFlatButton1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(241)))), ((int)(((byte)(82)))), ((int)(((byte)(73)))));
+            this.bunifuFlatButton1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.bunifuFlatButton1.BorderRadius = 7;
+            this.bunifuFlatButton1.ButtonText = "Cancelar";
+            this.bunifuFlatButton1.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.bunifuFlatButton1.DisabledColor = System.Drawing.Color.Gray;
+            this.bunifuFlatButton1.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.bunifuFlatButton1.ForeColor = System.Drawing.Color.White;
+            this.bunifuFlatButton1.Iconcolor = System.Drawing.Color.Transparent;
+            this.bunifuFlatButton1.Iconimage = null;
+            this.bunifuFlatButton1.Iconimage_right = null;
+            this.bunifuFlatButton1.Iconimage_right_Selected = null;
+            this.bunifuFlatButton1.Iconimage_Selected = null;
+            this.bunifuFlatButton1.IconMarginLeft = 0;
+            this.bunifuFlatButton1.IconMarginRight = 0;
+            this.bunifuFlatButton1.IconRightVisible = true;
+            this.bunifuFlatButton1.IconRightZoom = 0D;
+            this.bunifuFlatButton1.IconVisible = true;
+            this.bunifuFlatButton1.IconZoom = 90D;
+            this.bunifuFlatButton1.IsTab = false;
+            this.bunifuFlatButton1.Location = new System.Drawing.Point(230, 469);
+            this.bunifuFlatButton1.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.bunifuFlatButton1.Name = "bunifuFlatButton1";
+            this.bunifuFlatButton1.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(241)))), ((int)(((byte)(82)))), ((int)(((byte)(73)))));
+            this.bunifuFlatButton1.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(219)))), ((int)(((byte)(221)))), ((int)(((byte)(224)))));
+            this.bunifuFlatButton1.OnHoverTextColor = System.Drawing.Color.White;
+            this.bunifuFlatButton1.selected = false;
+            this.bunifuFlatButton1.Size = new System.Drawing.Size(162, 39);
+            this.bunifuFlatButton1.TabIndex = 38;
+            this.bunifuFlatButton1.Text = "Cancelar";
+            this.bunifuFlatButton1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.bunifuFlatButton1.Textcolor = System.Drawing.Color.White;
+            this.bunifuFlatButton1.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            // 
+            // frmCAlmacen
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.ClientSize = new System.Drawing.Size(1204, 788);
+            this.Controls.Add(this.pnl_nuevaEntradaActiva);
+            this.Controls.Add(this.btn_nuevaEntrada);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.pictureBox2);
+            this.Controls.Add(this.tablaProductos);
+            this.Controls.Add(this.tb_busqueda);
+            this.Controls.Add(this.pb_lupa);
+            this.Controls.Add(this.lbl_buscar);
+            this.Controls.Add(this.pb_buscar);
+            this.Controls.Add(this.pb_linea);
+            this.Controls.Add(this.lbl_Titulo);
+            this.Controls.Add(this.pnl_nuevaEntradaInactiva);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Name = "frmCAlmacen";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "            ";
+            ((System.ComponentModel.ISupportInitialize)(this.pb_linea)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_buscar)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_lupa)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tablaProductos)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_buscar2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_lupa2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_cantidad)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_totalPagar)).EndInit();
+            this.pnl_nuevaEntradaActiva.ResumeLayout(false);
+            this.pnl_nuevaEntradaActiva.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox6)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox8)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_buscarProducto)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).EndInit();
+            this.pnl_nuevaEntradaInactiva.ResumeLayout(false);
+            this.pnl_nuevaEntradaInactiva.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox7)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox5)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lbl_Titulo;
+        private System.Windows.Forms.PictureBox pb_linea;
+        private System.Windows.Forms.PictureBox pb_buscar;
+        private System.Windows.Forms.Label lbl_buscar;
+        private System.Windows.Forms.PictureBox pb_lupa;
+        private System.Windows.Forms.PictureBox pictureBox2;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label lbl_nuevaEntrada;
+        private System.Windows.Forms.PictureBox pb_buscar2;
+        private System.Windows.Forms.PictureBox pb_lupa2;
+        private System.Windows.Forms.Label lbl_buscarProducto;
+        private System.Windows.Forms.PictureBox pb_cantidad;
+        private System.Windows.Forms.PictureBox pb_totalPagar;
+        private System.Windows.Forms.Label lbl_totalPagar;
+        private Bunifu.Framework.UI.BunifuFlatButton button1;
+        private System.Windows.Forms.Label label11;
+        private System.Windows.Forms.PictureBox pictureBox6;
+        private System.Windows.Forms.PictureBox pictureBox4;
+        private System.Windows.Forms.Label label10;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.PictureBox pictureBox3;
+        public System.Windows.Forms.Panel pnl_nuevaEntradaActiva;
+        public System.Windows.Forms.TextBox tb_cantidad;
+        public System.Windows.Forms.TextBox tb_codigo;
+        public System.Windows.Forms.TextBox tb_busqueda2;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_registrarEntrada;
+        public System.Windows.Forms.PictureBox pictureBox8;
+        public System.Windows.Forms.Panel pnl_nuevaEntradaInactiva;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_nuevaEntrada;
+        public System.Windows.Forms.PictureBox pb_buscarProducto;
+        public System.Windows.Forms.DataGridView tablaProductos;
+        private System.Windows.Forms.DataGridViewTextBoxColumn codigo_barras;
+        private System.Windows.Forms.DataGridViewTextBoxColumn cantidad_actual;
+        private System.Windows.Forms.DataGridViewTextBoxColumn descripcion;
+        private System.Windows.Forms.DataGridViewTextBoxColumn precio_compra;
+        public System.Windows.Forms.TextBox tb_busqueda;
+        public System.Windows.Forms.Label lbl_total;
+        public System.Windows.Forms.TextBox tb_descripcion;
+        private System.Windows.Forms.PictureBox pictureBox7;
+        private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.PictureBox pictureBox5;
+        private System.Windows.Forms.Label label12;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label lbl_cantidad;
+        private Bunifu.Framework.UI.BunifuFlatButton bunifuFlatButton1;
+        private Bunifu.Framework.UI.BunifuFlatButton btn_cancelar;
+    }
+}

--- a/Vistas/frmCAlmacen.resx
+++ b/Vistas/frmCAlmacen.resx
@@ -1,0 +1,498 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="pb_linea.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAIAAAAACCAYAAACQRtQYAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAABhJREFUOE9juPUu7P8oHrl4NAGMaBz2HwCTFR0u1yiNmAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pb_buscar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAVUAAAAtCAYAAAAeCvg2AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAB0dJREFUeF7tnc1uHFUQhWOCPROcURIRbCJlYdAIgTcsrIgsvc1TZd4geRTEkg2w
+        Y8OzDIIHMHVuqm7Orb49091JxOZ80nHdW3/dcaJS/3icewc4MX02Qb28KbXImXqMUNRMreO8Y+slPbNy
+        DPsP7c89sj/vw9fLz5qS0xMfZ6ryeR2q59ix4xyLZ+Xj944FO7bOuXnfy50i5Id68THl/CU9WFE7p0cv
+        d0o9cuYcB4qaqXWcd2w9tycsdJzVavWtmd9Me9OdJEmS1NXP6/X6G7P94Xp3d4fA1rR//fr13X6/N5cQ
+        QogM5uObN28wWPd2IYq5GVevlZObm5tTs78gUQghxHF2ux0G6x8mzE8M1sp90xcmXaEKIcREMC9tbv5t
+        euBztIIp+9jkqUIIIaaAufnkyZNHt7e3n2OYAjwHWG02m6dmPU0IIcQUMDdNX26325XZ8ggAQ3VtujB5
+        mhBCiClgbj58+PDi6uoKc7QMVXzB84BLk6cJIYSYAubmYKg+e/YML6k0VIUQYiaYm+fn55if7ZWqOb82
+        62lCCCGmgLlpunz+/Dnu+MtQPfErVQ1VIYSYCeamCe+kBs9UNVSFEGImmJumuP0vn6qKZ6oaqkIIMRPM
+        TVNcqWqoCiHEh4C5md/+n+ABq15UCSHEfDA3TRf8w//4oitVIYRYAOamKd7+l9t/fNGLKiGEWADmpql9
+        +49nqrr9F0KI+WBu4pmq2ffPVE26UhVCiAVgbpoGn6jSM1UhhFgA5iZ9TPXdj1SZNFSFEGIBmJtjv1BF
+        Q1UIIWaCuWlqbv/1TFUIIRaCuYnbf12pCiHERwBz06QXVUII8THA3DS1Q9U/CaChKoQQM8HcHNz+mzBU
+        MWk9TQghxBQwN03tb6ky6RNVQgixAMxNU/v2X7+lSgghloG5acKVKu74393+6+2/EEIsA3PT1H37r2eq
+        QggxE8xNn5/vb/9Nuv0XQogFYG7i7b/Z5kWVfqRKCCEWgLlp6t7+a6gKIcRMMDdN7f/7b9LPqQohxAIw
+        N3H7PzZU/9nv954qhBDiEJiXNjeh9r9TMT3w/w7gz91u5+lCCCEO8fbtWwzUX02DT1StbKh+ZfbW9A8S
+        dcUqhBB9MB9xAYp5ibm52Wyemj0zlaGKL6emR6Yr0yvT76a4rJUkSZJa/Wv6y/RqvV5fPTZubm4wR+tQ
+        ve+fqsJz1a3pR9OL09PTn8yGXvr+Jfa2LtbXgxyKh4/FeVEffUtvFx9nYBHH2i38RV5be3hOWSd/5PNx
+        aj7H3VfjHqv7Xox61tzwIZ/WNe6qdcjLe+S7v/Rhy3kpjh7wFwufq/YmX5XXR234m3r09L4cz8cKX2/N
+        tqyjX+pb9u6r9XkfebAsj0dOxCM/+8se/lDyx/Gqj9bl+BTnvrGu+Z5X9qjDmurDX3JZEadc9se6xGOf
+        4uVYEOWELx8zn0/kN/0ih+LhY3Fe1Ndjmkp9rKMmW8Sxdgt/kdfWHp5T1skf+Xycms9x99W46YUJcxLz
+        8sLn533TO+xq9sSn7MaEwXq1Wq2+Ozs7+97W16YfbF1sXvPebPUlcT7WoeKLOrecW/YH+pYaqiu1qR/s
+        aA/4EScfnxev6x6W9ybssa57WoeQg+9n2aMevoiF7fhrb1jEPafIY8XH/qRSjzXyPTd6NnW0Lvmwnhs1
+        NUb7pgfFajypHBfW1cTIRl70L7F8LFfu0yjV1O8BFPFYh2jfPY+ObXxRP1IT/auwRy7VDWzI96WPqeyz
+        Ih75rlrPe8+Fvyj5mh685r3n98T5WIeKL+rccm7ZH+hbaqiu1KZ+sKM94EecfHxevK57rDEfcYVqe8zL
+        DV+lBtjg2SoCmLh4FPDUX15BeN5aLHzZT77I66nUso/33MNs7ZNrslI81+Xz5ViJu+CL8wvf4HxD8Edu
+        rEm1LvZcx9ZV477mffWnmqZHjh3SyLGbY0ZOtqSSD7+pnjPnsyLuKvmc677uHmvzlZrwUW3xwcJHavLT
+        upHnljry5Zzq43zyNfmmOGfO47/D5nwop8RoXfau6rN4/fMilvJrjq8HxwpLOYM8iPrWXl7X+Mk36EEa
+        nCfvuYfZ2ifXZKV4rsvny7ESd8EX5xe+wfmG4PdnqI8uLy/Pr6+vz3a7XXnr34CrVTPlUYAJw/XMf+nq
+        QPBzbLvdrjgWa9MqYmO9II718o746rFZEYdlpfjg3A6tY89+0mrEX5R79dYdX/2z4fvo/vDV7y0LOVHP
+        NtZJ+FG6Bx4LO0v42TyuG+nRfG+wznm0b/5M4Y+aUORxHHaKUp9B7NC/5yPxxteJlb+zsXjaxzHwd8T+
+        nkrP3Jd9Sc05jOWN1A7yD32/IjbWC+JYL++Irx6bFXFYVooPzu3QOvZuUYs5iXkZs/MgkTRFoOeHQM//
+        KQV6fgj0/FMEev6sINY5/jEEev6eQM8Pgd4+bF5PFej5lwr0/P+HQM8/VaDnHxPorecK9PwfKtDzQ6Dn
+        /5QCPT8Eev4pAmN+4t69/wBu6JtWKCy63gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pb_lupa.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAV5JREFUSEvdlD8rRlEcgO8ko0mRgQ9h9zUMSj6BYmFhMkjKQkqxyGDwEdhMMrHp
+        XQxKKDHzPOc69dJ77znnyuKpp84593f+/c45txrACC7hOb7gB77hJS7iJHZmFuOg2sMLvOpre8RlLGYN
+        HcAJ1tGd9DOM8+ikxm1iNgsYV5xKgd+v0XhTmWQMHfgJc/M7ivZ5xXEb2nDbrmY11PKZQftth1oL3hYD
+        u9wOz+u+LjZjkDntwhG6uJ8X4hsGeBW7sI/2nwq1BtzBTV0s5gSTO/AM3rE1qIFbfK6LzfioXMVKqOUz
+        jfY7DLUWXLlpesAJGzK5w2T+I/7EDPY2+YhSHKDxG6GWyRbayRc6Z8MAfFz+VY1T0zOE2cQfXpzoDL2K
+        DhRTojt4+lU+xiJ80Q7oBHFA9Zx20V1EHNxvTtYJL4ATNp2L6YmvuThdJXROVwm/TleK/5muP5vE9OxV
+        VdX7BPzFaEc1dG/CAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <metadata name="codigo_barras.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="cantidad_actual.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="descripcion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="precio_compra.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="pictureBox2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAogAAABACAYAAACZbYZKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAW5JREFUeF7t2LGNwlAQQEEi+8qgWwJ+H2eTQAeU5BJAvuDEk+jAs9JEuwU87Wmf
+        n8vveR7Lcxq3bR7rCwCAY5nGct+b8D8OhSEAANNYt79InK/L49sBAABHdHuevi8AADii/YsoEAEACIEI
+        AEAIRAAAQiACABACEQCAEIgAAIRABAAgBCIAACEQAQAIgQgAQAhEAABCIAIAEAIRAIAQiAAAhEAEACAE
+        IgAAIRABAAiBCABACEQAAEIgAgAQAhEAgBCIAACEQAQAIAQiAAAhEAEACIEIAEAIRAAAQiACABACEQCA
+        EIgAAIRABAAgBCIAACEQAQAIgQgAQAhEAABCIAIAEAIRAIAQiAAAhEAEACAEIgAAIRABAAiBCABACEQA
+        AEIgAgAQAhEAgBCIAACEQAQAIAQiAAAhEAEACIEIAEAIRAAAQiACABACEQCAEIgAAIRABAAgBCIAACEQ
+        AQAIgQgAQAhEAABCIAIA8GF9vQGRIWG59yqZCwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pb_buscar2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAWsAAAAnCAYAAADJq2nbAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAPtJREFUeF7t1sGNQiEARVFKsf+NdvDtwuhnhA5+CSrOYjasJ7zkkJyE5LG+oYxz
+        u7XTXvu2//Tj4wXAAmo/jz7/hVqkAVZ1fIN9r+0yGQFYRe1bmQ4ArOQQa4AAYg0QQKwBAog1QACxBggg
+        1gABxBoggFgDBBBrgABiDRBArAECiDVAALEGCCDWAAHEGiCAWAMEEGuAAGINEECsAQKINUAAsQYIINYA
+        AcQaIIBYAwQQa4AAYg0QQKwBAog1QACxBggg1gABxBogQKnPfswGANZR9mffZgMAa7jXdimttZPfNcCa
+        Rp9Hp8s447J/yj17CMD/G5F+1Hb9DXUpbyNVeNcBsFvKAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="pb_lupa2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAbtJREFUSEvdlL1KA0EUha2CZaqAYqEPYZ/XsBDEJwi4jeZnk0AsRAQbRRC0CRYp
+        fATtrCSVdrKNhSAaEK31O8sJJLrJZgQbDxx25s65P3Nndua+o9lsFhuNxlYcx1dwAD+xvcMbxhW+y5aG
+        o9VqrQ2DmgnJrvnejtie6/V6ZJfZQXB80wADqhSKXkrBfB5usJ5Ix3jPS/lAvOngCeOpLdA6ur70aqXN
+        k9HpdBYUGL7kBR8CXUk+JHhjvGhzNuintq0t79g0E9CX7XdgUzYQ6bZIGHw78NN5PXqaDYlg39Mg0KJz
+        Fzd2IcYgga6ip0HA90T+tVptxaafQKAd3HkaBPwulCBvBzqDj6miCcDnnt2/epoNRE1VwTa3bZoJ7XZ7
+        VX7wzKZsqHJEAyp54rtkcy7we3Bhk/s/BMKKxLAfRVHJ5okg+Kn0FLVrUz5w2HeSpFqtrts8BqrVz6VX
+        Vbq0PSQreDkfIw9emgheQl3FM5i2xDyEPY+7dp8NVKTHTAHTV3OEOqcj1suWatddr/VsCgPBikoIM88F
+        e4Gk6d8Mw9oVAu3AScLaFQIFd5LftSsP/7Zdf5NE7YHHcRwnX8DcWBecuD4IAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="pb_cantidad.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAWsAAAAnCAYAAADJq2nbAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAPtJREFUeF7t1sGNQiEARVFKsf+NdvDtwuhnhA5+CSrOYjasJ7zkkJyE5LG+oYxz
+        u7XTXvu2//Tj4wXAAmo/jz7/hVqkAVZ1fIN9r+0yGQFYRe1bmQ4ArOQQa4AAYg0QQKwBAog1QACxBggg
+        1gABxBoggFgDBBBrgABiDRBArAECiDVAALEGCCDWAAHEGiCAWAMEEGuAAGINEECsAQKINUAAsQYIINYA
+        AcQaIIBYAwQQa4AAYg0QQKwBAog1QACxBggg1gABxBogQKnPfswGANZR9mffZgMAa7jXdimttZPfNcCa
+        Rp9Hp8s447J/yj17CMD/G5F+1Hb9DXUpbyNVeNcBsFvKAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="pb_totalPagar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAWsAAAAnCAYAAADJq2nbAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAPtJREFUeF7t1sGNQiEARVFKsf+NdvDtwuhnhA5+CSrOYjasJ7zkkJyE5LG+oYxz
+        u7XTXvu2//Tj4wXAAmo/jz7/hVqkAVZ1fIN9r+0yGQFYRe1bmQ4ArOQQa4AAYg0QQKwBAog1QACxBggg
+        1gABxBoggFgDBBBrgABiDRBArAECiDVAALEGCCDWAAHEGiCAWAMEEGuAAGINEECsAQKINUAAsQYIINYA
+        AcQaIIBYAwQQa4AAYg0QQKwBAog1QACxBggg1gABxBogQKnPfswGANZR9mffZgMAa7jXdimttZPfNcCa
+        Rp9Hp8s447J/yj17CMD/G5F+1Hb9DXUpbyNVeNcBsFvKAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="pnl_nuevaEntradaActiva.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAaIAAAIiCAYAAACKU8wqAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAACCBJREFUeF7t17FtxSAUQFGP4v2b/A2cjfAGCShN9OUy4TYH6SDzoL/ysdYY47zv
+        +5rG9AUA/+xjted3hAQIgN1mgmaM5vZ6uASAHa7jYQgAuwwhAiAlRACkhAiAlBABkBIiAFJCBEBKiABI
+        CREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkR
+        ACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQAp
+        IQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSEC
+        ICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAl
+        RACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQA
+        pIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSE
+        CICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiA
+        lBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQ
+        AZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQ
+        EiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIi
+        AFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBS
+        QgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIE
+        QEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBK
+        iABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogA
+        SAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJ
+        EQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREA
+        KSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkh
+        AiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIg
+        JUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVE
+        AKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACk
+        hAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQI
+        gJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICU
+        EAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBAB
+        kBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZAS
+        IgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIA
+        UkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJC
+        BEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRA
+        SogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqI
+        AEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABI
+        CREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkR
+        ACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQAp
+        IQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSEC
+        ICVEAKRWiMb7EAB2WSG63ocAsMMY43XM7ZwHf0UA7DYTNM5jrfWxqvTwCAD+2grQ50+EjuMbTx0ZpScm
+        mx8AAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="pictureBox6.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAALAAAAAtCAYAAAAOT+HDAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABPZJREFUeF7tXcFuHEUQtQnrcbBXRCJksWSJFawiwoWDiZIjR/gAf4/9B/afIHHk
+        Atw48C+LzAeY9zpVneqe3vUQQOmR3pOeq7qqume8emrVzK5mDvbgEPxgAlt1U+ayZuoxnD5n6rxY95D/
+        LmvWrHMc/9v14xp1vB57rFVfc0pNi/E4U1mf1775MRfrp2EYhi9gfgG34L0odsIfTZttMd/f3zOxAbdX
+        V1f32+0WIUF4/6AWb25uKOItRPwlLLVaCPnw4uJiAfsTCwWhR1xfX1PEv4EfgmwtMh6BH4HaeYVuQW1C
+        o3+aVqnZvAtz930CWqkg9Alq1LTKXTiBKh6Wy+VTWCsThD5BjUKrn1Czpt305xh8BlqZIPQJavT09JRa
+        fQwmAbMZ5mAFWpkg9Alq9OTkZLVer7npvhHw2dkZm2IJWOge1CgFDFvuwAh+BmtlgtAnqFGw2IEPbQeW
+        gIXuQY2Cq/Pz81EPLAEL3YMaBcsWQjuwMBdQo9YDjy7iJGChe1CjYNkDs5/QRZwwB1CjYLkDg9qBhVmA
+        GgWLHph/dBEnzALUKDi+iFMLIcwB1ChY3EbTDizMBtTo6C4EqB5YmAWoUVACFuYJalT3gYXZghoFdRdC
+        mCeoUduBy7sQsBKw0D2oUbAUMCgBC7MANQqWArZ7ahKw0D2oUbC8iAMpYAatTBD6BDVKrda/B9Y3ccIs
+        QI2CRQuhX6MJswE1CpYthO5CCHMBNcrbaKMWAlQPLHQPatS0+raF4EAthDAHUKNg+VwIkGqWgIXuQY2C
+        xQ6sLzKE2YAaNa2WLQSoHljoHtSoabUp4Ds9H1joFfZ8YBdw2QPbE/9+51OwBaFH3N7eUrw/g8/q22gD
+        BPwp7HfgHQu1Ewu9gFq01wvcmUZHzwfmE9o/BtfgD+CvoG/Xovi++Rf4B/g9+Dn4xN7pkgX8yL6NY2/B
+        NxV9A75cLBavYJ2vbfyaY/jJmj+qCXmPRcY6n+/rprWN8Tgjyzx9s4wn2ty8htUkv4p7fTxOro95i+W8
+        5fK4lQtr5lqPsT74OW/M81hXj1lv8bROtLGuynMNxpNlzJjXDrFMm+9zPV7M55q2bszXx/JYy482+b6e
+        2W9BanLDVne1Wp3A5zsy3gC7tL+laAlSxOthGJ4fHR19Bf9r8AX8ZGs/jmFzrGKsp+9MMZ9nNtam8Z51
+        05wwL82t1qPduQbjzIdYPK/o5zFtHIMc08/j4DtZw88zjTmfMc+5bcTz2rTMW02i5VIsxium+fRZb7W+
+        ZjEv+Kme1mp9Ts6FcbFGyOV8xXRcWmORC9brnh8fH3PnpTaXcfd1cMBemAnuxGwnntqFHcn+OFnG6niI
+        eV2LaW6MxXFcAzavU8+pWeXrefX5xlzKGxnz8/PY6HydjHut+4F5no/jvGiNOW9+HOd4NadYo87t445j
+        F8f0mtoGpnrGwXzOsT7S88ZUH2st1hzTt3diUJPU5uLy8vLt7uvgLgyT2gmQQj6yr+tGZDzmNpsNG+qc
+        cx8cPLdrLTLmWnUPxPKxIz1PG1nlR+e2z/dxjAcOO+KJ9VotvxHL/xs/R4t7LH+2kazx+dG6X5FX8o8t
+        5/YfkXcD4rwdaxSfDf26LoyL/8niA3ddChcXc9xoH4SLeQqJVpwkWvH/k0QrThKt+BQSrXhNh/t1/r8g
+        0Yq3SLTiJNEau639qSRa8Xcl4Tbg4OBvSdXRqLIoThAAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="pictureBox8.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAogAAABACAYAAACZbYZKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAZdJREFUeF7t2MFpwwAQAEG9JJfhbvOwQsqwrU/cgdORSkiQA4EFVRDNwbzuClhu
+        2Ob0dj1P8+05zss6zfdvAACOZZxvn1sT/sWhMAQAYJzv6ysSp8vtsXcAAMARLc9hfwEAwBFtX0SBCABA
+        CEQAAEIgAgAQAhEAgBCIAACEQAQAIAQiAAAhEAEACIEIAEAIRAAAQiACABACEQCAEIgAAIRABAAgBCIA
+        ACEQAQAIgQgAQAhEAABCIAIAEAIRAIAQiAAAhEAEACAEIgAAIRABAAiBCABACEQAAEIgAgAQAhEAgBCI
+        AACEQAQAIAQiAAAhEAEACIEIAEAIRAAAQiACABACEQCAEIgAAIRABAAgBCIAACEQAQAIgQgAQAhEAABC
+        IAIAEAIRAIAQiAAAhEAEACAEIgAAIRABAAiBCABACEQAAEIgAgAQAhEAgBCIAACEQAQAIAQiAAAhEAEA
+        iGGcl3VvAQDAMQ3TvDz3FgAAHM94uT2G08f17IsIAMD4vqxbGw7bvCLxsjz2DgEA+N+2MJwu96/fOByG
+        H37tWHCYl10tAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="pictureBox4.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAALAAAAAtCAYAAAAOT+HDAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABPZJREFUeF7tXcFuHEUQtQnrcbBXRCJksWSJFawiwoWDiZIjR/gAf4/9B/afIHHk
+        Atw48C+LzAeY9zpVneqe3vUQQOmR3pOeq7qqume8emrVzK5mDvbgEPxgAlt1U+ayZuoxnD5n6rxY95D/
+        LmvWrHMc/9v14xp1vB57rFVfc0pNi/E4U1mf1775MRfrp2EYhi9gfgG34L0odsIfTZttMd/f3zOxAbdX
+        V1f32+0WIUF4/6AWb25uKOItRPwlLLVaCPnw4uJiAfsTCwWhR1xfX1PEv4EfgmwtMh6BH4HaeYVuQW1C
+        o3+aVqnZvAtz930CWqkg9Alq1LTKXTiBKh6Wy+VTWCsThD5BjUKrn1Czpt305xh8BlqZIPQJavT09JRa
+        fQwmAbMZ5mAFWpkg9Alq9OTkZLVer7npvhHw2dkZm2IJWOge1CgFDFvuwAh+BmtlgtAnqFGw2IEPbQeW
+        gIXuQY2Cq/Pz81EPLAEL3YMaBcsWQjuwMBdQo9YDjy7iJGChe1CjYNkDs5/QRZwwB1CjYLkDg9qBhVmA
+        GgWLHph/dBEnzALUKDi+iFMLIcwB1ChY3EbTDizMBtTo6C4EqB5YmAWoUVACFuYJalT3gYXZghoFdRdC
+        mCeoUduBy7sQsBKw0D2oUbAUMCgBC7MANQqWArZ7ahKw0D2oUbC8iAMpYAatTBD6BDVKrda/B9Y3ccIs
+        QI2CRQuhX6MJswE1CpYthO5CCHMBNcrbaKMWAlQPLHQPatS0+raF4EAthDAHUKNg+VwIkGqWgIXuQY2C
+        xQ6sLzKE2YAaNa2WLQSoHljoHtSoabUp4Ds9H1joFfZ8YBdw2QPbE/9+51OwBaFH3N7eUrw/g8/q22gD
+        BPwp7HfgHQu1Ewu9gFq01wvcmUZHzwfmE9o/BtfgD+CvoG/Xovi++Rf4B/g9+Dn4xN7pkgX8yL6NY2/B
+        NxV9A75cLBavYJ2vbfyaY/jJmj+qCXmPRcY6n+/rprWN8Tgjyzx9s4wn2ty8htUkv4p7fTxOro95i+W8
+        5fK4lQtr5lqPsT74OW/M81hXj1lv8bROtLGuynMNxpNlzJjXDrFMm+9zPV7M55q2bszXx/JYy482+b6e
+        2W9BanLDVne1Wp3A5zsy3gC7tL+laAlSxOthGJ4fHR19Bf9r8AX8ZGs/jmFzrGKsp+9MMZ9nNtam8Z51
+        05wwL82t1qPduQbjzIdYPK/o5zFtHIMc08/j4DtZw88zjTmfMc+5bcTz2rTMW02i5VIsxium+fRZb7W+
+        ZjEv+Kme1mp9Ts6FcbFGyOV8xXRcWmORC9brnh8fH3PnpTaXcfd1cMBemAnuxGwnntqFHcn+OFnG6niI
+        eV2LaW6MxXFcAzavU8+pWeXrefX5xlzKGxnz8/PY6HydjHut+4F5no/jvGiNOW9+HOd4NadYo87t445j
+        F8f0mtoGpnrGwXzOsT7S88ZUH2st1hzTt3diUJPU5uLy8vLt7uvgLgyT2gmQQj6yr+tGZDzmNpsNG+qc
+        cx8cPLdrLTLmWnUPxPKxIz1PG1nlR+e2z/dxjAcOO+KJ9VotvxHL/xs/R4t7LH+2kazx+dG6X5FX8o8t
+        5/YfkXcD4rwdaxSfDf26LoyL/8niA3ddChcXc9xoH4SLeQqJVpwkWvH/k0QrThKt+BQSrXhNh/t1/r8g
+        0Yq3SLTiJNEau639qSRa8Xcl4Tbg4OBvSdXRqLIoThAAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="pb_buscarProducto.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAV5JREFUSEvdlD8rRlEcgO8ko0mRgQ9h9zUMSj6BYmFhMkjKQkqxyGDwEdhMMrHp
+        XQxKKDHzPOc69dJ77znnyuKpp84593f+/c45txrACC7hOb7gB77hJS7iJHZmFuOg2sMLvOpre8RlLGYN
+        HcAJ1tGd9DOM8+ikxm1iNgsYV5xKgd+v0XhTmWQMHfgJc/M7ivZ5xXEb2nDbrmY11PKZQftth1oL3hYD
+        u9wOz+u+LjZjkDntwhG6uJ8X4hsGeBW7sI/2nwq1BtzBTV0s5gSTO/AM3rE1qIFbfK6LzfioXMVKqOUz
+        jfY7DLUWXLlpesAJGzK5w2T+I/7EDPY2+YhSHKDxG6GWyRbayRc6Z8MAfFz+VY1T0zOE2cQfXpzoDL2K
+        DhRTojt4+lU+xiJ80Q7oBHFA9Zx20V1EHNxvTtYJL4ATNp2L6YmvuThdJXROVwm/TleK/5muP5vE9OxV
+        VdX7BPzFaEc1dG/CAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="pictureBox3.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAVUAAAAtCAYAAAAeCvg2AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAB0dJREFUeF7tnc1uHFUQhWOCPROcURIRbCJlYdAIgTcsrIgsvc1TZd4geRTEkg2w
+        Y8OzDIIHMHVuqm7Orb49091JxOZ80nHdW3/dcaJS/3icewc4MX02Qb28KbXImXqMUNRMreO8Y+slPbNy
+        DPsP7c89sj/vw9fLz5qS0xMfZ6ryeR2q59ix4xyLZ+Xj944FO7bOuXnfy50i5Id68THl/CU9WFE7p0cv
+        d0o9cuYcB4qaqXWcd2w9tycsdJzVavWtmd9Me9OdJEmS1NXP6/X6G7P94Xp3d4fA1rR//fr13X6/N5cQ
+        QogM5uObN28wWPd2IYq5GVevlZObm5tTs78gUQghxHF2ux0G6x8mzE8M1sp90xcmXaEKIcREMC9tbv5t
+        euBztIIp+9jkqUIIIaaAufnkyZNHt7e3n2OYAjwHWG02m6dmPU0IIcQUMDdNX26325XZ8ggAQ3VtujB5
+        mhBCiClgbj58+PDi6uoKc7QMVXzB84BLk6cJIYSYAubmYKg+e/YML6k0VIUQYiaYm+fn55if7ZWqOb82
+        62lCCCGmgLlpunz+/Dnu+MtQPfErVQ1VIYSYCeamCe+kBs9UNVSFEGImmJumuP0vn6qKZ6oaqkIIMRPM
+        TVNcqWqoCiHEh4C5md/+n+ABq15UCSHEfDA3TRf8w//4oitVIYRYAOamKd7+l9t/fNGLKiGEWADmpql9
+        +49nqrr9F0KI+WBu4pmq2ffPVE26UhVCiAVgbpoGn6jSM1UhhFgA5iZ9TPXdj1SZNFSFEGIBmJtjv1BF
+        Q1UIIWaCuWlqbv/1TFUIIRaCuYnbf12pCiHERwBz06QXVUII8THA3DS1Q9U/CaChKoQQM8HcHNz+mzBU
+        MWk9TQghxBQwN03tb6ky6RNVQgixAMxNU/v2X7+lSgghloG5acKVKu74393+6+2/EEIsA3PT1H37r2eq
+        QggxE8xNn5/vb/9Nuv0XQogFYG7i7b/Z5kWVfqRKCCEWgLlp6t7+a6gKIcRMMDdN7f/7b9LPqQohxAIw
+        N3H7PzZU/9nv954qhBDiEJiXNjeh9r9TMT3w/w7gz91u5+lCCCEO8fbtWwzUX02DT1StbKh+ZfbW9A8S
+        dcUqhBB9MB9xAYp5ibm52Wyemj0zlaGKL6emR6Yr0yvT76a4rJUkSZJa/Wv6y/RqvV5fPTZubm4wR+tQ
+        ve+fqsJz1a3pR9OL09PTn8yGXvr+Jfa2LtbXgxyKh4/FeVEffUtvFx9nYBHH2i38RV5be3hOWSd/5PNx
+        aj7H3VfjHqv7Xox61tzwIZ/WNe6qdcjLe+S7v/Rhy3kpjh7wFwufq/YmX5XXR234m3r09L4cz8cKX2/N
+        tqyjX+pb9u6r9XkfebAsj0dOxCM/+8se/lDyx/Gqj9bl+BTnvrGu+Z5X9qjDmurDX3JZEadc9se6xGOf
+        4uVYEOWELx8zn0/kN/0ih+LhY3Fe1Ndjmkp9rKMmW8Sxdgt/kdfWHp5T1skf+Xycms9x99W46YUJcxLz
+        8sLn533TO+xq9sSn7MaEwXq1Wq2+Ozs7+97W16YfbF1sXvPebPUlcT7WoeKLOrecW/YH+pYaqiu1qR/s
+        aA/4EScfnxev6x6W9ybssa57WoeQg+9n2aMevoiF7fhrb1jEPafIY8XH/qRSjzXyPTd6NnW0Lvmwnhs1
+        NUb7pgfFajypHBfW1cTIRl70L7F8LFfu0yjV1O8BFPFYh2jfPY+ObXxRP1IT/auwRy7VDWzI96WPqeyz
+        Ih75rlrPe8+Fvyj5mh685r3n98T5WIeKL+rccm7ZH+hbaqiu1KZ+sKM94EecfHxevK57rDEfcYVqe8zL
+        DV+lBtjg2SoCmLh4FPDUX15BeN5aLHzZT77I66nUso/33MNs7ZNrslI81+Xz5ViJu+CL8wvf4HxD8Edu
+        rEm1LvZcx9ZV477mffWnmqZHjh3SyLGbY0ZOtqSSD7+pnjPnsyLuKvmc677uHmvzlZrwUW3xwcJHavLT
+        upHnljry5Zzq43zyNfmmOGfO47/D5nwop8RoXfau6rN4/fMilvJrjq8HxwpLOYM8iPrWXl7X+Mk36EEa
+        nCfvuYfZ2ifXZKV4rsvny7ESd8EX5xe+wfmG4PdnqI8uLy/Pr6+vz3a7XXnr34CrVTPlUYAJw/XMf+nq
+        QPBzbLvdrjgWa9MqYmO9II718o746rFZEYdlpfjg3A6tY89+0mrEX5R79dYdX/2z4fvo/vDV7y0LOVHP
+        NtZJ+FG6Bx4LO0v42TyuG+nRfG+wznm0b/5M4Y+aUORxHHaKUp9B7NC/5yPxxteJlb+zsXjaxzHwd8T+
+        nkrP3Jd9Sc05jOWN1A7yD32/IjbWC+JYL++Irx6bFXFYVooPzu3QOvZuUYs5iXkZs/MgkTRFoOeHQM//
+        KQV6fgj0/FMEev6sINY5/jEEev6eQM8Pgd4+bF5PFej5lwr0/P+HQM8/VaDnHxPorecK9PwfKtDzQ6Dn
+        /5QCPT8Eev4pAmN+4t69/wBu6JtWKCy63gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pnl_nuevaEntradaInactiva.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAaIAAAIiCAYAAACKU8wqAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAACCBJREFUeF7t17FtxSAUQFGP4v2b/A2cjfAGCShN9OUy4TYH6SDzoL/ysdYY47zv
+        +5rG9AUA/+xjted3hAQIgN1mgmaM5vZ6uASAHa7jYQgAuwwhAiAlRACkhAiAlBABkBIiAFJCBEBKiABI
+        CREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkR
+        ACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQAp
+        IQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSEC
+        ICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAl
+        RACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQA
+        pIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSE
+        CICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiA
+        lBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQ
+        AZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQ
+        EiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIi
+        AFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBS
+        QgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIE
+        QEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBK
+        iABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogA
+        SAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJ
+        EQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREA
+        KSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkh
+        AiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIg
+        JUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVE
+        AKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACk
+        hAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQI
+        gJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICU
+        EAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBAB
+        kBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZAS
+        IgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIA
+        UkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJC
+        BEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRA
+        SogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqI
+        AEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABI
+        CREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQApIQIgJUQApIQIgJQQAZASIgBSQgRASogASAkR
+        ACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSECICVEAKSECICUEAGQEiIAUkIEQEqIAEgJEQAp
+        IQIgJUQApIQIgJQQAZASIgBSQgRASogASAkRACkhAiAlRACkhAiAlBABkBIiAFJCBEBKiABICREAKSEC
+        ICVEAKRWiMb7EAB2WSG63ocAsMMY43XM7ZwHf0UA7DYTNM5jrfWxqvTwCAD+2grQ50+EjuMbTx0ZpScm
+        mx8AAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="pictureBox7.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAVUAAAAtCAYAAAAeCvg2AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAB0dJREFUeF7tnc1uHFUQhWOCPROcURIRbCJlYdAIgTcsrIgsvc1TZd4geRTEkg2w
+        Y8OzDIIHMHVuqm7Orb49091JxOZ80nHdW3/dcaJS/3icewc4MX02Qb28KbXImXqMUNRMreO8Y+slPbNy
+        DPsP7c89sj/vw9fLz5qS0xMfZ6ryeR2q59ix4xyLZ+Xj944FO7bOuXnfy50i5Id68THl/CU9WFE7p0cv
+        d0o9cuYcB4qaqXWcd2w9tycsdJzVavWtmd9Me9OdJEmS1NXP6/X6G7P94Xp3d4fA1rR//fr13X6/N5cQ
+        QogM5uObN28wWPd2IYq5GVevlZObm5tTs78gUQghxHF2ux0G6x8mzE8M1sp90xcmXaEKIcREMC9tbv5t
+        euBztIIp+9jkqUIIIaaAufnkyZNHt7e3n2OYAjwHWG02m6dmPU0IIcQUMDdNX26325XZ8ggAQ3VtujB5
+        mhBCiClgbj58+PDi6uoKc7QMVXzB84BLk6cJIYSYAubmYKg+e/YML6k0VIUQYiaYm+fn55if7ZWqOb82
+        62lCCCGmgLlpunz+/Dnu+MtQPfErVQ1VIYSYCeamCe+kBs9UNVSFEGImmJumuP0vn6qKZ6oaqkIIMRPM
+        TVNcqWqoCiHEh4C5md/+n+ABq15UCSHEfDA3TRf8w//4oitVIYRYAOamKd7+l9t/fNGLKiGEWADmpql9
+        +49nqrr9F0KI+WBu4pmq2ffPVE26UhVCiAVgbpoGn6jSM1UhhFgA5iZ9TPXdj1SZNFSFEGIBmJtjv1BF
+        Q1UIIWaCuWlqbv/1TFUIIRaCuYnbf12pCiHERwBz06QXVUII8THA3DS1Q9U/CaChKoQQM8HcHNz+mzBU
+        MWk9TQghxBQwN03tb6ky6RNVQgixAMxNU/v2X7+lSgghloG5acKVKu74393+6+2/EEIsA3PT1H37r2eq
+        QggxE8xNn5/vb/9Nuv0XQogFYG7i7b/Z5kWVfqRKCCEWgLlp6t7+a6gKIcRMMDdN7f/7b9LPqQohxAIw
+        N3H7PzZU/9nv954qhBDiEJiXNjeh9r9TMT3w/w7gz91u5+lCCCEO8fbtWwzUX02DT1StbKh+ZfbW9A8S
+        dcUqhBB9MB9xAYp5ibm52Wyemj0zlaGKL6emR6Yr0yvT76a4rJUkSZJa/Wv6y/RqvV5fPTZubm4wR+tQ
+        ve+fqsJz1a3pR9OL09PTn8yGXvr+Jfa2LtbXgxyKh4/FeVEffUtvFx9nYBHH2i38RV5be3hOWSd/5PNx
+        aj7H3VfjHqv7Xox61tzwIZ/WNe6qdcjLe+S7v/Rhy3kpjh7wFwufq/YmX5XXR234m3r09L4cz8cKX2/N
+        tqyjX+pb9u6r9XkfebAsj0dOxCM/+8se/lDyx/Gqj9bl+BTnvrGu+Z5X9qjDmurDX3JZEadc9se6xGOf
+        4uVYEOWELx8zn0/kN/0ih+LhY3Fe1Ndjmkp9rKMmW8Sxdgt/kdfWHp5T1skf+Xycms9x99W46YUJcxLz
+        8sLn533TO+xq9sSn7MaEwXq1Wq2+Ozs7+97W16YfbF1sXvPebPUlcT7WoeKLOrecW/YH+pYaqiu1qR/s
+        aA/4EScfnxev6x6W9ybssa57WoeQg+9n2aMevoiF7fhrb1jEPafIY8XH/qRSjzXyPTd6NnW0Lvmwnhs1
+        NUb7pgfFajypHBfW1cTIRl70L7F8LFfu0yjV1O8BFPFYh2jfPY+ObXxRP1IT/auwRy7VDWzI96WPqeyz
+        Ih75rlrPe8+Fvyj5mh685r3n98T5WIeKL+rccm7ZH+hbaqiu1KZ+sKM94EecfHxevK57rDEfcYVqe8zL
+        DV+lBtjg2SoCmLh4FPDUX15BeN5aLHzZT77I66nUso/33MNs7ZNrslI81+Xz5ViJu+CL8wvf4HxD8Edu
+        rEm1LvZcx9ZV477mffWnmqZHjh3SyLGbY0ZOtqSSD7+pnjPnsyLuKvmc677uHmvzlZrwUW3xwcJHavLT
+        upHnljry5Zzq43zyNfmmOGfO47/D5nwop8RoXfau6rN4/fMilvJrjq8HxwpLOYM8iPrWXl7X+Mk36EEa
+        nCfvuYfZ2ifXZKV4rsvny7ESd8EX5xe+wfmG4PdnqI8uLy/Pr6+vz3a7XXnr34CrVTPlUYAJw/XMf+nq
+        QPBzbLvdrjgWa9MqYmO9II718o746rFZEYdlpfjg3A6tY89+0mrEX5R79dYdX/2z4fvo/vDV7y0LOVHP
+        NtZJ+FG6Bx4LO0v42TyuG+nRfG+wznm0b/5M4Y+aUORxHHaKUp9B7NC/5yPxxteJlb+zsXjaxzHwd8T+
+        nkrP3Jd9Sc05jOWN1A7yD32/IjbWC+JYL++Irx6bFXFYVooPzu3QOvZuUYs5iXkZs/MgkTRFoOeHQM//
+        KQV6fgj0/FMEev6sINY5/jEEev6eQM8Pgd4+bF5PFej5lwr0/P+HQM8/VaDnHxPorecK9PwfKtDzQ6Dn
+        /5QCPT8Eev4pAmN+4t69/wBu6JtWKCy63gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAWsAAAAnCAYAAADJq2nbAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAPtJREFUeF7t1sGNQiEARVFKsf+NdvDtwuhnhA5+CSrOYjasJ7zkkJyE5LG+oYxz
+        u7XTXvu2//Tj4wXAAmo/jz7/hVqkAVZ1fIN9r+0yGQFYRe1bmQ4ArOQQa4AAYg0QQKwBAog1QACxBggg
+        1gABxBoggFgDBBBrgABiDRBArAECiDVAALEGCCDWAAHEGiCAWAMEEGuAAGINEECsAQKINUAAsQYIINYA
+        AcQaIIBYAwQQa4AAYg0QQKwBAog1QACxBggg1gABxBogQKnPfswGANZR9mffZgMAa7jXdimttZPfNcCa
+        Rp9Hp8s447J/yj17CMD/G5F+1Hb9DXUpbyNVeNcBsFvKAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="pictureBox5.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAWsAAAAnCAYAAADJq2nbAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAPtJREFUeF7t1sGNQiEARVFKsf+NdvDtwuhnhA5+CSrOYjasJ7zkkJyE5LG+oYxz
+        u7XTXvu2//Tj4wXAAmo/jz7/hVqkAVZ1fIN9r+0yGQFYRe1bmQ4ArOQQa4AAYg0QQKwBAog1QACxBggg
+        1gABxBoggFgDBBBrgABiDRBArAECiDVAALEGCCDWAAHEGiCAWAMEEGuAAGINEECsAQKINUAAsQYIINYA
+        AcQaIIBYAwQQa4AAYg0QQKwBAog1QACxBggg1gABxBogQKnPfswGANZR9mffZgMAa7jXdimttZPfNcCa
+        Rp9Hp8s447J/yj17CMD/G5F+1Hb9DXUpbyNVeNcBsFvKAAAAAElFTkSuQmCC
+</value>
+  </data>
+</root>

--- a/Vistas/frmEAlmacen.cs
+++ b/Vistas/frmEAlmacen.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace VistasMrTiendita
+{
+    public partial class frmEAlmacen : Form
+    {
+        public frmEAlmacen()
+        {
+            InitializeComponent();
+            //tablaProductos.Rows.Add("661440000953", "10", "Azúcar Zulka baja en calorías", "30.50");
+            widthColumnas();
+            tablaProductos.AllowUserToAddRows = false;
+            //frmEAlmacenController controlador = new frmEAlmacenController(this);
+        }
+
+        public void widthColumnas()
+        {
+            tablaProductos.Columns[0].Width = 120;
+            tablaProductos.Columns[1].Width = 75;
+            tablaProductos.Columns[2].Width = 245;
+        }        
+
+        
+    }
+}

--- a/Vistas/frmEAlmacen.designer.cs
+++ b/Vistas/frmEAlmacen.designer.cs
@@ -1,0 +1,389 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmEAlmacen
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmEAlmacen));
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.lbl_Titulo = new System.Windows.Forms.Label();
+            this.tablaProductos = new System.Windows.Forms.DataGridView();
+            this.codigo_barras = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.cantidad = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.descripcion = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.precio = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.editar = new System.Windows.Forms.DataGridViewImageColumn();
+            this.eliminar = new System.Windows.Forms.DataGridViewImageColumn();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.pictureBox2 = new System.Windows.Forms.PictureBox();
+            this.tb_busqueda = new System.Windows.Forms.TextBox();
+            this.pb_lupa = new System.Windows.Forms.PictureBox();
+            this.lbl_buscar = new System.Windows.Forms.Label();
+            this.pb_buscar = new System.Windows.Forms.PictureBox();
+            this.btn_nuevoProducto = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.label5 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tablaProductos)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_lupa)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_buscar)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
+            this.pictureBox1.Location = new System.Drawing.Point(32, 55);
+            this.pictureBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(109, 2);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox1.TabIndex = 3;
+            this.pictureBox1.TabStop = false;
+            // 
+            // lbl_Titulo
+            // 
+            this.lbl_Titulo.AutoSize = true;
+            this.lbl_Titulo.Font = new System.Drawing.Font("Roboto", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_Titulo.Location = new System.Drawing.Point(27, 27);
+            this.lbl_Titulo.Name = "lbl_Titulo";
+            this.lbl_Titulo.Size = new System.Drawing.Size(108, 29);
+            this.lbl_Titulo.TabIndex = 2;
+            this.lbl_Titulo.Text = "Almacén";
+            // 
+            // tablaProductos
+            // 
+            this.tablaProductos.AllowUserToOrderColumns = true;
+            this.tablaProductos.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.tablaProductos.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
+            this.tablaProductos.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.tablaProductos.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tablaProductos.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.SingleHorizontal;
+            this.tablaProductos.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+            this.tablaProductos.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.tablaProductos.ColumnHeadersVisible = false;
+            this.tablaProductos.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.codigo_barras,
+            this.cantidad,
+            this.descripcion,
+            this.precio,
+            this.editar,
+            this.eliminar});
+            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            dataGridViewCellStyle2.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle2.Padding = new System.Windows.Forms.Padding(2);
+            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(245)))), ((int)(((byte)(158)))));
+            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.tablaProductos.DefaultCellStyle = dataGridViewCellStyle2;
+            this.tablaProductos.GridColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(215)))), ((int)(((byte)(215)))));
+            this.tablaProductos.Location = new System.Drawing.Point(32, 239);
+            this.tablaProductos.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tablaProductos.Name = "tablaProductos";
+            this.tablaProductos.ReadOnly = true;
+            this.tablaProductos.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+            this.tablaProductos.RowHeadersVisible = false;
+            this.tablaProductos.RowHeadersWidth = 51;
+            this.tablaProductos.RowTemplate.Height = 24;
+            this.tablaProductos.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
+            this.tablaProductos.Size = new System.Drawing.Size(985, 476);
+            this.tablaProductos.TabIndex = 7;
+            // 
+            // codigo_barras
+            // 
+            this.codigo_barras.HeaderText = "Código de barras";
+            this.codigo_barras.MinimumWidth = 6;
+            this.codigo_barras.Name = "codigo_barras";
+            this.codigo_barras.ReadOnly = true;
+            // 
+            // cantidad
+            // 
+            this.cantidad.HeaderText = "Cantidad";
+            this.cantidad.MinimumWidth = 6;
+            this.cantidad.Name = "cantidad";
+            this.cantidad.ReadOnly = true;
+            // 
+            // descripcion
+            // 
+            this.descripcion.HeaderText = "Descripción";
+            this.descripcion.MinimumWidth = 6;
+            this.descripcion.Name = "descripcion";
+            this.descripcion.ReadOnly = true;
+            // 
+            // precio
+            // 
+            this.precio.HeaderText = "Precio";
+            this.precio.MinimumWidth = 6;
+            this.precio.Name = "precio";
+            this.precio.ReadOnly = true;
+            // 
+            // editar
+            // 
+            this.editar.HeaderText = "Editar";
+            this.editar.Image = ((System.Drawing.Image)(resources.GetObject("editar.Image")));
+            this.editar.MinimumWidth = 6;
+            this.editar.Name = "editar";
+            this.editar.ReadOnly = true;
+            // 
+            // eliminar
+            // 
+            this.eliminar.HeaderText = "Eliminar";
+            this.eliminar.Image = ((System.Drawing.Image)(resources.GetObject("eliminar.Image")));
+            this.eliminar.MinimumWidth = 6;
+            this.eliminar.Name = "eliminar";
+            this.eliminar.ReadOnly = true;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label4.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.ForeColor = System.Drawing.Color.White;
+            this.label4.Location = new System.Drawing.Point(621, 207);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(58, 20);
+            this.label4.TabIndex = 16;
+            this.label4.Text = "Precio";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label3.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label3.ForeColor = System.Drawing.Color.White;
+            this.label3.Location = new System.Drawing.Point(296, 207);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(99, 20);
+            this.label3.TabIndex = 15;
+            this.label3.Text = "Descripción";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label2.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.ForeColor = System.Drawing.Color.White;
+            this.label2.Location = new System.Drawing.Point(195, 207);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(77, 20);
+            this.label2.TabIndex = 14;
+            this.label2.Text = "Cantidad";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label1.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.ForeColor = System.Drawing.Color.White;
+            this.label1.Location = new System.Drawing.Point(43, 207);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(64, 20);
+            this.label1.TabIndex = 13;
+            this.label1.Text = "Código";
+            // 
+            // pictureBox2
+            // 
+            this.pictureBox2.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox2.Image")));
+            this.pictureBox2.Location = new System.Drawing.Point(32, 196);
+            this.pictureBox2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox2.Name = "pictureBox2";
+            this.pictureBox2.Size = new System.Drawing.Size(985, 44);
+            this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox2.TabIndex = 12;
+            this.pictureBox2.TabStop = false;
+            // 
+            // tb_busqueda
+            // 
+            this.tb_busqueda.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_busqueda.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_busqueda.Location = new System.Drawing.Point(75, 134);
+            this.tb_busqueda.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_busqueda.Name = "tb_busqueda";
+            this.tb_busqueda.Size = new System.Drawing.Size(357, 21);
+            this.tb_busqueda.TabIndex = 20;
+            // 
+            // pb_lupa
+            // 
+            this.pb_lupa.Image = ((System.Drawing.Image)(resources.GetObject("pb_lupa.Image")));
+            this.pb_lupa.Location = new System.Drawing.Point(40, 132);
+            this.pb_lupa.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_lupa.Name = "pb_lupa";
+            this.pb_lupa.Size = new System.Drawing.Size(25, 25);
+            this.pb_lupa.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_lupa.TabIndex = 19;
+            this.pb_lupa.TabStop = false;
+            // 
+            // lbl_buscar
+            // 
+            this.lbl_buscar.AutoSize = true;
+            this.lbl_buscar.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_buscar.Location = new System.Drawing.Point(28, 103);
+            this.lbl_buscar.Name = "lbl_buscar";
+            this.lbl_buscar.Size = new System.Drawing.Size(140, 20);
+            this.lbl_buscar.TabIndex = 18;
+            this.lbl_buscar.Text = "Buscar producto:";
+            // 
+            // pb_buscar
+            // 
+            this.pb_buscar.Image = ((System.Drawing.Image)(resources.GetObject("pb_buscar.Image")));
+            this.pb_buscar.Location = new System.Drawing.Point(32, 127);
+            this.pb_buscar.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_buscar.Name = "pb_buscar";
+            this.pb_buscar.Size = new System.Drawing.Size(413, 39);
+            this.pb_buscar.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_buscar.TabIndex = 17;
+            this.pb_buscar.TabStop = false;
+            // 
+            // btn_nuevoProducto
+            // 
+            this.btn_nuevoProducto.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_nuevoProducto.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_nuevoProducto.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_nuevoProducto.BorderRadius = 7;
+            this.btn_nuevoProducto.ButtonText = "Agregar producto";
+            this.btn_nuevoProducto.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_nuevoProducto.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_nuevoProducto.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_nuevoProducto.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(78)))), ((int)(((byte)(89)))), ((int)(((byte)(8)))));
+            this.btn_nuevoProducto.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_nuevoProducto.Iconimage = null;
+            this.btn_nuevoProducto.Iconimage_right = null;
+            this.btn_nuevoProducto.Iconimage_right_Selected = null;
+            this.btn_nuevoProducto.Iconimage_Selected = null;
+            this.btn_nuevoProducto.IconMarginLeft = 0;
+            this.btn_nuevoProducto.IconMarginRight = 0;
+            this.btn_nuevoProducto.IconRightVisible = true;
+            this.btn_nuevoProducto.IconRightZoom = 0D;
+            this.btn_nuevoProducto.IconVisible = true;
+            this.btn_nuevoProducto.IconZoom = 90D;
+            this.btn_nuevoProducto.IsTab = false;
+            this.btn_nuevoProducto.Location = new System.Drawing.Point(469, 127);
+            this.btn_nuevoProducto.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.btn_nuevoProducto.Name = "btn_nuevoProducto";
+            this.btn_nuevoProducto.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_nuevoProducto.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_nuevoProducto.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_nuevoProducto.selected = false;
+            this.btn_nuevoProducto.Size = new System.Drawing.Size(173, 39);
+            this.btn_nuevoProducto.TabIndex = 21;
+            this.btn_nuevoProducto.Text = "Agregar producto";
+            this.btn_nuevoProducto.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_nuevoProducto.Textcolor = System.Drawing.Color.White;
+            this.btn_nuevoProducto.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label5.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label5.ForeColor = System.Drawing.Color.White;
+            this.label5.Location = new System.Drawing.Point(795, 207);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(54, 20);
+            this.label5.TabIndex = 22;
+            this.label5.Text = "Editar";
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label6.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label6.ForeColor = System.Drawing.Color.White;
+            this.label6.Location = new System.Drawing.Point(915, 207);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(70, 20);
+            this.label6.TabIndex = 23;
+            this.label6.Text = "Eliminar";
+            // 
+            // frmEAlmacen
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.ClientSize = new System.Drawing.Size(1204, 788);
+            this.Controls.Add(this.label6);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.btn_nuevoProducto);
+            this.Controls.Add(this.tb_busqueda);
+            this.Controls.Add(this.pb_lupa);
+            this.Controls.Add(this.lbl_buscar);
+            this.Controls.Add(this.pb_buscar);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.pictureBox2);
+            this.Controls.Add(this.tablaProductos);
+            this.Controls.Add(this.pictureBox1);
+            this.Controls.Add(this.lbl_Titulo);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Name = "frmEAlmacen";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "frmEAlmacen";
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tablaProductos)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_lupa)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_buscar)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Label lbl_Titulo;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.PictureBox pictureBox2;
+        private System.Windows.Forms.PictureBox pb_lupa;
+        private System.Windows.Forms.Label lbl_buscar;
+        private System.Windows.Forms.PictureBox pb_buscar;
+        private System.Windows.Forms.DataGridViewTextBoxColumn codigo_barras;
+        private System.Windows.Forms.DataGridViewTextBoxColumn cantidad;
+        private System.Windows.Forms.DataGridViewTextBoxColumn descripcion;
+        private System.Windows.Forms.DataGridViewTextBoxColumn precio;
+        private System.Windows.Forms.DataGridViewImageColumn editar;
+        private System.Windows.Forms.DataGridViewImageColumn eliminar;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label label6;
+        public System.Windows.Forms.DataGridView tablaProductos;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_nuevoProducto;
+        public System.Windows.Forms.TextBox tb_busqueda;
+    }
+}

--- a/Vistas/frmEAlmacen.resx
+++ b/Vistas/frmEAlmacen.resx
@@ -1,0 +1,230 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAIAAAAACCAYAAACQRtQYAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAABhJREFUOE9juPUu7P8oHrl4NAGMaBz2HwCTFR0u1yiNmAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <metadata name="codigo_barras.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="cantidad.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="descripcion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="precio.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="editar.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="editar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAARBJREFUOE/NlDEOAUEYRrdA6QwKBZ1OJ0qRSNyAVjRu4AbO4BBaoVGLE5BIdKJX
+        4Huzho3M7Czb+JKXnZmYN/+Y2Y1ypiFWYiumDOQJspPoiLrYiYmIKoJVbuL+QVu4gmwvjmLAgILnQmMj
+        vinXVsYTiZXSZhFTSdYgOYiW6cWpCqRU12cgq9Bus2l679jKhqanZBHabQZlJCS0lSW3SZwykia0lfFM
+        xisjPmFNfB4ASZURn3AuOLmx6cUJyohPyMTe85m8Z6ky4hLagyC0+Q3VpsnMHSQu4UicBa8koqXoCl9K
+        4uVxCalkJniXCwwEEhR+m/8XlsXLwx+f52tbFMxfmJ7C/VoLVviFq2C+PFH0ANjrWrZyej78AAAAAElF
+        TkSuQmCC
+</value>
+  </data>
+  <metadata name="eliminar.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="eliminar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAaFJREFUOE+dlD8rhlEYh8/GQnwA8QlEUQaDTGwWk4QyKItsFhmMSsqg/F0sSomJ
+        EhaJQcpG+AJSlMHC7zr3c789z/uc6HXV1fs75zznPuf5c97wC03yTH5XuScZq5lJSYE5OZtJ/pAz8lfa
+        Em7J56o+fJGbVX1upEtW39Z/7ZCRPnkrz7NciyeSuWyswL68sBjJX8BLqNySqOxE8OKOLRbZljwzYGVu
+        wYsw6cBiaJeMdcdWCPdy3WKRBflmMe6ASZ2xZQV5HOCL9caWvXXmlvDPBNgZeSC20gW5pi7LU7LEsGSw
+        VbZkeVxCvuCoZKxe+sKDsoSvzDMC8rTFQkE+asagR5KZW8JXG4qtEF6lP5t8QfreLYZ+yRx/eQWaJYN+
+        m5yIDYuFgmvyyWKYkMxpjK0En3LeYriROxYLBflzyO/2y2IadsUO4EhSCPIFyd6/Kh8tprmSfODA7i4t
+        FgpeS9/5ofT+JLvSj9Gy5IwCp+TUYriTSxbjQn6CkrDyg8WI/5Hym88NFuOCKxbTLEqOn/+h/iXXJo+d
+        MyL5DGpxTGaE8AP3SpF4W1z6gAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pictureBox2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAogAAABACAYAAACZbYZKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAW5JREFUeF7t2LGNwlAQQEEi+8qgWwJ+H2eTQAeU5BJAvuDEk+jAs9JEuwU87Wmf
+        n8vveR7Lcxq3bR7rCwCAY5nGct+b8D8OhSEAANNYt79InK/L49sBAABHdHuevi8AADii/YsoEAEACIEI
+        AEAIRAAAQiACABACEQCAEIgAAIRABAAgBCIAACEQAQAIgQgAQAhEAABCIAIAEAIRAIAQiAAAhEAEACAE
+        IgAAIRABAAiBCABACEQAAEIgAgAQAhEAgBCIAACEQAQAIAQiAAAhEAEACIEIAEAIRAAAQiACABACEQCA
+        EIgAAIRABAAgBCIAACEQAQAIgQgAQAhEAABCIAIAEAIRAIAQiAAAhEAEACAEIgAAIRABAAiBCABACEQA
+        AEIgAgAQAhEAgBCIAACEQAQAIAQiAAAhEAEACIEIAEAIRAAAQiACABACEQCAEIgAAIRABAAgBCIAACEQ
+        AQAIgQgAQAhEAABCIAIA8GF9vQGRIWG59yqZCwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pb_lupa.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAV5JREFUSEvdlD8rRlEcgO8ko0mRgQ9h9zUMSj6BYmFhMkjKQkqxyGDwEdhMMrHp
+        XQxKKDHzPOc69dJ77znnyuKpp84593f+/c45txrACC7hOb7gB77hJS7iJHZmFuOg2sMLvOpre8RlLGYN
+        HcAJ1tGd9DOM8+ikxm1iNgsYV5xKgd+v0XhTmWQMHfgJc/M7ivZ5xXEb2nDbrmY11PKZQftth1oL3hYD
+        u9wOz+u+LjZjkDntwhG6uJ8X4hsGeBW7sI/2nwq1BtzBTV0s5gSTO/AM3rE1qIFbfK6LzfioXMVKqOUz
+        jfY7DLUWXLlpesAJGzK5w2T+I/7EDPY2+YhSHKDxG6GWyRbayRc6Z8MAfFz+VY1T0zOE2cQfXpzoDL2K
+        DhRTojt4+lU+xiJ80Q7oBHFA9Zx20V1EHNxvTtYJL4ATNp2L6YmvuThdJXROVwm/TleK/5muP5vE9OxV
+        VdX7BPzFaEc1dG/CAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="pb_buscar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAVUAAAAtCAYAAAAeCvg2AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAB0dJREFUeF7tnc1uHFUQhWOCPROcURIRbCJlYdAIgTcsrIgsvc1TZd4geRTEkg2w
+        Y8OzDIIHMHVuqm7Orb49091JxOZ80nHdW3/dcaJS/3icewc4MX02Qb28KbXImXqMUNRMreO8Y+slPbNy
+        DPsP7c89sj/vw9fLz5qS0xMfZ6ryeR2q59ix4xyLZ+Xj944FO7bOuXnfy50i5Id68THl/CU9WFE7p0cv
+        d0o9cuYcB4qaqXWcd2w9tycsdJzVavWtmd9Me9OdJEmS1NXP6/X6G7P94Xp3d4fA1rR//fr13X6/N5cQ
+        QogM5uObN28wWPd2IYq5GVevlZObm5tTs78gUQghxHF2ux0G6x8mzE8M1sp90xcmXaEKIcREMC9tbv5t
+        euBztIIp+9jkqUIIIaaAufnkyZNHt7e3n2OYAjwHWG02m6dmPU0IIcQUMDdNX26325XZ8ggAQ3VtujB5
+        mhBCiClgbj58+PDi6uoKc7QMVXzB84BLk6cJIYSYAubmYKg+e/YML6k0VIUQYiaYm+fn55if7ZWqOb82
+        62lCCCGmgLlpunz+/Dnu+MtQPfErVQ1VIYSYCeamCe+kBs9UNVSFEGImmJumuP0vn6qKZ6oaqkIIMRPM
+        TVNcqWqoCiHEh4C5md/+n+ABq15UCSHEfDA3TRf8w//4oitVIYRYAOamKd7+l9t/fNGLKiGEWADmpql9
+        +49nqrr9F0KI+WBu4pmq2ffPVE26UhVCiAVgbpoGn6jSM1UhhFgA5iZ9TPXdj1SZNFSFEGIBmJtjv1BF
+        Q1UIIWaCuWlqbv/1TFUIIRaCuYnbf12pCiHERwBz06QXVUII8THA3DS1Q9U/CaChKoQQM8HcHNz+mzBU
+        MWk9TQghxBQwN03tb6ky6RNVQgixAMxNU/v2X7+lSgghloG5acKVKu74393+6+2/EEIsA3PT1H37r2eq
+        QggxE8xNn5/vb/9Nuv0XQogFYG7i7b/Z5kWVfqRKCCEWgLlp6t7+a6gKIcRMMDdN7f/7b9LPqQohxAIw
+        N3H7PzZU/9nv954qhBDiEJiXNjeh9r9TMT3w/w7gz91u5+lCCCEO8fbtWwzUX02DT1StbKh+ZfbW9A8S
+        dcUqhBB9MB9xAYp5ibm52Wyemj0zlaGKL6emR6Yr0yvT76a4rJUkSZJa/Wv6y/RqvV5fPTZubm4wR+tQ
+        ve+fqsJz1a3pR9OL09PTn8yGXvr+Jfa2LtbXgxyKh4/FeVEffUtvFx9nYBHH2i38RV5be3hOWSd/5PNx
+        aj7H3VfjHqv7Xox61tzwIZ/WNe6qdcjLe+S7v/Rhy3kpjh7wFwufq/YmX5XXR234m3r09L4cz8cKX2/N
+        tqyjX+pb9u6r9XkfebAsj0dOxCM/+8se/lDyx/Gqj9bl+BTnvrGu+Z5X9qjDmurDX3JZEadc9se6xGOf
+        4uVYEOWELx8zn0/kN/0ih+LhY3Fe1Ndjmkp9rKMmW8Sxdgt/kdfWHp5T1skf+Xycms9x99W46YUJcxLz
+        8sLn533TO+xq9sSn7MaEwXq1Wq2+Ozs7+97W16YfbF1sXvPebPUlcT7WoeKLOrecW/YH+pYaqiu1qR/s
+        aA/4EScfnxev6x6W9ybssa57WoeQg+9n2aMevoiF7fhrb1jEPafIY8XH/qRSjzXyPTd6NnW0Lvmwnhs1
+        NUb7pgfFajypHBfW1cTIRl70L7F8LFfu0yjV1O8BFPFYh2jfPY+ObXxRP1IT/auwRy7VDWzI96WPqeyz
+        Ih75rlrPe8+Fvyj5mh685r3n98T5WIeKL+rccm7ZH+hbaqiu1KZ+sKM94EecfHxevK57rDEfcYVqe8zL
+        DV+lBtjg2SoCmLh4FPDUX15BeN5aLHzZT77I66nUso/33MNs7ZNrslI81+Xz5ViJu+CL8wvf4HxD8Edu
+        rEm1LvZcx9ZV477mffWnmqZHjh3SyLGbY0ZOtqSSD7+pnjPnsyLuKvmc677uHmvzlZrwUW3xwcJHavLT
+        upHnljry5Zzq43zyNfmmOGfO47/D5nwop8RoXfau6rN4/fMilvJrjq8HxwpLOYM8iPrWXl7X+Mk36EEa
+        nCfvuYfZ2ifXZKV4rsvny7ESd8EX5xe+wfmG4PdnqI8uLy/Pr6+vz3a7XXnr34CrVTPlUYAJw/XMf+nq
+        QPBzbLvdrjgWa9MqYmO9II718o746rFZEYdlpfjg3A6tY89+0mrEX5R79dYdX/2z4fvo/vDV7y0LOVHP
+        NtZJ+FG6Bx4LO0v42TyuG+nRfG+wznm0b/5M4Y+aUORxHHaKUp9B7NC/5yPxxteJlb+zsXjaxzHwd8T+
+        nkrP3Jd9Sc05jOWN1A7yD32/IjbWC+JYL++Irx6bFXFYVooPzu3QOvZuUYs5iXkZs/MgkTRFoOeHQM//
+        KQV6fgj0/FMEev6sINY5/jEEev6eQM8Pgd4+bF5PFej5lwr0/P+HQM8/VaDnHxPorecK9PwfKtDzQ6Dn
+        /5QCPT8Eev4pAmN+4t69/wBu6JtWKCy63gAAAABJRU5ErkJggg==
+</value>
+  </data>
+</root>

--- a/Vistas/frmEditarProveedor.cs
+++ b/Vistas/frmEditarProveedor.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+//using MrTiendita.Controladores;
+
+namespace VistasMrTiendita
+{
+    public partial class frmEditarProveedor : Form
+    {
+        public frmEditarProveedor(string accion, int id)
+        {
+            InitializeComponent();
+            if (accion == "agregar")
+            {
+                lbl_Titulo.Text = "Agregar proveedor";
+            }
+            else
+            {
+                lbl_Titulo.Text = "Actualizar proveedor";
+            }
+            //frmProveedorController controlador = new frmProveedorController(this, accion, id);
+        }
+
+        private void btn_Cerrar_Click(object sender, EventArgs e)
+        {
+            this.Close();   
+        }
+    }
+}

--- a/Vistas/frmEditarProveedor.designer.cs
+++ b/Vistas/frmEditarProveedor.designer.cs
@@ -1,0 +1,216 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmEditarProveedor
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmEditarProveedor));
+            this.lbl_Titulo = new System.Windows.Forms.Label();
+            this.btn_Cerrar = new System.Windows.Forms.PictureBox();
+            this.tb_telefono = new System.Windows.Forms.TextBox();
+            this.tb_nombre = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.pictureBox3 = new System.Windows.Forms.PictureBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.pictureBox2 = new System.Windows.Forms.PictureBox();
+            this.btn_guardarProveedor = new Bunifu.Framework.UI.BunifuFlatButton();
+            ((System.ComponentModel.ISupportInitialize)(this.btn_Cerrar)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // lbl_Titulo
+            // 
+            this.lbl_Titulo.AutoSize = true;
+            this.lbl_Titulo.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.lbl_Titulo.Font = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_Titulo.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.lbl_Titulo.Location = new System.Drawing.Point(13, 6);
+            this.lbl_Titulo.Name = "lbl_Titulo";
+            this.lbl_Titulo.Size = new System.Drawing.Size(61, 24);
+            this.lbl_Titulo.TabIndex = 6;
+            this.lbl_Titulo.Text = "Titulo";
+            // 
+            // btn_Cerrar
+            // 
+            this.btn_Cerrar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btn_Cerrar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.btn_Cerrar.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_Cerrar.Image = ((System.Drawing.Image)(resources.GetObject("btn_Cerrar.Image")));
+            this.btn_Cerrar.Location = new System.Drawing.Point(502, 4);
+            this.btn_Cerrar.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.btn_Cerrar.Name = "btn_Cerrar";
+            this.btn_Cerrar.Size = new System.Drawing.Size(25, 25);
+            this.btn_Cerrar.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.btn_Cerrar.TabIndex = 5;
+            this.btn_Cerrar.TabStop = false;
+            this.btn_Cerrar.Click += new System.EventHandler(this.btn_Cerrar_Click);
+            // 
+            // tb_telefono
+            // 
+            this.tb_telefono.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_telefono.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_telefono.Location = new System.Drawing.Point(323, 103);
+            this.tb_telefono.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_telefono.Name = "tb_telefono";
+            this.tb_telefono.Size = new System.Drawing.Size(179, 21);
+            this.tb_telefono.TabIndex = 33;
+            // 
+            // tb_nombre
+            // 
+            this.tb_nombre.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_nombre.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_nombre.Location = new System.Drawing.Point(32, 103);
+            this.tb_nombre.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_nombre.Name = "tb_nombre";
+            this.tb_nombre.Size = new System.Drawing.Size(245, 21);
+            this.tb_nombre.TabIndex = 32;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(315, 73);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(79, 20);
+            this.label2.TabIndex = 29;
+            this.label2.Text = "Teléfono:";
+            // 
+            // pictureBox3
+            // 
+            this.pictureBox3.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox3.Image")));
+            this.pictureBox3.Location = new System.Drawing.Point(309, 96);
+            this.pictureBox3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox3.Name = "pictureBox3";
+            this.pictureBox3.Size = new System.Drawing.Size(205, 41);
+            this.pictureBox3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox3.TabIndex = 28;
+            this.pictureBox3.TabStop = false;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(13, 73);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(75, 20);
+            this.label1.TabIndex = 27;
+            this.label1.Text = "Nombre:";
+            // 
+            // pictureBox2
+            // 
+            this.pictureBox2.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox2.Image")));
+            this.pictureBox2.Location = new System.Drawing.Point(17, 96);
+            this.pictureBox2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox2.Name = "pictureBox2";
+            this.pictureBox2.Size = new System.Drawing.Size(276, 41);
+            this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox2.TabIndex = 26;
+            this.pictureBox2.TabStop = false;
+            // 
+            // btn_guardarProveedor
+            // 
+            this.btn_guardarProveedor.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_guardarProveedor.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_guardarProveedor.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_guardarProveedor.BorderRadius = 7;
+            this.btn_guardarProveedor.ButtonText = "Guardar";
+            this.btn_guardarProveedor.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_guardarProveedor.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_guardarProveedor.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_guardarProveedor.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(78)))), ((int)(((byte)(89)))), ((int)(((byte)(8)))));
+            this.btn_guardarProveedor.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_guardarProveedor.Iconimage = null;
+            this.btn_guardarProveedor.Iconimage_right = null;
+            this.btn_guardarProveedor.Iconimage_right_Selected = null;
+            this.btn_guardarProveedor.Iconimage_Selected = null;
+            this.btn_guardarProveedor.IconMarginLeft = 0;
+            this.btn_guardarProveedor.IconMarginRight = 0;
+            this.btn_guardarProveedor.IconRightVisible = true;
+            this.btn_guardarProveedor.IconRightZoom = 0D;
+            this.btn_guardarProveedor.IconVisible = true;
+            this.btn_guardarProveedor.IconZoom = 40D;
+            this.btn_guardarProveedor.IsTab = false;
+            this.btn_guardarProveedor.Location = new System.Drawing.Point(17, 191);
+            this.btn_guardarProveedor.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.btn_guardarProveedor.Name = "btn_guardarProveedor";
+            this.btn_guardarProveedor.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_guardarProveedor.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_guardarProveedor.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_guardarProveedor.selected = false;
+            this.btn_guardarProveedor.Size = new System.Drawing.Size(497, 39);
+            this.btn_guardarProveedor.TabIndex = 35;
+            this.btn_guardarProveedor.Text = "Guardar";
+            this.btn_guardarProveedor.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_guardarProveedor.Textcolor = System.Drawing.Color.White;
+            this.btn_guardarProveedor.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            // 
+            // frmEditarProveedor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("$this.BackgroundImage")));
+            this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.ClientSize = new System.Drawing.Size(539, 262);
+            this.Controls.Add(this.btn_guardarProveedor);
+            this.Controls.Add(this.tb_telefono);
+            this.Controls.Add(this.tb_nombre);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.pictureBox3);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.pictureBox2);
+            this.Controls.Add(this.lbl_Titulo);
+            this.Controls.Add(this.btn_Cerrar);
+            this.DoubleBuffered = true;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Name = "frmEditarProveedor";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "frmEditarProveedor";
+            ((System.ComponentModel.ISupportInitialize)(this.btn_Cerrar)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lbl_Titulo;
+        private System.Windows.Forms.PictureBox btn_Cerrar;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.PictureBox pictureBox3;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.PictureBox pictureBox2;
+        public System.Windows.Forms.TextBox tb_telefono;
+        public System.Windows.Forms.TextBox tb_nombre;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_guardarProveedor;
+    }
+}

--- a/Vistas/frmEditarProveedor.resx
+++ b/Vistas/frmEditarProveedor.resx
@@ -1,0 +1,531 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="btn_Cerrar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAYAAAD0eNT6AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        xAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAADjPSURBVHhe7d15
+        /HVjvf9xmWdllllRKJ04qQyRUKlOpTToIJUx4xEqJc2USIdKAxlOg04hlCGzyJgImUuSecjsxu/3fqfv
+        6Xb73Pf9Hfa+rs+11uv5eLz+0OCxv3utva61117rumYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAGjWTWkz9m9pIfUBtp/ZUX1aHqKPU8epMdYm6cbJuVfdO1pPq/03W
+        JDX5f3+38v/vauV/11nqNHWM+p7aX31KfVT5tbxF/btaQs2mAADAdMyuVlQeRHdQ+6kj1MnqCnW7ekpN
+        PmBn7z51jTpH+cTEJynbq7epV6j5FQAAnTe3epXaTH1GeYA/V/1VPa2iQbTr+UrDRepH6vNqC7WGeoEC
+        AKApc6hVlQf6fdUJ6ibV10F+vN2m/JPDQWprtaaaRwEAUN2cai21q/qhuk5N+ds6DS7/DHKt+rHyvQ8b
+        qgUUAABDM7NaWW2u/K30PPW4igYqKptvVjxS7axWU89TAACMiwd8Dyb+punL+PeraPChfD2g/PPBPmp9
+        5ZssAQAIeZBYR/kGvTPUIyoaXKi9HlO+YuOnK/yzAScEANBzL1H+/f5U9aiKBg/qXg+rk5QfuXyRAgB0
+        nO/Q9yVh353vCW6iwYH6l+8hOFRtonjSAAA6YnHl2ep+pfiWT9PLP/14X9lJcXUAABqzlPId4f7dt7UZ
+        9ChXVynfTLi8AgAktIwaGfSZdIeG0cjJAFcGAKCyF6rd1eUqOmATDSOfYPpE0z8TeB8EABTgG/k2VV4o
+        h1n3qHb+ielsta2aTwEABsyT8vhObU/yEh2IiWrnm0y9XLKfNGE2QgCYAK9//2l1s4oOuERZ8/0CnmOC
+        tQoAYAz8bd9zuz+hooMrUSt5vQiuCgDANHgN+F3UH1V0ICVqveuV15ZYRAFA771SHaaYe5/6ktcm+L7y
+        6pIA0DteR9+r7PHMPvU5P074NsXPAwA6bVbl9fSvVNHBkKiveS4LfzZmUQDQGfMqz9L3FxUd/Ijomf6m
+        PNug74kBgGYtpLwG+99VdLAjojjPd7G/YqZBAE1ZUPlbDJP2EE0sP0boCbA8JwYApOVv/Az8RIPvIXWQ
+        4hFCAKl44N9XPayigxcRDaYHlT9rz1cAUI0XP/myYuAnKtu96pNqbgUAxfhRpa3VHSo6OBFRme5Wnl1w
+        TgUAQ+PJSjZRN6joYEREdfqr8kn5jAoABmoN9RsVHXyIKEcXqzUVAEzYCuokFR1siChfnl7bq2kyhwCA
+        cfHNRb7Bz88hRwcZqpMfsbxRXah8YuYD/YHqU2o79W7lpWfXUV5W2b1ULffPPMOcm0uNmEmN/OducTXy
+        v3+F8roNG6n3KV9m9m/OX1TfUD9WZ6trFI9/5sqPDu6l5lAAMF3+nd8H+ltVdFCh4TVJ3aTOUF4t7tNq
+        M+UB2INyC/PEe7BZVvkno43Vx9Qh6lfqWuWV8KK/nYbXzcr37gDAVL1cnaWigwgNrtvVqcpTvX5IrauW
+        UTOrrvNNaksqX6HYSn1dnaY8B370XtHg8pWaf1MA8H/8PL9nGfM30OjAQePL33YvVYer/1K+NL+wQmx+
+        9TrlnzJ81eC3iisGg82fca/Pwc8CAGZ4u+Jy/8TzjVdXqe+oLdRKqg/f6IfNP3v4PgafFBymvJT0kyra
+        BjT6rlevVwB6aFF1jIoODjT9HlG+pPol9Rblb68owzeoevDyuhP+yepRFW0jmnY+af2e8o2fAHrAN/lt
+        qTyVaHRQoDhPd3yi2lW9RrVwQ15fzK7808He6teKqanHlu+/8NMjADrMd2f75rPoIEDPzY/beSnWtykP
+        MmiDf3rxkxNeNOcSFW1bem4nKN+gCaBDfOf1LopvRtPOz03/Qvn3Zp8soRu8LbdXHuD4DEy7+9U2ylcK
+        ATRuKeXnyqMPOz2zoNE3le/Qn02h23wl563KT2bco6J9gp55NJOZBIGGefIPDnLPzfc/eAY9X9rnt/z+
+        8gyI/qnAj8AyD8Fzu095UjAADVlA/VRFH+q+5kHfj5G9UfF4Hqbkk4H11LcVN8g+u++qyaeOBpDUm9Vt
+        Kvog9y0/qneU8mN6sypgNPxTkO+K9/0gT6ho3+pbnsb5VQpAQv5t82DlZ3ujD3Cf+r3aQT1fARPhmRt3
+        Vp7RMdrX+pRPhj6hfLUEQBLLq8tU9KHtSw8qX6pcXQHDsIryDaN/V9E+2Jc8+ZJvLgZQ2XtUn5dhvVh5
+        idp5FFCC97Vt1eUq2if7kG8QZIVBoBJf8ve3kejD2fW8QIyXy2VlM9TmZY99n0lfpyM+UHFTLVCQl471
+        SmnRB7LL+UqHH9ny2vhAJgupPVUfb8A9Vy2mAAyZL7v17ZL/Dco39fEoErKbU3nWQa+2F+3LXe2vyldD
+        AAyBp+b06md9usvf87hvrrjEiNZ4+m1PNHWeivbtLjZJ+SoIgAHy42wnqehD18U8ZzvfJtAVayuvUhjt
+        613sCDWHAjBBK6irVfRB61r+tuRlXYEu8kmtT26jfb9r/U4tpwCMky8h9uH3fj9X7G9JQB+sqfqwLLfX
+        IXmTAjAG/r3/U+opFX2wutL56g0K6CNfEej6Sp1PKt8UCWAU/Hz/j1X0YepKnrxnIwXgmfU7rlDRZ6Ur
+        7a98YySAqfAqfn6mNvoAdaE/Kc9c6CscAP7Fg+MH1S0q+ux0of9V3BwIBJZV16jog9N6Dys/wsiHH5g2
+        r1rpxYe6uiTxhWoRBeCfXqPuUNEHpuU8Z8GRipn7gLHx1UBP9e3f0KPPVsvdqF6igN57h/I35OiD0nL+
+        nd93OwMYP6930cWfBX2FY10F9NYuqmt3+t+q/lPxOz8wGP4sbaa6ts6AF/XaVAG98yUVfShazZcqD1DM
+        1w8Mx7zKd9M/oaLPYIv5Z8I9FNALPpv/uoo+DK3mR5herQAM38tU11YD3VcBnTaTOlxFH4AW8zcRf3B9
+        5zKAcvzY4NbqQRV9NlvsEMVcAeik2dTPVbTjt5jn7V9RAahnGXWKij6jLfYdxUkAOmVudZqKdvjW8toE
+        fk6ZDymQxybqLhV9ZlvrR2oWBTRvQeVH4qIdvbVOVDzTD+S0qPJnNPrsttaxyldNgWa9QF2ioh28pR5V
+        /tbPo31AfpurLtwb4IWSfPUUaM7zVRe++f9BraIAtMNTi5+jos90S/lv8OOPQDPmV5epaIduJU9Q9FXF
+        ZTigTX7qaC/V+rwBF6h5FJCeL/tfqqIduZU8m9/6CkD7VlPXq+iz3kpnqzkVkNZ86iIV7cCt5EcVvRAJ
+        gO7wN2jfXR995lvJT1LNroB0Wv/N3/Nyb6MAdNf2yjf1RseAFvIXlJkVkIbnvz9fRTtsC92iVlcAum9V
+        1fJPAkcr5iFBCp4G92QV7agtdLpaSAHoD99Zf4yKjgkt5BkDeSwZVfks9Mcq2kGz51W4DlLMuAX0l9cT
+        mKSiY0T2vqGAalpd1c+ThHjqUABYR92pomNF9j6ngOI+r6IdMnt/VCziA2ByL1ae9Cs6ZmRvDwUU42lx
+        ox0xe8crZtUCEPGjgi2uWOqfMzdVwNB9QHmHi3bEzPn3fs8MBgBT4xvrPqNaO8b5Mea1FTA0aynvaNEO
+        mDV/kPdRADBavkeotfkC7lEvUcDALadau1HGH+D3KAAYqzXUXSo6tmTtJrWwAgbGi/tcq6IdLmv+4K6p
+        AGC8fHPgdSo6xmTN07GzbgAGws/Je7KcaEfLmmf5Wl4BwEQtqM5T0bEmaz9VzBaICfENMUeqaAfL2hnK
+        KxICwKB4uvNfqOiYk7WvKGDc9lbRjpW1nylPTQwAg+ZFeI5S0bEna9sqYMx8F2xLj8J4gQxWyQIwTL6s
+        foiKjkEZ8zTHGypg1DxT3gMq2qEy5oUx+L0LQCl7quhYlDE/HuinuIDp8u/nLS2VebBiVSwApe2kWrlK
+        erniyQBMk79F/1JFO1DGvB4BANSylXpKRcenbB2mgKn6gop2nIz5BkUAqO2DqpWTAG4KROidqoXLWX6N
+        OygAyOJDqoWTAE/l/hoF/B/PH32/inaYbO2mACCbVk4CblOLKeAfE1xcraIdJVsfVwCQle8JaOFK6pmK
+        x6bxjxtDoh0kW59TAJDdh1ULVwL2V+gxr+0f7RjZOlABQCt2VNGxLFO+UvEuhR56kWphsh9foeA5fwCt
+        2UdFx7RM3aeWUuiR2dSlKtohMuUVrWZSANCiA1R0bMvU2YrjbI8cpKIdIVPHKm5SAdAyX708XEXHuEzt
+        odAD/6Gy36XqO1RZ1Q9AF8yiss+w+rhaTaHD/Ozn3SraAbLkRxJZzx9Al3ge/t+o6JiXpT8qPxaOjjpR
+        RRs+S3epFysA6JoF1LUqOvZl6dsKHeRnU6MNnqVHFFNUAugyP311p4qOgVnaRKFDllaZH/nzpBleiwAA
+        um5t5Tn5o2Nhhnwl9oUKHeC7UE9X0YbO0s4KAPpiM5X5ZuxTFfOvdIAH12gDZ4nfnAD0kac3j46JWfK6
+        BmjYCuphFW3cDB2vmIACQB/5G/aPVHRszJBnCeSngEbNqM5X0YbNkB85mVcBQF/58cDfqegYmaGfKTRo
+        BxVt0Aw9qFZWANB3vknbN95Fx8oMbazQEE/448s30casnW984TETAPiXN6gnVXTMrN3fFJOzNcSXbaIN
+        maH9FADg2fZU0TEzQ4cqNGAjFW3ADJ2hWOAHAJ7LNwX+REXHztr5yq2vUiCxudWfVbQBa3eLWkgBAGI+
+        hl+lomNo7TyN8ewKSR2oog1XO8969SoFAJg23yCd9fHtLyok5KUcs95Eso0CAIzO1io6ltbuCfVyhUT8
+        29GFKtpgteM5UgAYu6z3A/heLiTyQRVtqNr9VXkJTADA2Myjsi4fzNwASfimEQ+00UaqmVf4W18BAMbn
+        39XjKjrG1uwmxQ2BCXxJRRuodvsrAMDE7KaiY2ztPq5Q0XLqURVtnJpdqTg7BICJ87ouZ6roWFszT+nO
+        YkEVHauiDVMzn5BwlygADM4y6gEVHXNrdrhCBeupaIPUbnsFABgsr88fHXNr5nu9VlcoyGvo+zJ7tEFq
+        dqLyI4kAgMHysfWXKjr21uw8xXG/oA+paEPUzJenllAAgOHwb+73qOgYXLP3KxQwm8o43/+2CgAwXJuq
+        6BhcM6/1MofCkO2qog1Qs7MVl4AAoIzjVHQsrpnHJgyRJ/25Q0Vvfq280M+KCgBQxpLq7yo6JtfqLuXZ
+        CzEk+6joja/ZJxUAoKxdVHRMrtmeCkOwoMr2HOgVahYFACjLEwT9VkXH5lrdreZVGLADVPSG18rPf75W
+        AQDqeIWapKJjdK32VhggP16XbcrfrykAQF0+FkfH6Frdr16gMCDfUNEbXatb1VwKAFCXbw73Y3jRsbpW
+        X1AYgEXUIyp6k2v1AQUAyOF9KjpW18oLBS2sMEH7qegNrtUFimf+ASAXz8cSHbNr9RWFCZhfZXrW82n1
+        agUAyGU15Zuzo2N3jR5WiyqMU7bn/o9QAICcvq+iY3etfAUb4+Cb7DyzUvSm1shnc559CgCQk3939134
+        0TG8Rp67Zj6FMdpDRW9orfZSAIDcso0drBEwRl5V6XYVvZk1+pNipScAyM8rxt6komN5jTx+zKwwSlup
+        6I2s1XsUAKANm6voWF4rP6aIUfq9it7EGl2ieOwPANrhdQIuV9ExvUYeRzAKG6joDazVmxUAoC1vV9Ex
+        vVbrKkzHiSp682p0vgIAtOk3Kjq21+gEhWlYXmWayOENCnl4mU3fj7G/Olqdpc5Tx6pD1Y7K+xAwDCuo
+        nZT3Ne9z3ve8Dx6lvqo2USwFm8vaKjq218gTya2kMBX/raI3rkbnKtTn3/LerU5Vj6toW03Z9cpLci6o
+        gInwc+WekOwGFe1rU+Z99BS1sfK+i/pOVtG2qtF3FQKeLCHTtL8+c0Rda6mJ3BDqSTj2VDyCg7GaRX1C
+        eVGXaN8aTb4JbU2Ful6lou1TIy9rzyJBgd1U9IbVyGfwqGcm5eU0B/VzkBdwWkoBo7G0ulBF+9JY8z78
+        OcXVgLp8BTHaPjXaXWEyfszOl22jN6tGLPhTjyfx+KmKtstEuk39mwKmxfuI95VoH5pIxyjv26jjdSra
+        LjW6VvFo+WTWU9EbVSPu1KzH35J8oIy2yyC6T/lyIBDx4H+3ivadQXSc8tUt1HGOirZLjXgkcDI/UtGb
+        VKM1FOrwZf9omwyye9SqCpic9wnvG9E+M8g+q1DHm1S0TWrkp5ggCyjfGBG9SaXz736owzf8lXoElJMA
+        TK7U4O+8j/Mlo56LVLRdSucxb37Ve14pKXqDauRHd1CeL/2Xnv6ZkwBYycF/pMsUNwXW8U4VbZMaeU6J
+        3vuDit6c0vk5X36fq8MTqETbZNhxT0C/Dfs3/2n1DoXyfPPdNSraJqW7UvWaL4VFb0yNPqpQR81HdLgS
+        0E81vvlPnienQR3bqWib1KjXT5wdrqI3pXQ+EMylUJ6nTh3tDH/DiisB/VLzm/9Ij6l5FMqbU9Xe/iN9
+        T/WSd/6HVPSmlM53n6OO96pom5SOk4B+yDD4j/QuhTr2U9E2KZ3HwF6uH7G5it6Q0vlMfFGFOryISrRd
+        asRJQLdlGvzdvgp1eGbQSSraLqXbSvVOlgUaensJJon/UdF2qRUnAd2UbfB3XkUQ9fxERduldKerXllI
+        ZTn78oEB9Xg51Wi71IyTgG7JOPi7MxTqyXIT+pOqV1eht1fRG1G6ixXq8prq0bapHU8HdEPtu/2nlaem
+        RV0eA6JtU7pePYWW5aDfy99ekvm5irZNhrgS0Las3/xH8qJXqGsbFW2b0vXmZNA3XzytojehZF7nu5d3
+        XyZzqIq2T5Y4CWhT9sHfHaxQ19zKY0G0fUrmKaIXV523p4regNJ9V6G+HVW0fTLFzwFtyXzZf/J2Vqjv
+        MBVtn9LtojrvchX98aVbXaG+5VW0fbLFSUAbWhn83SsV6styM+D5qtOyHOy98AzyuF5F2ylb/ByQWwuX
+        /Ue6WXleeuSQYU0a/zS+tOqs3VX0h5eOef9z2VtF2yljnATk1NLg7/ZSyCPLqrQfU511ror+6JI9op6v
+        kMeC6gEVba+M8XNALi1d9nf3qwUU8vAxyLPCRturZJ19NN2T/3jCg+iPLhmzb+WU5ebQ0cZJQA6tDf6u
+        09/yGnacirZX6ZZTnfMhFf2xpdtIIZ+ZlW+CibZZ1vg5oK7WLvu7i9QsCvlkWZhsB9U5x6vojy3ZvWpW
+        hZw8R8RtKtp2WeNKQB0tfvP/q1pSIScvE5xhToATVafMoR5W0R9bMhb+yc/f6lo7sHMSUFaLg79fr/dt
+        5OafiKPtVzLfp+YxszPerqI/tHQbKuTX4qVdfg4og30Dw+SfiKNtWLpOjVX+5h39kSW7S/HbWzs40GNK
+        7BMYNo8RHiuibVmyA1Vn3KKiP7JknnMebeGAjxHsCyjlWyraniW7RnXCS1X0B5buDQrt4cAP9gGUtJ6K
+        tmnpllXNy7DYy53Kj5mhTQwA/cW2R2keK/zEWLRtS7adal6Gx/8OUWgbA0H/sM1Ry9Eq2r4l89jZNJ9J
+        edrL6I8r2QYK7WNA6A+2NWp6j4q2cck8J8FsqlkZlll8SDX9JuJZGBi6j22M2uZWGdYGaPretQyrvP1C
+        oVsYILqLbYssTlbR9i7Zl1WzzlHRH1WyTtxIgedgoOgetiky8dgRbfOS/UY1yfMqP6GiP6pknXiUAiEG
+        jO5gWyKbJVS03Uv2uPJY2pzXq+gPKllnJlPAVDFwtI9tiKyuUtH2L5nnJWjOXir6Y0p2gEL3MYC0i22H
+        zA5S0T5Qsn1Uc7ykYfTHlIzFf/qDgaQ9bDNk91YV7QclO1M15Xmq9nKdXn54doX+YEBpB9sKLZhH1b6X
+        zcsDN7WQ3Uoq+kNK5isQ6B8GlvzYRmjJuSraJ0q2qmrGVir6I0q2q0I/McDkxbZBaz6jov2iZNurZhyu
+        oj+iZKsr9BcDTT5sE7RoTRXtGyU7QjXjWhX9EaXybyazKvQbA04ebAu0yr+/+56yaB8plcfUJsynnlbR
+        H1GqsxVgDDz1sQ3QurNUtJ+UymPqAiq9dVX0B5TsiwoYwQBUD+89usBjSrSvlGx9ld4uKnrxJdtIAZNj
+        ICqP9xxdkWE+gN1Vej9Q0YsvlS+VzK+AKTEglcN7jS55gar90/YPVXq/V9GLL9UfFDA1DEzDx3uMLvLa
+        MtG+U6r0a9vMpmrPmnSoAqaFAWp4eG/RVd9T0f5TqqfU3Cotz1YUvfCSbaGA6WGgGjzeU3TZh1W0D5Xs
+        NSqtD6noRZfM0xADo8GANTi8l+i6DF9wP6LS+oaKXnSpHlUzK2C0GLgmjvcQfZDhJ+7US9z/WkUvulSX
+        KGCsGMDGj/cOfXK5ivapUp2s0rpFRS+6VIcpYDwYyMaO9wx9U/sx97+olOZStZ+TZAVATAQD2ujxXqGP
+        Mkx05+n20/EBIXqxJWtiqkSkxsA2fbxH6Kt1VLR/lSzlkwDvVdGLLdnCCpgoBrip471Bn82ral/p/k+V
+        zqdV9GJLdbsCBoWB7rl4T4D697rto9L5HxW92FKdooBBYsD7F94L4Bm1n3Y7SqVzsYpebKm+qoBBY+Dj
+        PQAmd4iK9rlSXaDSuV9FL7ZUWypgGPo8ADL4A8+2k4r2u1LdpVLxYwnRCy3ZugoYlj4OhAz+wHO9UUX7
+        XslSPQr4MhW9yJItrYBh6tOAyOAPxJZV0f5XMo+5abxZRS+yVJMUawCghD4MjAz+wNTNqLzuTLQflmoj
+        lcZWKnqRpbpJAaV0eYBk8Aem70oV7Yul2kal8XkVvchSna6Akro4UDL4A6Nzgor2x1J9QaVRe4GE7yug
+        tC4NmAz+wOh9U0X7ZKmOVGnUnhjBsxACNXRh4GTwB8bmEyraL0t1hkrjOhW9yFKlnBsZvdHyAMrgD4yd
+        x5xo3yzV1SqNB1X0Iku1lgJqWlXdo6L9M2t+vS2+Zr/XQE21VwX0SXsKs6voBZZsCQXU1uK36Zbimz+y
+        WE5F+2ipvCLhLKq6JVX0AkuV5o0AhJOA4cTgj0xmVU+paF8t1eKquleo6MWVymsQAJlwEjDYGPyR0R0q
+        2l9LleKnsDeo6MWV6kYFZMNJwGBi8EdWvhEv2mdL5TUJqnufil5cqX6rgIw4CZhYDP7I7BwV7beler+q
+        bgcVvbhSnaSArDgJGF8M/sjuWBXtu6XaTlW3j4peXKmOUEBmnASMLQZ/tOC7Ktp/S+XJiKr7hopeXKkO
+        VEB2nASMLgZ/tGJfFe3DpdpPVedv4NGLK9VeCmgBJwHTjsEfLdldRftxqQ5V1f1URS+uVNsqoBWcBMQx
+        +KM1W6poXy7VMao634QXvbhSvUsBLeEk4Nkx+KNFm6hofy7Viaq6M1X04kq1vgJaw0nAMzH4o1UbqWif
+        LpXH3uouUtGLKxULAaFVfT8JYPBHy9ZV0X5dqhRz4PxBRS+uVKsroFV9PQlg8EfrPPZE+3aprlDV3aSi
+        F1cqH0CBlvXtJIDBH12wsor271LdoKq7XUUvrlQrKaB1fTkJYPBHVyyron28VLep6h5Q0Ysr1YsU0AVd
+        Pwlg8EeXLKyi/bxUPlZU97CKXlypllRAV3T1JIDBH10zr4r29VL5M1Xdoyp6caXyWRjQJV07CWDwRxfN
+        raL9vVR/V9XVPgGYTwFd05WTAAZ/dNVcKtrnS/WIqu4xFb24Us2hgC5q/SSAwR9dVvsE4HFVnV9E9OJK
+        NZMCuqrVkwAGf3TdnCra90v1lKruCRW9uFLNqICu4gQAyMlXn6N9v1QpTgAmqejFlWpWBXQRPwEAec2u
+        ov2+VP75vbonVfTiSuXfYYCu4SZAILfaJwAPqupqXwF4vgK6pCuD/0icBKCLat8EeK+q7iEVvbhSLaiA
+        ruja4D8SJwHoGo890b5eqjtUdbUPVospoAu6OviPxEkAumQJFe3npbpVVfcXFb24Ui2lgNZ1ffAfiZMA
+        dMWLVbSPl+pmVd11KnpxpWIxILSuL4P/SJwEoAtepqL9u1Qee6u7QkUvrlSrKKBVfRv8R+IkAK3z/hvt
+        26W6SlV3oYpeXKnWUkCL+jr4j8RJAFq2tor261Jdoqo7W0UvrlRvUUBr+j74j8RJAFq1oYr26VKdrqo7
+        RUUvrlTvV0BLGPyfHScBaNF7VbQ/l+pYVd3PVPTiSrWNAlrB4B/HSQBas62K9uVSHaGq+66KXlypdldA
+        Cxj8px0nAWjJXiraj0v1DVXdV1T04kr1eQVkx+A/ujgJQCv2V9E+XKoUY9/HVfTiSvXfCsiMwX9scRKA
+        FnxfRftvqfZQ1fk3+OjFlerHCsiKwX98cRKA7I5T0b5bqhT3v22iohdXqrMUkBGD/8TiJACZnaOi/bZU
+        KZ6AW19FL65Uf1RANgz+g4mTAGR1tYr22VJ5HoLqVlXRiyvV/QrIhMF/sHESgIz+rqL9tVQvV9Uto6IX
+        V7I5FJABg/9w4iQAmcyjov20ZAur6jz4Ri+uZMsqoDYG/+HGSQCyWFFF+2ipJqkZVQr3qOhFluq1CqjJ
+        P4XV/hyMNb/eFl+z32ugptr3vt2q0qi9JPC7FFBLi9/8R75Nt/zagVo2V9G+WapLVRq/UtGLLNVuCqih
+        CwMoJwHA2HxSRftlqU5UaXxPRS+yVIcooLQuDZycBACj5zEn2idL5VkI0/isil5kqX6pgJK6OGByEgCM
+        zskq2h9LlWoNnK1V9CJLxWRAKKnLAyUnAcD03aCifbFUXoo4jbeo6EWW6jGV5pEIdFofBkhOAoCpm0U9
+        oaL9sFQpZgEc8QoVvciSLamAYerTwMhJABBbQUX7X8mWV2nMrZ5W0Qst1ToKGJY+DoicBADPVfuK91Nq
+        NpXK31T0Yku1lQKGoc8DIScBwLPtrKL9rlR/Vumcq6IXW6oDFTBoDIC8B8DkDlbRPleqM1U6h6noxZbq
+        NAUMEgPfv/BeAM/wWBPtb6XyWJtO7ZmRblPAoDDgPRfvCTDDDHeoaF8r1adUOpuo6MWWbAEFTBQD3dTx
+        3qDPFlHRPlayD6h0XqmiF1uytRUwEQxw08d7hL7y8/fR/lWy1VQ6GR4F3E4B48XANnq8V+ijj6lo3yqV
+        HwGcS6XkNYqjF10qFgXCeDGgjR3vGfrmByrar0p1vUrLi/JEL7pUv1XAWDGQjR/vHfrkdyrap0p1rEpr
+        XxW96FI9qmZVwGgxgE0c7yH6wGsAeIyJ9qdSfUGltamKXnTJUt4ggZQYuAaH9xJd530l2o9K9j6V1stU
+        9KJLxo2AGA0GrMHjPUWX7aiifahkL1dpzaxqXyJJOUsSUmGgGh7eW3TV0Sraf0o1SaVbBGhKtW+SuFIB
+        U8MANXy8x+gi34Ef7Tul+oNKr/ZjEn5Och4FTImBqRzea3TJgqr2PDceW9P7LxW9+JKtp4DJMSCVx3uO
+        rnirivaXku2g0nudil58yfZRwAgGonp479EFn1fRvlKyV6v05lS+WSH6A0qVcr1kVMEAVB/bAK07W0X7
+        SakeV+lvABxxmYr+iFL5SYTZFfqNgScPtgVa5S+1j6loHynVxaoZ31TRH1Ey/xSB/mLAyYdtghZtoKJ9
+        o2QeU5uxhYr+iJJ9WqGfGGjyYtugNV9S0X5Rsi1VM16qoj+iZL9W6B8GmPzYRmjJBSraJ0q2smrG89S9
+        KvpDSvWwauamCQwEA0s72FZogeeUqX1T+wNqJtWUX6nojynZ+gr9wIDSHrYZsnuLivaDkp2kmrO3iv6Y
+        kn1NofsYSNrFtkNmB6hoHyjZHqo5GSYEulqh2xhA2sc2RFbXqWj7l6yJCYCmNKt6SEV/UMmWU+gmBo7u
+        YFsimxVUtN1L9qCaRTXpVBX9USXbXqF7GDC6h22KTDKsa3OyatYnVPRHlewEhW5hoOguti2yOF1F27tk
+        HkOb5d8uoj+qZP4ZgmmBu4MBovvYxqhtXuX596NtXbLXqmbNrPwMY/SHlcxLOaJ9DAz9wbZGTe9W0TYu
+        mb+8+l66pvkSfPTHlexwhbYxIPQP2xy1/EBF27dkTT7/P6UMN1Lco5q9kxIMBD3Gtkdp/tZdeyZbt4Nq
+        3ooq+uNK90aF9jAAgH0AJWWY/c+9SHXCDSr6A0v2HYW2cODHCPYFlJLh8v+1qjO+oaI/smR3Kd+UiDZw
+        wMeU2CcwbFku/x+oOsOX36M/snTrKeTHgR5Tw76BYfITY9E2LN2GqjO8LG+GaYG/rZCbD/C+aTPaflnz
+        611VoQy/1y3uI69UyO0IFW2/knkp+87NXXOciv7YkvnSDpMC5bW0uk1F2y5rDP51tHgScKd6qUJO/qLq
+        qzXRtivZiapztlLRH1s6T/CAfHx/xgUq2mZZ49JuXS3+HODV5TzLHPLZREXbrHTbqc5ZTD2toj+4ZL9Q
+        yCfDuhFjiW/+ObR4JYAnknI6SUXbq2RPKY+VnXShiv7okj2hFlbIw9vj7yraXhlj8M+ltZMAfxFaXSGP
+        F6pJKtpeJTtbddbuKvqjS7ezQh77qGg7ZYzBP6fWTgL8bRN57Kmi7VS6HVVnLaky/AxwiUIeGSaKGk38
+        5p9bS/cE+Di4nEIOV6toO5XM+4THyE77rYr++NKtolDfCiraPtnim38bWroS0PRa7x2SYdl6d77qvN1U
+        9MeX7hCF+vxzTLR9MsXg35ZWTgLOUKjP88NE26d0Xjiv87L8DOCbzngcpz7fER1tnyxx2b9NLfwc8IB6
+        nkI98yhvh2j7lMxjoudB6YUsz3tvq1DXz1W0bTLEN/+2tXAlYBGFej6qou1SuotUb+yqojehdL9XqOs8
+        FW2b2jH4d0P2kwAvl456rlTRdildr55MW0J5woPojSjdGgr1nKmi7VIzBv9uyXwS8HKFOl6vom1Sul7O
+        TXOqit6M0h2pUM/RKtoutWLw76asJwHLKNTxMxVtk9Idr3pnUxW9GaV7VDEzYD1fUdF2qRGDf7dlOwnw
+        zHOzKJS3uMow85/r5fo0c6j7VfSGlO6zCnVkWYCDwb8fMp0E/EGhjs+paJuUzivUehXCXsryCJgPCHMp
+        lOdHMR9X0XYpFYN/v2Q5CWAukjrmVF6aOdompfuW6q01VfSm1Gh7hTpOUdE2KRGDfz9lOAlYX6G8HVS0
+        PWr0WtVbngTjWhW9MaW7Xs2kUN67VLRNhh2Df7/VPAm4SXG8Kc/v+Y0q2ialu071fiKovVT05tRoY4Xy
+        ZlS/U9E2GVYM/rBaJwFMQlbH+1W0PWq0h+o9zwnwpIreoNL1YjGGpPxzUKm5IRj8MbnSJwGefGZmhfIu
+        VdE2Kd1jaiEFOVZFb1KN1laoo8SduQz+iJQ6CfANr6wtUYfvuYi2SY08/wn+aQMVvUk1+rVCHf4p4BgV
+        bZdBxOCPaSlxEsCl/3qyTD7n1lL4J98IcY2K3qgacRWgHj8TO4yTgL8qrxAHTMsr1bAeEdtboQ7fbR9t
+        kxqxBk1gJxW9WTXymSLq8ZUAT840qHtDfG+Hl6EGRuOl6o8q2pfGky/7b6dQz2kq2jY14ipQwOsye43+
+        6A2rEVcB6vNCTZepaPuMJs80+THFDVcYKx+Pvqu8Tnu0b4023/DHb/51ZZpv5kHlyc8Q8KxI0ZtWI09O
+        g/p8NeCd6mTlO2ejbTVlN6tPqQUUMBGrq5PUWE8E/Jy/v+lx8lnfGSraRjX6psJUeGnM6E2rFUsF5+Jv
+        ZZ40aF/lVRz9wT5XeVWvg5XX1PZvuMCgLas+obzPPaCmPFZ4YZmrlKf39d3mTPKTw7pqym1VK59ErqQw
+        DWep6M2rkT/sADClxdSKahW1tGJVv5zOVtGxvUa+koTpeJuK3rxavVkBANqS6fFy93qF6fAjgV4mM3oD
+        a3SF4nIeALTD9w5lmfXPXaIwSluq6E2s1QcVAKAN2cYQr0GAUfLvaX9W0RtZo1uV15AGAOQ2h7pFRcfy
+        Gv1FcY/IGPn57ejNrBUrNwFAfp9W0TG8VrsqjJEnS7hPRW9ojfxaeK4cAPJaRGWaUM6TkTHxzzh9WUVv
+        aq2YxAEA8vq2io7dtfq8wjgtqh5V0RtbI89Nz0QzAJCP52TwhEzRsbtGvhLBVeMJ+rqK3txa/Ub5UUUA
+        QA4+JmeaRM59QWGCfBXgYRW9wbXaTAEActhCRcfqWnnRn4UUBuBrKnqTa3W7mk8BAOryTXa3qehYXasv
+        KgzIgspnVNEbXauvKgBAXf+tomN0rR5SfPsfsP1U9GbX6gnl1QsBAHX4pmzfnB0do2vlp9cwYL4KkOn5
+        TnehYp0AACjP8/2fr6Jjc618pdpjFYbAv6tEb3rNmOUJAMrbSUXH5Jp9RmFI5leZZgd0/r1nWQUAKMPH
+        3Gz3hfnm8LkVhmh3Fb35NTtdMTcAAAyfj7WnqOhYXLPtFIZsVnWDijZAzfwcKgBguLZW0TG4ZtcqVvwr
+        ZFMVbYSa3a08aREAYDgWV15gJzoG1+xdCoX4ElC2uz/dyYqfAgBgOI5T0bG3Zn4ajON+YeuoaGPUzpen
+        AACDtaWKjrm1W1uhgoxng74z9cUKADAYL1LZ5oFxHoNQyUuUZ+SLNkzNLlbcEAIAEzezyviT72NqeYWK
+        DlLRxqndpxQAYGI+q6JjbO0+p1CZV+X7m4o2UM18ZWI1BQAYnzXUJBUdY2v2JzWnQgJenz/aSLXzfAUs
+        GwwAY+dZ9a5T0bG1dhsrJOFHMM5S0Yaq3U8UAGBsjlLRMbV2pyoks7LKeEOg214BAEZnWxUdS2vnnyNe
+        ppDQ11S00Wrnu0VXVQCAaXuFekRFx9LafUUhqXnUrSracLXjfgAAmLYXqBtVdAyt3Z+Vxxgk9l4VbbwM
+        cT8AAMR8L9cJKjp2ZmgjhQYcq6INmKGPKQDAs31SRcfMDB2t0IisK0a5J9WGCgDwjPWUj43RMbN2d6mF
+        FBryERVtzAzdq1gvAABmmGFZdaeKjpUZ8jwzaIx/T/LyvNEGzdA1ipsCAfSZb6q7UkXHyAydrljqt1FL
+        q4wrSI3klaRmVADQNz72Zb7p72G1nELDdlDRxs3SZxQA9M1XVXRMzNJOCo3zWebZKtrAGXpaba4AoC98
+        zIuOh1k6TXHpvyN8w92DKtrQGfJMgesqAOi6tZSPedGxMEO+SXsJhQ75sIo2dpb82OLLFQB01YrqHhUd
+        A7P0PoUO8kx80QbP0s1qUQUAXfNC5XX0o2Nflpjwp8M8z7Tnc442fJYuUXMpAOiKedXvVHTMy5LXkZlf
+        ocPeoJ5S0Q6QpV+omRUAtG5W5efpo2NdlnwztscG9MD+KtoJMnWUYo4AAC3zMexHKjrGZeoAhZ6YTWW/
+        HOUOUQDQqq+r6NiWqQuVr1KgR1ZSD6loh8jUFxUAtMbHruiYlik/8reMQg/5cY9op8jWHgoAWvEpFR3L
+        MuXf/d+p0GPfUtHOkSnvqFspAMhuVxUdx7J1oELP+X6Ai1W0g2TKJwHbKgDI6kPKx6roGJapixS/++Mf
+        llJ3q2hHyZQ/WNspAMjG8/tnf8Ta3aeWVcD/eatq4czVH7CPKADIYgv1pIqOWZnyMf7tCniOL6lop8mW
+        d+LtFQDUtrVq4Zu/Y/l1TNVMKvuMVSP5JGAbBQC1+Ia/Fq6cumMVS/ximhZQ16toB8qWP3g7KgAobS8V
+        HZcydpWaRwHT9VLlG0WiHSlj+yoAKGUfFR2LMubJfl6sgFF7s2rhppaRDlasHQBgmHyMaWF635F8DH+j
+        AsZsNxXtVFn7oZpFAcCg+bl5H2OiY0/WPqaAcTtMRTtW1n6p5lQAMCjzqVZukB7pCAVMiGcKPE9FO1jW
+        fqMWVAAwUS9Ul6voWJO1MxQz/WEgFlY3qmhHy5qfZFhBAcB4raj+pKJjTNZ8x//zFTAwy6s7VbTDZe0e
+        tY4CgLFaS/kYEh1bsvY3tbQCBu5V6kEV7XhZe1x5jm4AGK33q0dUdEzJml/vqxUwNBupSSraATN3kOIx
+        QQDT4pnyWnrGfyQ/7vcOBQzdh1Ur019Onh/h4QkBAJF51UkqOnZk76MKKObTKtoRs+e7eZdTADDCx4Q/
+        qOiYkT1fsQCK+7aKdsjs3a02VACwnvIxITpWZM8/bQJVePXAY1S0Y2bPv5ntqVgdC+gnf/Y/oVqa8nzy
+        fqA4fqEqT717vIp20Bbya/csXwD6w7/3/0xFx4QWOk7NrIDqPFvgKSraUVvIE2e8TAHovtXUTSo6FrTQ
+        qcrHXCCNOdSZKtphW+hRtbMC0F2eE6S15/sn77dqbgWkM4+6QEU7biv9RPGTANAtvuR/lIo+8610iXqB
+        AtLy4HmxinbgVvLc32soAO3z7HheGyT6rLfSpWp+BaTnlfiuUNGO3EqeQng3xeyBQJt8k9xnVYszl07e
+        hYrFfdAUX6ryjhvt0C3lpYVfrAC0Yxl1roo+0y3ly/5880eTfNba+j0B7u9qK8Uzt0B+Wyp/ZqPPckv5
+        2Mn9SGjaXOrXKtrBW+tktYQCkM9i6ucq+uy21vnKNy4CzfMCPC3PEzB5Xh/cS4UCyMFX5j6i7lfRZ7a1
+        zlEM/uiUWVVXzs7diWppBaAe/9bviXGiz2iLnaA8pwrQOb4rt/VncSfvYeX1BLwmAoBy/K1/a9WF3/pH
+        Olp5anWgszxYtrqK4NTynbqrKgDD90rl38ijz2KrHai4yRi94W/OT6vow9BiT6lDlWdDBDB4fqrIy9+2
+        unrf1NpXAb3zIdX6JB1Tdot6n+JsHhgMf5Y8h//tKvrMtZq/NGyrgN56i3pIRR+QlvMkJF51DMD4raK6
+        MKHPlHlBoncroPdWV3eq6IPScj7D/75aVAEYvUXUt1TXrhC6O9RrFIB/Wk5dp6IPTOv5Csc+anYFYOr8
+        CJzvD+rKM/1T5mPc8grAFBZQZ6rog9OF/qz86BKPDQLP5t/5N1E3q+iz04VOVyzqA0yDJwzyZfPoA9SV
+        rlT/oQDMMMMG6ncq+qx0pcMUz/gDo+Rvyl38/W/yfqvWU0AfraX8rTj6bHQlP+rsn/8AjNGbVFd/C5w8
+        LzL0KgX0wdrqDBV9FrqUZyncWAEYJ98wc42KPmBd6zz1NgV0ke9891z30b7ftXyz38oKwATNr05T0Qet
+        i3k1sDcqoAvWV11asGd6Ha9Yxx8YIN8l7MeD/Gx99KHrYpcrz4DGUwNozYzKV7N8n0u0b3cx/97vaX39
+        twMYgo2U1+SPPoBd7Xq1s5pLAZnNpnzS+kcV7ctd7QH1DgVgyLwO/0Uq+iB2uXvVfmopBWSyuPqc6uKM
+        ntPr94rJfYCC/E3DK4NFH8iu559BfDOVf1sFavJ6F0eqJ1S0r3Y9/+1zKgAVbKoeVNGHsw9drDxnwrwK
+        KMFLXm+vrlLRPtmH7lMs5gMksKK6TEUf1L7k9QY829gaChgGP8b3beXn26N9sC9doJZRAJLwNJuecatP
+        TwlMLd+A5ScmFlLARCymfAOqn0iJ9rU+5bv8/bOjpysHkJCn1v2Lij7AfesxdZx6r+J3SoyW76/xwjwn
+        qSdVtG/1rdsVc3MADfAkHP+jog9yX3tEHaP8bDbfYDAlzzXhufn9DfcuFe1Dfe1E5SshABryQdX33yuj
+        7lbfUr5aMrNCP/lE8C3qB8o3tUX7Sp/zY7cfUAAa9SJ1loo+4PTMQe5o5Uu+vrsb3eanRXz3ugd9b/to
+        n6AZZviV8twGABrnaYT92BJXA6ad7xnwyoTbqSUUusGT1Oyqfq0eV9G2p2fyMcKP1fqYAaBDPIOgB7jo
+        g0/Pzc95f129Vc2t0AZfyfGl/QOUV6WLti09N18pXFYB6Cif2W+p+M1zbHmmt3PV3spzDfixS+TgJzw8
+        K+QX1flqkoq2IcX5p5CPKL71Az3xQuVlO6MDAk2/h5W/MXnQ8RWCBRTKWFD5Pf+8Olv5p5toG9H0+6Fa
+        RAHoId/8xrwBE8+TpFytvq8+rFZVPG44cb7S8u9qB3WU8sqQ0ftPY+sm9SYFoOd8CdWzCPJNarD5UrTv
+        I/CCKZ6Z0HMQMDvh1L1A+Vl8z7x3qDpP+UpL9N7S+PI+6bkOuKcFwLOspM5Q0YGDBtef1WnqELWj8gxr
+        vvlqRtV1/kbvu/I3Uh7oD1Z+L+5Q0XtFg8snVK9QADBV71e3qeggQsPrUXWF8lLH31SfVJup16nlVAs/
+        KfibpReneoPaXPlv8CDv58pvUNygVz7/xOfPNDf5ARgVT5jix6j6us55xnyfgb8p+2eFc9Sx6ntqX/Ux
+        5ac7fE+Hf9v1LIdeq35l5ZMH3zjnS+xRIwODt7n/eSnl/88qyv8On4BsoN6jtlUe1PdXvt/Br8E34vk1
+        Mc9Erjz99WcV62AAGBdfrvUc+h58ooMMEeXLV5F4ph/AQLxa+TfE6GBDRDm6TPmKDQAMlC8V+xKzf8uN
+        Dj5EVCffWOopfL2qIQAMje/k9sGGZVOJ6ubPoB8xnU0BQDGec90Hn/tVdHAiouHkGy5986dv3ASAajwN
+        ricSekBFBysiGkyeGMkT+SysACANz3L3VcXsbUSD7SHlx3IXUwCQlp859+VJTgSIJpYv9fsb/6IKAJrh
+        KwL+aeAeFR3ciCjON/f5s+OJmQCgWZ4e1vO++1Gl6GBHRM/kmR498HNzH4BO8eODnh/e891HBz+ivna5
+        8lTOPM4HoNM8oZBXgztdMcUw9bWn1PHq9QoAemcF5RsG71XRQZKoaz2oDlVeNREAes+TCm2vvKpcdNAk
+        ar3r1a5qPgUACHgJ2iMVSxFT6z2mvJrm+or1+AFglF6o9lBXq+jgSpQ13+i6k5pfAQAmwFcFPCEKCxBR
+        1h5RI9/2AQADNrt6nzpZPamiAzFRqR5XJ6hN1VwKAFDA4soTDJ2n/EhVdIAmGnTe185UXhKbS/wAUNkS
+        auRkgLkFaBj5CRXP0resAgAktKTy41bnK64M0HibpM5QuygGfQBojFcm3ET5scL7VXSgJxrJK1j6N31f
+        3l9EAQA6YFblO7S/rjwpSzQAUP+6SX1LvUkxFz8A9MBLlO8b8Hzs96locKDu5Wmn/1dtq16kAAA9NpPy
+        XAM+IfCz3Pxc0J38W/4lymtO+AqQV6UEACDkQWJNtZc6Ud2tosGF8nWn8lUdzyK5lppDAQAwbl65cDN1
+        sLpU+ZtlNABRufyUx5XKq+ttobyNAAAYqjnV2sqPHB6ufFLwqIoGKpp4fm8vVt9RXjlyDTW3AgCgupnV
+        Suq96kvKj5T9STE50ejzFM83ql+prylfdXm58nsLAEBT/Du0B7GNlX+b9rdYTzLzF9XXkwMv7HSB8tWT
+        jyu/Ny9TPIoHAOgFnxysrPwc+pZqb/Vt5asHl6nbVTSAZu4B5WWcT1HfV59R/ts2UC9V/vkEAABMhycx
+        8noHq6h11DvVh9Xuyj81+ITBjy96lcTT1IXKj75dq3w5/Q7l59+fUCMDtP95at2iblD+d/xG+d95rPqJ
+        8g13B6hPqm2Uv7n7Nfnb+2LKrxUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAABozAwz/H8kns8+GbGJuwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pictureBox3.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAALAAAAAtCAYAAAAOT+HDAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABPZJREFUeF7tXcFuHEUQtQnrcbBXRCJksWSJFawiwoWDiZIjR/gAf4/9B/afIHHk
+        Atw48C+LzAeY9zpVneqe3vUQQOmR3pOeq7qqume8emrVzK5mDvbgEPxgAlt1U+ayZuoxnD5n6rxY95D/
+        LmvWrHMc/9v14xp1vB57rFVfc0pNi/E4U1mf1775MRfrp2EYhi9gfgG34L0odsIfTZttMd/f3zOxAbdX
+        V1f32+0WIUF4/6AWb25uKOItRPwlLLVaCPnw4uJiAfsTCwWhR1xfX1PEv4EfgmwtMh6BH4HaeYVuQW1C
+        o3+aVqnZvAtz930CWqkg9Alq1LTKXTiBKh6Wy+VTWCsThD5BjUKrn1Czpt305xh8BlqZIPQJavT09JRa
+        fQwmAbMZ5mAFWpkg9Alq9OTkZLVer7npvhHw2dkZm2IJWOge1CgFDFvuwAh+BmtlgtAnqFGw2IEPbQeW
+        gIXuQY2Cq/Pz81EPLAEL3YMaBcsWQjuwMBdQo9YDjy7iJGChe1CjYNkDs5/QRZwwB1CjYLkDg9qBhVmA
+        GgWLHph/dBEnzALUKDi+iFMLIcwB1ChY3EbTDizMBtTo6C4EqB5YmAWoUVACFuYJalT3gYXZghoFdRdC
+        mCeoUduBy7sQsBKw0D2oUbAUMCgBC7MANQqWArZ7ahKw0D2oUbC8iAMpYAatTBD6BDVKrda/B9Y3ccIs
+        QI2CRQuhX6MJswE1CpYthO5CCHMBNcrbaKMWAlQPLHQPatS0+raF4EAthDAHUKNg+VwIkGqWgIXuQY2C
+        xQ6sLzKE2YAaNa2WLQSoHljoHtSoabUp4Ds9H1joFfZ8YBdw2QPbE/9+51OwBaFH3N7eUrw/g8/q22gD
+        BPwp7HfgHQu1Ewu9gFq01wvcmUZHzwfmE9o/BtfgD+CvoG/Xovi++Rf4B/g9+Dn4xN7pkgX8yL6NY2/B
+        NxV9A75cLBavYJ2vbfyaY/jJmj+qCXmPRcY6n+/rprWN8Tgjyzx9s4wn2ty8htUkv4p7fTxOro95i+W8
+        5fK4lQtr5lqPsT74OW/M81hXj1lv8bROtLGuynMNxpNlzJjXDrFMm+9zPV7M55q2bszXx/JYy482+b6e
+        2W9BanLDVne1Wp3A5zsy3gC7tL+laAlSxOthGJ4fHR19Bf9r8AX8ZGs/jmFzrGKsp+9MMZ9nNtam8Z51
+        05wwL82t1qPduQbjzIdYPK/o5zFtHIMc08/j4DtZw88zjTmfMc+5bcTz2rTMW02i5VIsxium+fRZb7W+
+        ZjEv+Kme1mp9Ts6FcbFGyOV8xXRcWmORC9brnh8fH3PnpTaXcfd1cMBemAnuxGwnntqFHcn+OFnG6niI
+        eV2LaW6MxXFcAzavU8+pWeXrefX5xlzKGxnz8/PY6HydjHut+4F5no/jvGiNOW9+HOd4NadYo87t445j
+        F8f0mtoGpnrGwXzOsT7S88ZUH2st1hzTt3diUJPU5uLy8vLt7uvgLgyT2gmQQj6yr+tGZDzmNpsNG+qc
+        cx8cPLdrLTLmWnUPxPKxIz1PG1nlR+e2z/dxjAcOO+KJ9VotvxHL/xs/R4t7LH+2kazx+dG6X5FX8o8t
+        5/YfkXcD4rwdaxSfDf26LoyL/8niA3ddChcXc9xoH4SLeQqJVpwkWvH/k0QrThKt+BQSrXhNh/t1/r8g
+        0Yq3SLTiJNEau639qSRa8Xcl4Tbg4OBvSdXRqLIoThAAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="pictureBox2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAALAAAAAtCAYAAAAOT+HDAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABPZJREFUeF7tXcFuHEUQtQnrcbBXRCJksWSJFawiwoWDiZIjR/gAf4/9B/afIHHk
+        Atw48C+LzAeY9zpVneqe3vUQQOmR3pOeq7qqume8emrVzK5mDvbgEPxgAlt1U+ayZuoxnD5n6rxY95D/
+        LmvWrHMc/9v14xp1vB57rFVfc0pNi/E4U1mf1775MRfrp2EYhi9gfgG34L0odsIfTZttMd/f3zOxAbdX
+        V1f32+0WIUF4/6AWb25uKOItRPwlLLVaCPnw4uJiAfsTCwWhR1xfX1PEv4EfgmwtMh6BH4HaeYVuQW1C
+        o3+aVqnZvAtz930CWqkg9Alq1LTKXTiBKh6Wy+VTWCsThD5BjUKrn1Czpt305xh8BlqZIPQJavT09JRa
+        fQwmAbMZ5mAFWpkg9Alq9OTkZLVer7npvhHw2dkZm2IJWOge1CgFDFvuwAh+BmtlgtAnqFGw2IEPbQeW
+        gIXuQY2Cq/Pz81EPLAEL3YMaBcsWQjuwMBdQo9YDjy7iJGChe1CjYNkDs5/QRZwwB1CjYLkDg9qBhVmA
+        GgWLHph/dBEnzALUKDi+iFMLIcwB1ChY3EbTDizMBtTo6C4EqB5YmAWoUVACFuYJalT3gYXZghoFdRdC
+        mCeoUduBy7sQsBKw0D2oUbAUMCgBC7MANQqWArZ7ahKw0D2oUbC8iAMpYAatTBD6BDVKrda/B9Y3ccIs
+        QI2CRQuhX6MJswE1CpYthO5CCHMBNcrbaKMWAlQPLHQPatS0+raF4EAthDAHUKNg+VwIkGqWgIXuQY2C
+        xQ6sLzKE2YAaNa2WLQSoHljoHtSoabUp4Ds9H1joFfZ8YBdw2QPbE/9+51OwBaFH3N7eUrw/g8/q22gD
+        BPwp7HfgHQu1Ewu9gFq01wvcmUZHzwfmE9o/BtfgD+CvoG/Xovi++Rf4B/g9+Dn4xN7pkgX8yL6NY2/B
+        NxV9A75cLBavYJ2vbfyaY/jJmj+qCXmPRcY6n+/rprWN8Tgjyzx9s4wn2ty8htUkv4p7fTxOro95i+W8
+        5fK4lQtr5lqPsT74OW/M81hXj1lv8bROtLGuynMNxpNlzJjXDrFMm+9zPV7M55q2bszXx/JYy482+b6e
+        2W9BanLDVne1Wp3A5zsy3gC7tL+laAlSxOthGJ4fHR19Bf9r8AX8ZGs/jmFzrGKsp+9MMZ9nNtam8Z51
+        05wwL82t1qPduQbjzIdYPK/o5zFtHIMc08/j4DtZw88zjTmfMc+5bcTz2rTMW02i5VIsxium+fRZb7W+
+        ZjEv+Kme1mp9Ts6FcbFGyOV8xXRcWmORC9brnh8fH3PnpTaXcfd1cMBemAnuxGwnntqFHcn+OFnG6niI
+        eV2LaW6MxXFcAzavU8+pWeXrefX5xlzKGxnz8/PY6HydjHut+4F5no/jvGiNOW9+HOd4NadYo87t445j
+        F8f0mtoGpnrGwXzOsT7S88ZUH2st1hzTt3diUJPU5uLy8vLt7uvgLgyT2gmQQj6yr+tGZDzmNpsNG+qc
+        cx8cPLdrLTLmWnUPxPKxIz1PG1nlR+e2z/dxjAcOO+KJ9VotvxHL/xs/R4t7LH+2kazx+dG6X5FX8o8t
+        5/YfkXcD4rwdaxSfDf26LoyL/8niA3ddChcXc9xoH4SLeQqJVpwkWvH/k0QrThKt+BQSrXhNh/t1/r8g
+        0Yq3SLTiJNEau639qSRa8Xcl4Tbg4OBvSdXRqLIoThAAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="$this.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAiEAAAE0CAYAAAD65OMyAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAF6RJREFUeF7t3U+zJUlZB+AZOOfebmhUkBlY3JAxaB1bQ1wMzDSBgCuXuprQj0ME
+        CxZo4ADNLHWpK924dsEOFgZ8EcJww67Nt8g3fU/eOhcCyOrN80T8pqoys+qce+90xBtZ/14L3/nOd976
+        wQ9+8F8vXrz4WVu+FBEREfkN8+8ffvjhW63MeH0rNvZEARLFx99+8M8vf+8f//Xl7T/8m4iIiMivnagn
+        /vqf/uVl1Bff/OY3/6iVG+eWj758+fKyIGkD/iMG7h1ERERE5NfN33zwzy+/+93v/vCTn/zk77aS4/E7
+        77wTxchHtgIkxJSJGRARERH5bSfqixcvXvzPo0ePPtdKjjdanrScXr58GSXIL4qQvR1FREREftNEnXFz
+        c/OFVnJ8vuXNu7u7x++///5HFSEiIiKyNFFntHLjeStE/vzRo0d/0Nbj1Myp5XVFiIiIiCxLL0K+2vLF
+        lrhI9fdbblsUISIiIrIuvQj5Wsu7LX/S8umWRy2KEBEREVmXUoS81/InT548eTOKkO12XUWIiIiIrErU
+        GafTaRQhLYoQERERWZ95JqQlbtV1OkZERETWJouQ8/n8PIuQt956SxEiIiIia2MmRERERF5JdoqQ7ZqQ
+        FkWIiIiIrMtchLg7RkRERA6JmRARERF5JSlFSF6Y+qYLU0VERGR5ehHy9ZYxExIvsXM6RkRERJYm6ozT
+        6TSKENeEiIiIyCHpMyHbNSE3NzdOx4iIiMgxySLkfD7XC1O9RVdERETWZpoJeZanYxQhIiIisjS1CGlx
+        i66IiIgckyxC+rtjnilCRERE5JD0IuTe3TGKEBEREVkaRYiIiIi8kkSdcTqdXBMiIiIixyZnQvotuu6O
+        ERERkWPSi5CLmRAPKxMREZHlqUVIPDHVTIiIiIgckixC8ompihARERE5JFFnzBemxukYL7ATERGRpbky
+        E+LdMSIiIrI2vQjZ7o6pb9E1EyIiIiJLkzMhLeN0TItrQkRERGRtsgg5n8/v9iLkjbu7u8eKEBEREVma
+        XoSMx7ZHEdJiJkRERETWJuqM0+kURUjOhFyejhERERFZlVZwbHfH5IWpF0UIAMAKWYS0XDwnRBECACw1
+        FSHxArvtmpDWpQgBANbZmwmJIqRFEQIArBN1Rr8w1ekYAOA4ZkIAgFeiz4TcK0JalyIEAFinFyHb6Zib
+        m5tnWYS0KEIAgHWizmgFxzYTEkVI3B3z9OnT29alCAEA1ukzIVmEuCYEADhGnwkZd8c8efLk8lX+AAAr
+        zEVIi5kQAGC9XoRs746JIiSuCfGcEABguagz9m7RVYQAAEv1mZCv50yIIgQAOMS1mZDWpQgBANbJIuR8
+        Pj+PIiTujokipEURAgCsE3VGKzjGhaktb97d3T1uXYoQAGCdnAlpxccoQtwdAwAslzMhvQh5u+WNFkUI
+        ALDWVIS4OwYAOEbUGaf+Ft1ehHhYGQCwXp8JuXhOiCIEAFiuFyH1se3b3TGKEABgqagz+nNCvMofADhO
+        L0LG6RgPKwMADhF1Ris4xt0xihAA4BC9CNnujnE6BgA4TNQZ9XSMIgQAOEQvQi4eVubuGABgub0ipMWr
+        /AGAtaLOaEXHVoTUa0JalyIEAFinFiEtcXfM9tj21qUIAQDW6UXIxbtjWhQhAMBaUWfsXRPSoggBANbJ
+        mZD62HYvsAMAluszId6iCwAcq8+E3Ls7RhECACyVMyGKEADgUDkT4nQMAHCoPhNycTpGEQIALJczIVGE
+        tGwPK2tLzwkBANbqRUh9WNk2E9K6FCEAwDpRZ5SHlb0dRUiL0zEAwFo5E5IXpubpGEUIALDUPBPSi5Db
+        1qUIAQDW6UVIXhPidAwAcIyoM1rBMe6OaXGLLgCwXhYh5/P5eXliqtMxAMBaZkIAgFci6ozp3THujgEA
+        1suZkDgd05ZbEWImBABYrhQheTrGY9sBgPWizijPCXE6BgA4hpkQAOCV6EXIeGx7i4eVAQDrZRHSshUh
+        XuUPABwi6ozpmhAzIQDAer0Iqadj3KILAKwXdUYrOOZrQh4rQgCApXoRku+OedbW3aILAKyXRUjL9tj2
+        uDDV6RgAYLmdImS7MLV1KUIAgHVqEdKS14R4lT8AsFYvQsZzQlreePr0qSIEAFgr6ox8lX8vQpyOAQDW
+        m2dCXBMCABxipwhxiy4AsN7eTIhbdAGA5aLO6O+OeR5FSMubcWGqIgQAWKoXIfdOx7QuRQgAsE4pQsZM
+        SBQhLYoQAGCdqDNaweFV/gDAsXoRcvEqf0UIALBc1Bn9wlTXhAAAx8mZkCxCWjysDABYr8+EuDAVADhW
+        nwn5WlwT0l/l75oQAGC9XoTUC1PNhAAA6+VMSMsoQjy2HQBYrhYhcTpGEQIAHGKeCYlrQhQhAMByvQi5
+        uEVXEQIALJdFSL0wVRECACzXi5B7745pXYoQAGCdqDPyse39wlTXhAAA69UipGUrQlrMhAAAa0Wd0YqO
+        KEIuHtveuhQhAMA6fSbEC+wAgGP1mZBRhDx58sRj2wGA9XoRcvECu7gwtXUpQgCAdbIIabm4MLVFEQIA
+        rDMXIU7HAACHqEVIPx2jCAEA1utFyHZhaitCnrWlx7YDAOtdmQm5VYQAAEvVmZAWzwkBAI4xz4RkEdKi
+        CAEA1ok6I5+YWp8ToggBAJbqMyEXT0x9+vSpa0IAgLV6EbI9MTWKkJY37+7uHitCAIClsghpGU9MdToG
+        AFiuzISMV/krQgCA5WoRknfHeIEdALBc1Bl5d0yLIgQAOEafCfl6vTC1xekYAGCtXoS4JgQAOFYWIS1b
+        ERIPK2tLRQgAsFYpQsYtui2KEABgragz4sLUvDumv0VXEQIArNWLkO2JqeUFdh7bDgCsFXVGKzhcmAoA
+        HKsXIfUWXdeEAADr5UxIS56OiSLEC+wAgLWizugXpm5FSFyY6nQMALBcL0LGLbrujgEADhF1Ris46nNC
+        tiKkdSlCAIB1+kxIvsDumZkQAOAQvQjZHtt+c3PzrC1dEwIArBd1Ris4sgjZ7o5RhAAAy5UiZNwdc3d3
+        5xZdAGCtXoRs745pS09MBQCOEXVGPickipB8TkjrUoQAAOv0mRDPCQEAjpVFSD4xta27MBUAWK8XIRen
+        Y9pSEQIArJUzIS31ianujgEA1soiJGdCoghxOgYAWG6vCGlRhAAAa0Wd4S26AMDhykxIPrbdc0IAgPV6
+        ETLujlGEAACHKDMheTrmjbZ0OgYAWCtnQlrGTIgX2AEAy0WdEe+OKUWIJ6YCAOvtzYS0uCYEAFhrnglx
+        iy4AcIg+E+IFdgDAseYixEwIAHCIXoTE6ZjnLdtMSIsiBABYqxQheTrGhakAwHpRZ+SFqa0IeaYIAQAO
+        sTcT4sJUAGC5uQjx2HYA4BC9CKnvjnF3DACwXhYhLRdPTG1RhAAA6/QiZNyiayYEADiEmRAA4JXIIqRe
+        E+LuGABguV6EbHfHRBHS4u4YAGC9qDNOp5PTMQDAsaaZEE9MBQCO0WdC6ukY14QAAOvlTEi+yr+tuyYE
+        AFgvi5AWzwkBAI7Ti5Bxi26L0zEAwHpZhLS4OwYAOE4vQuKakOf5Kn9FCACw3N5MiNMxAMByWYScz+d3
+        swhpUYQAAGvVmZDb29u323K7Rbd1KUIAgHVKEbLdotsSMyGPWxQhAMA6WYSUh5U5HQMArFdmQrYLU73K
+        HwA4RC9CxrtjWhHise0AwHpzEdLidAwAsF4tQvKaEKdjAIDldmZCnI4BANbLImR+gV3rUoQAAOvUmZB+
+        OsZMCACwXtQZp9OpvjvmDTMhAMByORNST8e0mAkBANbqRcg2E3Jzc/MsHlbW1m9blyIEAFgnZ0J6ETIu
+        TG1LRQgAsM40EzJOx7QuRQgAsE4tQlpcEwIAHCOLkPP5/DxmQvIFdq1LEQIArBN1Rtyi24qQd1sx8qzP
+        hNyaCQEAlpqKkO0tuk+fPlWEAABrRZ3RCo4oQrw7BgA4zk4R4sJUAGC9LEJatiIkTsd4TggAsFzUGfnu
+        mPqcEEUIALDUPBPS4mFlAMB6WYSUu2OiCHncoggBANbZmwlxTQgAsNxOEeIWXQBgvVqExKv8FSEAwCF6
+        EVJf5a8IAQDWq0VIi+eEAADH6EVInI55HkVIi+eEAADrZRESj23vr/J3OgYAWK/MhFw8rKxFEQIArFNn
+        QhQhAMBhFCEAwCuRRUiLa0IAgOP0IuTr5/P5eX2LbutShAAA6+RMSJ6O8QI7AOAQe0WIh5UBAMv1ImQ8
+        MbXFhakAwHpRZ5xOp7gmxEwIAHCcXoSMh5X1a0IUIQDAWlFntIJjuybk9vb27bZuJgQAWK8WIf05IVsR
+        0roUIQDAOlmEtGxFSFtuDytrXYoQAGCdWoS0uDsGADjGThHise0AwHpRZ8QtulGEeGw7AHCYMhOyvTvG
+        LboAwCFKEXJxYaoiBABYKouQfovuM7foAgCHKDMhz1tcEwIAHGOaCXFNCABwjDIT4jkhAMBxehFSb9F9
+        4+7u7rEiBABYam8mxAvsAIDlos6or/Jv8e4YAGC9WoT00zHujgEA1os6oxUdTscAAMfqRci4MDUfVqYI
+        AQCWijqjnI551pZu0QUA1qtFSMt2YaqZEABgubkIidMxnhMCACwXdUYrOMZj29u60zEAwHpZhLRcvMCu
+        RRECAKzTi5C4OyaLkO1hZS2KEABgnTITMq4JiSKkdSlCAIB1os6Y7o5RhAAA680zIS1OxwAA62URcj6f
+        xzUhnhMCACxnJgQAeCV2ihC36AIA681FiLtjAIBDmAkBAF6JUoSMJ6a6MBUAWK4XIfHE1DETEi+wa12K
+        EABgnagzTqfTKEJcEwIAHKLPhGzXhORbdJ2OAQCWyyIkXuXflnlh6q0iBABYapoJeZanYxQhAMBStQhp
+        cYsuAHCMLEL6u2OeKUIAgEP0IuTe3TGKEABgKUUIAPBKRJ1xOp1cEwIAHCtnQvotuu6OAQCO0YuQi5kQ
+        DysDAJarRUg8MdVMCABwiCxC8ompihAA4BBRZ8wXpsbpmNalCAEA1rkyE+LdMQDAWr0I2e6OqW/RbV2K
+        EABgnZwJaRmnY1pcEwIArJVFyPl8frcXIW/c3d09VoQAAEv1ImQ8tj2KkBYzIQDAWlFnnE6nKEJyJsTp
+        GABgvT4Tst0dkxemKkIAgOWyCGm5eE6IIgQAWGoqQuIFdts1Ia1LEQIArLM3ExJFSMvrr7148eJnP//5
+        z/tQAIDfjqgvogjpF6bePx3z4Ycf/tePfvSjPhwA4LfjJz/5yctvfetbP2wFx/5MyPe+970/jNmQn/70
+        p1vFAgDwm4h64sc//vHL73//+//73nvv/X1/gV3covt2y6ejCGnDXm/L117/xje+8ccffPDBf8aUiYiI
+        iMhvkig+vv3tb//3V77ylb9rdcZftSLkq235xdvb2z9uy99vuYn6o2X7z83vNW35VstftHy55at9p6he
+        InE+J9cvEud6+vmeseypY+bxW1tv3/bL9TJujO1tdf1eYuzO+r3vMY3btqfx23pvH8eoY3v7th3LKfP4
+        h8Zmoq/ut7XP+9TtHNeT32tL3Wcam5+zjWnb29+49F/s15Ljxs/Rt7e26M/2vj2OEdt9vX7enOzb+mui
+        f27r7fUz67h7nxPbbbl7/J7sv9int2fb+LySerx5/22fqW87Zm8bKeNz7MX36W1jXNmuP9fYZ6dvbtuO
+        kettOfqjvfdnm3//v/i83B5je/u2Hcsp8/iHxmair+63tc/71O0c15Pfa0vdZxqbn7ONadv+/Zfvnfv0
+        9mwbn1dSjzfvv+0z9W3H7G0jZXyOvfg+vW2MK9v15xr77PTNbdsxcr0tR3+09/5s+23++//Ltoy64guP
+        Hj363Kc+9anfef/99z/68mVcr/oLH235WH+97tObm5svtOWX+mt3n2fa9lif29uHxAfsjsm2XObYki9H
+        X9237tPXY5+xXx27t90yf8a9tH3i59s+u2/X/tGeie3edvE95nHZvtdff/bW/t78u4jtPn5rn/fP9rq+
+        M2YvMXb8nqfPresj5ZgX/dnel9n35Thmfv8cM/98D2Vnn7Hv9JkjsZ3jY32vv69ffI9sn79f3X8+1rWx
+        03L3u/R9x/7zPrGMMWWfi8+ak/uV9bFdv2fpu0i0T33js+dlZt6u7fmZe2Pm482/x5aL/2cidZ++Hvtc
+        /bnm7Zb5M+6l7ePf///31bFbyjEv+rO9L7PPv/9fLHe/S9937D/vE8sYU/a5+Kw5uV9ZH9v1e5a+i0T7
+        1Dc+e15m5u3anp+5N6a1xb+zL/W64vO9zoj3xkTdMXzknXfeObflJ1piwOdaYsrkWcuflvxZLtsBc31L
+        294SfZkcM7VfjO99o62MGWOn9Zr4jItjZB44Vu2/6Mu2tnzos2P7Yp+WZ305jtFz7/eU2Rmbbfd+pr6e
+        7dsxe7I/18cy2rOvr4/xsd6XOWZ3vWcbm+19WY/1qySOMb5HLGP/ltHe1+f9dpOf3ZfbMfrxckz9PeTx
+        6/htXG+7+NzYnsY9tIyxI6WvjqufPbZ7//ZZdd8ybmyX/q0tljmujB/7TBltfWw9zti/fMa2fSXZnz/v
+        6IvjTMcfY6b2i/G9b7SVMWPstF6Tv797fQ8cq/Zf9GVbWz702bF9sU+Lf/8PJ44xvkcsY/+W0d7X5/12
+        k5/dl9sx+vFyTP095PHr+G1cb7v43Niexj20jLEjpa+Oq589tnv/9ll13zJubJf+rS2WOa6MH/tMGW19
+        bD3O2L98xrZ9JdmfP+/oi+NMxx9j2jLqiKgn4kxL1BefiHqjzoKEuC7kI20Z52g+1hKnZuLCkc+0fLYv
+        P9MrmMhnPv7xj29tff2zdXvuv5L5uNv6zn5j3C/Jve9QE30teawxNtv7ckvdJ9f79vgufWz9zHvfM36u
+        HDONe+jnvZdrY6K9/u4eSv8uta3+Hff+pmN9b/ta+7VxkanvV/q7tn22cflz9mPs/Sy7v4fcfy9xjDze
+        tD2We5nGXPw9S+LvXv8/275HbGdby/xzjOT4kjF2b59ou3aszEP9vW/vdzXa+t9g/K6yva3XfwfZdrG9
+        k/m42/rOfnvfaS/3vkNN9LXkserfZWvvyy11n1zv2+O79LH1M+99z/5vbhy7t8e4h37ee7k2Jtrr7+6h
+        9O9S2+rfce9vOtb3tq+1XxsXmfp+pb9r22cblz9nP4Z//5d983F381B/79v7XY22/jcYv6tsb+v130G2
+        XWy3RD0RdcXHW6LOiHrjntf7laoxRXKOe3gj/XW7j+dlWY/bbLKtrs9tsdyOGdt5/Fgvx6mpx8j+a2O3
+        RF9+vzz2vL6Xst84TrbnmN53r23ad1vOn1f6s6+uj3E1pW8bl/uV/bdxeexYPnS8lnt9fd9M9ufxL45Z
+        foZt/PR5dZkZ4/r61h77zD9Dtpft0V6341h5vPn79IzvXD73Yp95v/lnyH3r/r1vjMt95mX09eVDuRib
+        36cco37P+XvMiX0ujlePE5n3n/q3/fc+K9Zj7Nw3j2nL+Xijf2rbPis/P5a5Xo5TU4+R/dfGbom+/H71
+        56zreyn7jeNke47pfffapn235fx5pT/76voYV1P6tnG5X9l/G5fHjuVDx2u519f3zWR/Hv/imOVn2MZP
+        n1eXmTGur2/tsc/8M2R72R7tdTuOlcebv0/P+M7lcy/2mfebf4bct+7f+8a43GdeRl9fPpSLsfl9yjHq
+        95y/x5zY5+J49TiRef+pf9t/77NiPcbOffOYtpyPN/pLW+S25RzXgbTldjHqLxOD5kTlErnWN6/P46+t
+        19R9c3ltv7mvts1919prX22rffP2Q+Mj2VeXe+OvHWNuz/2zfW+/a/3ZPrflem2bx839uaxjHhp/bZ+9
+        zGPqvtlWsze2rl/bf97OtpraXpd7bbHc6699e2P22rNvXu61xbJmbsv9ru0zt+fYeTvHX2urffP6PP7a
+        ek3dN5fX9pv7atvcd6299tW22jdvPzQ+kn11uTf+2jHm9tw/2/f2u9af7XNbrte2edzcn8s65qHx1/bZ
+        yzym7pttNXtj6/q1/eftbKup7XW51xbLvf7atzdmrz375uVeWyxr5rbc79o+c3uOnbdz/LW22jevz+Nj
+        fcdrr/0feTcke8+dbz4AAAAASUVORK5CYII=
+</value>
+  </data>
+</root>

--- a/Vistas/frmError.cs
+++ b/Vistas/frmError.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace VistasMrTiendita
+{
+    public partial class frmError : Form
+    {
+        public frmError(string mensaje)
+        {
+            InitializeComponent();
+            lbl_Mensaje.Text = mensaje;
+        }
+
+        private void btn_No_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.OK;
+        }
+    }
+}

--- a/Vistas/frmError.designer.cs
+++ b/Vistas/frmError.designer.cs
@@ -1,0 +1,133 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmError
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmError));
+            this.bunifuElipse1 = new Bunifu.Framework.UI.BunifuElipse(this.components);
+            this.lbl_Mensaje = new System.Windows.Forms.Label();
+            this.btn_No = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // bunifuElipse1
+            // 
+            this.bunifuElipse1.ElipseRadius = 5;
+            this.bunifuElipse1.TargetControl = this;
+            // 
+            // lbl_Mensaje
+            // 
+            this.lbl_Mensaje.AutoEllipsis = true;
+            this.lbl_Mensaje.Font = new System.Drawing.Font("Roboto", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_Mensaje.Location = new System.Drawing.Point(26, 160);
+            this.lbl_Mensaje.Name = "lbl_Mensaje";
+            this.lbl_Mensaje.Size = new System.Drawing.Size(281, 60);
+            this.lbl_Mensaje.TabIndex = 5;
+            this.lbl_Mensaje.Text = "Mensaje";
+            this.lbl_Mensaje.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // btn_No
+            // 
+            this.btn_No.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(210)))), ((int)(((byte)(71)))), ((int)(((byte)(63)))));
+            this.btn_No.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(241)))), ((int)(((byte)(82)))), ((int)(((byte)(73)))));
+            this.btn_No.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_No.BorderRadius = 4;
+            this.btn_No.ButtonText = "Aceptar";
+            this.btn_No.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_No.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_No.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_No.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_No.Iconimage = null;
+            this.btn_No.Iconimage_right = null;
+            this.btn_No.Iconimage_right_Selected = null;
+            this.btn_No.Iconimage_Selected = null;
+            this.btn_No.IconMarginLeft = 0;
+            this.btn_No.IconMarginRight = 0;
+            this.btn_No.IconRightVisible = true;
+            this.btn_No.IconRightZoom = 0D;
+            this.btn_No.IconVisible = true;
+            this.btn_No.IconZoom = 90D;
+            this.btn_No.IsTab = false;
+            this.btn_No.Location = new System.Drawing.Point(101, 318);
+            this.btn_No.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btn_No.Name = "btn_No";
+            this.btn_No.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(241)))), ((int)(((byte)(82)))), ((int)(((byte)(73)))));
+            this.btn_No.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(210)))), ((int)(((byte)(71)))), ((int)(((byte)(63)))));
+            this.btn_No.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_No.selected = false;
+            this.btn_No.Size = new System.Drawing.Size(130, 33);
+            this.btn_No.TabIndex = 8;
+            this.btn_No.Text = "Aceptar";
+            this.btn_No.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_No.Textcolor = System.Drawing.Color.White;
+            this.btn_No.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_No.Click += new System.EventHandler(this.btn_No_Click);
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.BackColor = System.Drawing.Color.Transparent;
+            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
+            this.pictureBox1.Location = new System.Drawing.Point(114, 26);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(102, 90);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox1.TabIndex = 9;
+            this.pictureBox1.TabStop = false;
+            // 
+            // frmError
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("$this.BackgroundImage")));
+            this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.ClientSize = new System.Drawing.Size(335, 403);
+            this.Controls.Add(this.pictureBox1);
+            this.Controls.Add(this.btn_No);
+            this.Controls.Add(this.lbl_Mensaje);
+            this.DoubleBuffered = true;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Name = "frmError";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "frmError";
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Bunifu.Framework.UI.BunifuElipse bunifuElipse1;
+        private System.Windows.Forms.Label lbl_Mensaje;
+        private Bunifu.Framework.UI.BunifuFlatButton btn_No;
+        private System.Windows.Forms.PictureBox pictureBox1;
+    }
+}

--- a/Vistas/frmError.resx
+++ b/Vistas/frmError.resx
@@ -1,0 +1,520 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="bunifuElipse1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="$this.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAVUAAAGZCAYAAAA5JqLhAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAGL9JREFUeF7t3bGvJld5x3Ew916b+FrEIqxBWglHWifYlqCAsN4imDZFUkSC5H9I
+        Q5E/wJIlGgoE2PjPSJrUFKQJFBH8GxQWoqHbnGf8PMOZ885d75y5iiLl85W+zLwzZ+Z9d7389JyZM2c+
+        E/z4xz9+/ec///kvPvzww4/b8ilJctd/++ijj15vsfnZ9JII1AjTX/7rD57+7vv/8PT3//h3JMnByMf/
+        +sG/RLB+/P7777/x1ltv3bz33nsvtBjdhmsL1H+PhnsnIUlujQL0pz/96S9bfH6h+XKEa1v+KVyjpP3d
+        9/9+92CS5NaoWD/44IPft/iMywAPmq80r5sRrJ+E6t6BJMl9IzdbfH6j+ej29vZLbfn55ueaQpUkj5qh
+        +s7Nzc3X2/Krr7766he++93vXglVkpwwcvPq6uo719fXf9Ni9K+aX3z06NGLbfmCUCXJg2al+p3mt5t/
+        fXt7++D1119/SaiS5IQVqq1Sfact3xSqJHnCIVTfevnll19rS6FKkjNmqL4boXpzc/NWW3/t4cOHMQJA
+        qJLkUSM3r66u3m0hGqH6ZlvGeFWVKknOWJVq83FzqVSbEaqfFaokedAK1bqm2qxKVaiS5FEzVGNIlbv/
+        JHnWyM28plrd/wcG/5PkpH2lmjeq6u6/7j9JHjVDdbn73+yvqapUSfKofaXafCuuqQpVkpw0cjMmVIlQ
+        re6/UCXJSTNU1yFV3WOqrqmS5FGrUq1QNaSKJE8YudkCdB2n2tT9J8lZq1KtUI3uv0qVJCcdKtX+2X+h
+        SpJHrVC9vr5+XFP/CVWSnLSrVJdQ1f0nyRN2lWrdqDJLFUnO2lWqrqmS5FkjN4cnqqJS9ToVkpwxK9Vl
+        6j83qkjypFmpbl78J1RJctKsVNdrqp79J8kTVqXaQjS6/x5TJckzZqXav/jPe/9JctasVDfdf6FKkpNm
+        pToOqdL9J8kZM1T7d1S5pkqSs/aVanOZ+k+okuSkkZt5938Zp2pCFZI8YVepPm6qVEnyjH2l2qzB/+7+
+        k+SMVanWY6qGVJHkCStUm3X3/0GGqsdUSfKoGarV/e8fUxWqJHnUIVT7CVV0/0nyqBmq9ToVg/9J8oxV
+        qQ7zqbpRRZIz9pVqPPtv8D9JnjBys2b+b0FaleqLQpUkJ6xKtQXrk+z+m6WKJGetUG0aUkWSZ81QNfUf
+        Sd6HfaUa3f/b21vv/SfJWftQbZqliiTPGLnZv6OqaZwqSc6aobq5pmpCFZKcNHKzBegSqt0TVbr/JDlj
+        Vao1+N81VZI8YYVqC9FxSJXuP0keNXKzBeg6pEqokuQJK1RrQpW2bpwqSc4auZlDquJtqlGpevafJGfN
+        SjVuVHlFNUmeNUO1v6aqUiXJWbtQXSrVpkqVJGfNUI0hVRWqKlWSnDVyM8epLjeq4ppqPqYqVEnyqFWp
+        dq9TMaSKJGetUG3WONW4pmpCFZKcMXIzx6lGpdqHqkqVJI9alWo9URUz/3tFNUlOmqFalWr/OhXdf5I8
+        ah+qdU1VpUqSk0Zu3jH1n1AlyaNmqC6zVLUgXa6ptqXuP0nOGLnZAnQzpEr3nyQnzUr13eaTFqT9hCoq
+        VZI86lCpvt2WKlWSnLUq1QjVZg2pUqmS5IwZqnvzqQpVkjzqWKl2oar7T5JHjdxsAbpMUp2Vao1TVamS
+        5FEzVPup/wz+J8lZK1Sby+D/plAlyVkzVOuJqmXmf0OqSHLSrlKNa6pRqT7wOhWSnLQq1e6JKt1/kpy1
+        r1Sbb+r+k+QJq1KNUB2GVAlVkjxqVar5OhWhSpJnjNzsn6jS/SfJE2aluk5S3axQ9UQVSR41K9UI1bhR
+        tXT/VaokOWlWqrr/JHkfZqjWK6qX7r/B/yQ5aeRm3KjauaYqVEnyqH2lGo+pmvmfJE+YoWqWKpK8D/tK
+        tdm/o0qokuRRIzdr8H/OUlWVqu4/SR41K9X1MdUYUpV3/4UqSR61QrW5XFONUG1LQ6pIcsYM1fWaaoaq
+        a6okOeNQqZqliiTPGLkZz/5HqA5T/7mmSpJHzUp17f43DakiyVn7SjVCNcapevafJCetSjWf/XdNlSTP
+        WKHaXF781zSkiiRnzVDt7/67pkqSs0Zu1tR/dfff1H8kOWmG6tj9F6okOWPkZgvQvUmqjVMlyaNmpRrX
+        VB/XLFW6/yQ5aVaqxqmS5H2YleomVNtSpUqSM2aorkOqzFJFkieM3GwBulSqZv4nyZNmqNbdf4+pkuQZ
+        K1Sb/TVVN6pIcsY+VKP775oqSZ5wrFSbrqmS5KyRm/2QqghVg/9JctI7KlXXVElyxgzVzSTVKlWSnLQL
+        1Zilqn+iyjVVkjxq5GZNqNJcBv/ns/9ClSSPmqHad/8f6P6T5KSRmy1Aa5yqa6okecasVKv7X3f/hSpJ
+        zpiV6macalOokuSMd4SqcaokOWOGasxSFa9TeTtD1ZAqkpyxQrWpUiXJsw6hGuNUvU6FJGe9o1IVqiQ5
+        Y4ZqvU6lD1XXVEnyqBWq9URVTlLtmipJzpihur6jysz/JHnCyM3+FdXNbfefJHnMFqB3P1EFAHh+dkJ1
+        O58qAOD5yVDdXFPdzFIFAHh+dirV7d1/AMDzI1QB4B7JUF3v/nfvqBKqAHCUPlRvbm6Wd1RlqLpRBQBH
+        idyscaq7j6kCAJ6fvlJtuvsPAGcYQ7XpRhUAzCJUAeAeqVCNwf95TdXdfwCYZadSFaoAMEsfqnX3/+HD
+        h9H9d/cfAI6iUgWAeyRy8+rqan1M1RNVAHCCDNXN3X/jVAFgksjNFqARqo+bl6+oBgA8PxWq19fXj+tG
+        lUoVACbJUF2uqQpVADhJH6rNpfufoWpIFQAcZQzVi1dUAwCenzFUuyFVKlUAOErkZj9ONSrVfKJKpQoA
+        Rxkq1f5GlUoVAI5SoVqvqI5QbQpVAJihC9VlnKobVQBwggzVzSxVxqkCwCSRm8Oz/x5TBYBZslLd3P1v
+        S/OpAsAMVak2n1T3v6lSBYAZslJdu/9uVAHACfpQzUq1nv0XqgBwlAzVzThVoQoAk1SoNtfuvxf/AcAk
+        Gar9kCqPqQLALJGbxqkCwD2RlWp0/+MdVa6pAsAZMlQ33f+mUAWAGapSzQlV3o5QVakCwCRdpVpvU3VN
+        FQBm6UO12Xf/3f0HgKNEbsbrVHLw//LiP0OqAGCSrFQ3r1Np6v4DwAwZqnX3f6lUvfgPACbZqVTdqAKA
+        WSI3hyeqdP8BYJa+Ur25uXlTqALACSpU4+6/mf8B4CR9pdo08z8AnCFyM6+pxuD/6v67+w8AM2SlurlR
+        ZZJqAJgkQ7Wf+q+GVAlVADhK5GY+purZfwA4S1Wqefc/rqka/A8As2SovltDqvLuvxtVADBD5Gbc/df9
+        B4B7ICvVeqKqv1GlUgWAo1SlGqHaXGapEqoAMElfqUaoNr2jCgBm6SvVevbffKoAMMlepdpUqQLADBmq
+        rqkCwH3Qh2oO/jekCgBm6UI13vv/5u3trWf/AWCWDNV+QhXdfwCYpSrVeEw1QtVjqgBwgjFUm0IVAGaJ
+        3Iyp/1qILqGa11SFKgDMkJXqGqpN11QBYJYM1b1xqu7+A8BRhlBdZqnymCoATNKF6jqkKidUUakCwFEi
+        N+tGVU2o0lSpAsAMXajGE1V199+NKgCYIXKzBeg4+F+oAsAMXaVaE6qoVAFglgzV9e6/ShUAThC52QK0
+        ZqkSqgBwhrFSber+A8AsO6GqUgWAWSI3W4DG3f8a/K9SBYBZMlRrQpV6nYrB/wAwQ+RmdP+zUvWOKgA4
+        Q1aqm1DNZ/9VqgBwlKpUW4i6UQUAZ+lDtcapqlQBYJLIzRagy+D/ZoTql9syblS5pgoAR6lQjQlVapYq
+        lSoATNJVquZTBYCzRG5eXV19p6b+y1BVqQLADBWqLUT7qf9UqgAwQ+RmC9A1VLtZqtyoAoCjZKiuM/83
+        DakCgFkiN6v7n6Hq7j8AzFKVaheqblQBwCxCFQDukQzVTfe/6YkqAJihKtWapSrv/htSBQAz9JXqzc3N
+        223p7j8AzFKV6tXV1ZO2dE0VAM5QodpcB/+rVAFgkgzV6v4bpwoAZ+gr1aa7/wBwhjFUu2f/VaoAcJQM
+        1b1xqkIVAI5SoVoz/6tUAeAEkZv9hCrxOhWhCgCTZKiO11R1/wFghsjNFqD9NdXXHj58KFQBYIYM1ahU
+        l2f/hSoAnKAq1bpR1dbd/QeAWSI380ZVVKpL97/pRhUAzJCV6vKOqnj2vwtVT1QBwFGqUvXiPwC4B4ZK
+        1eB/ADhDVqrrK6qNUwWAE2Sl2k/9V6HqmioAHKUP1WYfqipVADjKUKm6+w8AZ6hQzWuqy+tUHj169GJb
+        V6kCwFEiN+NGVXN98Z/HVAFgkqpUm0ulGlP/GacKAJNUqNaQKqEKACcYQ9XgfwA4QYbq+kRVW3dNFQBm
+        idyMG1UtRGtIldepAMAsVak2x6n/jFMFgKNUqNY11WZVqkIVAI6SoWpIFQDcB5GbeU21uv8PPFEFAJP0
+        lWo9+593/3X/AeAoGarre/+b7v4DwCx9pdpcnqgSqgAwSeTm1SdvUx2n/hOqAHCUDNXxdSqGVAHADFWp
+        mlAFAO6ByM0WoOs41abuPwDMUpVqhWp0/1WqADDJUKn2z/4LVQA4SoXq9fX145r6T6gCwCRdpbqEqu4/
+        AJygq1TrRpVZqgBglq5SdU0VAM4SuTk8URWVqtepAMAMWakuU/+5UQUAJ8lKdfPiP6EKAJNkpbpeU/Xs
+        PwCcoCrVFqLR/feYKgCcISvV/sV/3vsPALNkpbrp/gtVAJgkK9VxSJXuPwDMkKHav6PKNVUAmKWvVJvL
+        1H9CFQAmidzMu//LOFUTqgDACbpK9XFTpQoAZ+gr1WYN/nf3HwBmqEq1HlM1pAoATlCh2qy7/w8yVD2m
+        CgBHyVCt7n//mKpQBYCjDKHaT6ii+w8AR8lQrdepGPwPAGeoSnWYT9WNKgCYoa9U49l/g/8B4ASRmzXz
+        fwvSqlRfFKoAMEFVqi1Yn2T33yxVADBLhWrTkCoAOEuGqqn/AOA+6CvV6P7f3t567z8AzNKHatMsVQBw
+        hsjN/h1VTeNUAWCWDNXNNVUTqgDAJJGbLUCXUO2eqNL9B4AZqlKtwf+uqQLACSpUW4iOQ6p0/wHgKJGb
+        LUDXIVVCFQBOUKFaE6q0deNUAWCWyM0cUhVvU41K1bP/ADBLVqpxo8orqgHgLBmq/TVVlSoAzNKF6lKp
+        NlWqADBLhmoMqapQVakCwCyRmzlOdblRFddU8zFVoQoAR6lKtXudiiFVADBLhWqzxqnGNVUTqgDADJGb
+        OU41KtU+VFWqAHCUqlTriaqY+d8rqgFgkgzVqlT716no/gPAUfpQrWuqKlUAmCRy846p/4QqABwlQ3WZ
+        paoF6XJNtS11/wFghsjNFqCbIVW6/wAwSVaq7zaftCDtJ1RRqQLAUYZK9e22VKkCwCxVqUaoNmtIlUoV
+        AGbIUN2bT1WoAsBRxkq1C1XdfwA4SuRmC9BlkuqsVGucqkoVAI6SodpP/WfwPwDMUqHaXAb/N4UqAMyS
+        oVpPVC0z/xtSBQCTdJVqXFONSvWB16kAwCRVqXZPVOn+A8AsfaXafFP3HwBOUJVqhOowpEqoAsBRqlLN
+        16kIVQA4Q+Rm/0SV7j8AnCAr1XWS6maFqieqAOAoWalGqMaNqqX7r1IFgEmyUtX9B4D7IEO1XlG9dP8N
+        /geASSI340bVzjVVoQoAR+kr1XhM1cz/AHCCDFWzVAHAfdBXqs3+HVVCFQCOErlZg/9zlqqqVHX/AeAo
+        Wamuj6nGkKq8+y9UAeAoFarN5ZpqhGpbGlIFADNkqK7XVDNUXVMFgBmGStUsVQBwhsjNePY/QnWY+s81
+        VQA4Slaqa/e/aUgVAMzSV6oRqjFO1bP/ADBJVar57L9rqgBwhgrV5vLiv6YhVQAwS4Zqf/ffNVUAmCVy
+        s6b+q7v/pv4DgEkyVMfuv1AFgBkiN1uA7k1SbZwqABwlK9W4pvq4ZqnS/QeASbJSNU4VAO6DrFQ3odqW
+        KlUAmCFDdR1SZZYqADhB5GYL0KVSNfM/AJwkQ7Xu/ntMFQDOUKHa7K+pulEFADP0oRrdf9dUAeAEY6Xa
+        dE0VAGaJ3OyHVEWoGvwPAJPcUam6pgoAM2SobiapVqkCwCRdqMYsVf0TVa6pAsBRIjdrQpXmMvg/n/0X
+        qgBwlAzVvvv/QPcfACaJ3GwBWuNUXVMFgDNkpVrd/7r7L1QBYIasVDfjVJtCFQBmuCNUjVMFgBkyVGOW
+        qnidytsZqoZUAcAMFapNlSoAnGUI1Rin6nUqADDLHZWqUAWAGTJU63Uqfai6pgoAR6lQrSeqcpJq11QB
+        YIYM1fUdVWb+B4ATRG72r6hu6v4DwCxZqXqiCgDug51Q/dN8qh9++OHHf/zjH7MpAOBZRF5mqG6uqa6z
+        VH300Ue/+NWvfpXNAQDP4je/+c3TH/7wh//ZArQq1Rr8/8nd/5/97Gd/2VL349/+9rdLAgMALol8/PWv
+        f/20ZeYf3nnnnX9qARqhWjP//6n7H//z/vvvv/GTn/zkP6KkJUle+sEHH/zhRz/60X8/fvz4n1tuxp3/
+        CNVvNd945ZVXvtiWLzaXUA1uXn311S+05evNrzefNP+2GQeFdYLFeI1ADCfIIQWbfZ3L9mhb2+qY2NZv
+        b67nGPb12zffMxwfjr9j7/tr+/Ibcn3d/2nGMXW+tlzOU9vHNrG/1mtfc/2+2J/LsU3/udpsluP2XK9j
+        lvX6XG36/WXty/WLY+6ya1frz2y/Z52jM84x/tb138vevlyu9ufsjrvY12+rdmXuW35Lfe73teXFedO9
+        79v85q7Npu3z2LW/+HOnh88d7YZj6tzjd2w+53FxTGy/8/fEMs+7WMfEtn57cz3HsK/fvvme4fhw/B17
+        31/bxz/vcxnH1PnaMvIxcvIbL7300lfbMvLzuvkJ3/ve9z7XFn/WjGEBj66vr7/RlpHAj2Nqq1y+E+v1
+        OY3rCf3nZVu2qWV/jtVs++1cxrblXG25bqvP1b72dZ/Xds3+962/K47p2u393guH84ZxXP2+/twX23bc
+        7NtrG98X1v5ab27+Lsvct2vt79sN23Z/69i+2rblM39/fe6O2fz3S9djxuP3zPP06xfHdN+32daWF99f
+        7e5oX+7+rvHYbtn/ucd/s7Gs8/XtwvVzt73/7vg77//N1/aLz3e0qfP351yMdmW3ffPvLZb9sbUvtsV6
+        13ZtP1jnW8/bL8tsu/69tW313ePf5f/F///H7/hWW4+cfCMH/kd+Ro5+wtOnT6NkvWneNh9k8v7Vzc1N
+        XCt4M5a1/mne1bY/17htb73//Kxt3TKGNWy2j9Y5uv1fG5Zru/5z82t3nbMcznunY5vxuFqv7Xuf0/XP
+        W9a+cXu/b9zfPq9/9n5ft775u+m943zP3Nbv67Yt31Ht+jajz9g//s71nP2yrPOU/b4Z7zr/uG1nefFv
+        Kz73bard2GZcb8u9c63bxn1ltBk+XyzvOnb0rrb9ucZte+v952dt65b/m///j/ZvNCMn41rq7Te/+c3r
+        995774W2viE2RPn6cvPPm1/Kd1lHCr/W0vjLtT58/nImdWyr7avxufZXm1rv3dm+nD/PN+67+J7a3rl8
+        d6zHuYf2/bb1mL3P0a6tL8tar33VLrf11v71NwyO2y7+jvJztVvbD+2W7bncnCM/b/Z3+5bz1P783O/v
+        26/r3fmqXa1X28167Ovbxr48R7W5OF9sq3Nm29i/nnO0O/biz3/Xepwvz1mObfY+Lw7fMX7/cr7ctlmm
+        9X21b7H2pfV53R/tq924rdb7fW292lebzTK277S/aLvTZu/z2i6WuX01Ptf+alPrvTvbl/Pn+cZ9F99T
+        2zuX7471OPfQvt+2HrP3Odq19WVZ680Hr7zyyl+0ZXT5o0KN3Iz8XK+nFrEhjBL2OsdchTFM4NN8Kd95
+        HV/w+Vxf7LcP257pXW1i+/Puq/V+meu7vzP/zJtjxvVP8ytf+crFuWNbf+6ybxP743Nti+Wzjsnlun/8
+        7dWueXGOcuf8y+c4Nn5zd46NdVy/P9cvvqvOs3Ou+jdzyJ3v3Dv3brve2lb/vZ7lzvEv3fV3sPdd6cW/
+        gfG/Wb/v07blcvf4cb0/pt/Xt8n1Z/6eZ/j/7f//0S5uSkWYRl7uBmpPhesLWc4uxnpeJqgTrPvC2Nft
+        37SpY8v63J8/XbfFsl+PfbG+9x3dtvU7ar3ahHXO2F7nrv21r9reZbWp7+yOWz/Xcvj+WtZ677i//7ws
+        ++/b2V5t937X2rZbrvurfe7b/L3ccY5lvb63O349Vyxrf398bMvP67I/vnM8djlnHZNe/Bm7NhuH71iP
+        z+2b39SfL5fj52U5tFv3xfY47/CdvePx/fb1z1D76zfWvuG8m2P67bVtaL/uj+Xz7K9tQ9uLY2LfcK51
+        vY4t63N//nTdFst+PfbF+t53dNvW76j1ahPWOWN7nbv2175qe5fVpvuOtuj5zGf+B4vmGSbpyme4AAAA
+        AElFTkSuQmCC
+</value>
+  </data>
+  <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAYAAAD0eNT6AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AABBC0lEQVR4Xu3dB7hc1Xnvf9GxAZtiG1zu
+        zSXJtR334MT55/79JDjG+JpqkGQgBgyiukJiDE5wTBWIaosmBKIJsOmiNwnRwQZMMab3EqqQ9syZtrf2
+        aN13Ha2xRlvv0WlT9lr7+3uezyPQOTplZu/39845UyYQQvIdY8wa4mNJknwpTdMtm83md+S/9128ePEh
+        8v/Hihny378R14i58v/3iYfEc/L/L4mFGYkwGfbvlns/+fcv2o/hPtZ98ndzhf0cv5H/P0McI/99sP1a
+        5L8ni2/If3/Rfq1idfflE0IIISQbKcoPS2n+rZTndlKmP5I/p8mfF4nb5b+fkD/fEdmy9sU78j38Sf68
+        XVzovjf7PW5rlxn53j/kLgZCCCEkrEjJrdZoNDaV0vuGlN/+8ueJ8ucc+fNx+bMmtOIskppcFn+UP+1l
+        coL8uZ/8uUW9Xv9fctmt6i5GQgghJL+RwvqYLS8psQPkz5niHvnvitCKD8OL5TK0PwW5TBwu/z05SZLP
+        2qXKXeSEEEJI7yIFtIYtomazubuU0nRX9FVXWui+xC0Gs8UB4qtynbzfXT2EEELI+GNvbUrZf17sLaUz
+        S9gfV9toxYT+WSzXzWPibLmu9hKfk+uOXyEQQggZWaQ0PiAlspWYKp0yX5RdwcA/JTFPrsujxbfkul3P
+        Xc2EEEKKHlsKUg5biGnC/ihfe4gcwiBXcfqEsPfPmCzXPY9CIISQokSG/vtk+H9DHC8ekVJYkikJFEdT
+        joGHxXFiCzk21naHCSGEkBCSJMkXZdgfLOwT2dTd8Aey7MMybxEH2ft9uMOHEEKIL7G35OwtOjFdhvkr
+        brgDo/WyHEP21wXb8tMBQgjJaWRAbyS32qbI0L5a8Nh7dJo9pq6SY2wPOdY2dIcdIYSQfkQG8YfsY/Fl
+        MF8nuPMeeiWV2DuMHiDH4Efd4UgIIaSbkYG7sQzeH8sAvlv+bLqBDPSLXQbulD9/KMfmh91hSgghpBOR
+        wWrvuT9Zhiy39JFndhm4J0mSfeWY5TkHCCFkLJEBuroM021kqF4qeNEc+MY+NfRv5RjeWo5lXruAEEKG
+        SxzHn5LBebjg3vsIxRuyCExPkuQL7jAnhBBiY39cKsNxHxmS9ynDEwiG+xXBXnLMr+sOf0IIKV7k1v6n
+        ZSBOk8G4MDsogcCV5difKcvAF93pQAghYUdu+awpg8/eoc8+K582GIFCkfPhIXfHwfe504QQQsKJDLeP
+        yaA7WgbeO9kBCGDQ23KOHCXnCs8tQAjxP3LLZjP7o04ZbjwHPzAysbhM/KM7jQghxI/ILZhVpfQniXvb
+        hhqAUZJz6G6xoz2n3OlFCCH5iwypNe1T88rAekobZgDGRs6pF+RP+9TDvCgRISQ/kaG0nh1O4vXWwALQ
+        FW+Jw+WcW9+dfoQQ0vvIENpQbpkcJQMpahtQALpvkZx7R8g5uIE7HQkhpPuRobORDCD7bH2L2gYSgN4b
+        kEVgml3G3elJCCGdjwyZD8nAscXPLX4gX+wiMF3O0Y3d6UoIIeOPDJV1ZcAcIih+IN9aPxH4oDt9CSFk
+        9JEhsqZ9hjIZKvaOR9qwAZBPC8Qhcg7zqAFCyMgjQ2N1Kf59ZIC81jZQAPjnFTmXp8g5zUsSE0JWnjRN
+        txB/VAYJAE/JOf2U+JY7zQkhZFniOP6MDIobsoMDQFCuazQaf+VOe0JIkWOM+bjcMjhPBkMzMygAhKkh
+        5/xxcu5/wI0BQkiRIif/GjII7LP3ldsGA4DisHcUtE8vzP0DCClKZPv/ungiMwwAFJDMgoflz39y44EQ
+        EmLs7/7kRLcvM6oOAgCFZu8fsKkbF4SQEOJ+3P+fgtfkB7AyNXGwzIzV3fgghPiaJEm+lKbpQ5mTHACG
+        JDPjMfnz790YIYT4FNng3ycn8TQ5idP2ExsARmixzBD7+gLruLFCCMl75Lz9Jzlxn2k7kQFgTGSWvCC2
+        cOOFEJLHyKa+vpyoM+WkXZI9iQFgnC6TGbORGzeEkLxEin9bOUFfz5ywANBJbzWbzd3d2CGE9DOykX9c
+        TsrrMicpAHTT1TJ7PurGECGk15Fb/TvIiWifzUs7QQGgmxY1m82d3TgihPQisnnbe/hPV05IAOi12TKT
+        1nXjiRDSrcjJ9ndS/tzDH0BuyEx6Uf78RzemCCGdjGzYq8gJZl+8J26ddACQIzaHy6zixYUI6VTkhPqf
+        cmLdIbSTDgByI03T+3hNAUI6EDmZJslJ9V72JAOAHIuazeZ33RgjhIwmcqv/A3ISzc6cVADgDbkBcx53
+        ECRkFInj+FNy4vB6/QC8J7PsmSRJPuvGGyFkqMjJsp2cNFH2JAIAj5XtrzPdmCOEtMfec1ZOEPvqfTyP
+        P4AQLZEZZ19dcHU39gghckJ8SE6OWzMnCwCE6A6ZeRu78UdIcZMkyWZyQryUOUEAIGSviX9wY5CQ4sW+
+        qpacBLW2kwIAiqIhN4D2ceOQkGLEGLNWmqZnKScEABSNfS2B97nxSEi4kQP9Y1L+DygnAQAUkszE38ls
+        3MSNSULCS5Ikn5OD/ZXswQ8AWPy6zMgvuXFJSDiRDXcLOcB5fD8ADM0+X8C33NgkxP/IVrunHNhJ5kAH
+        AKzIZj83PgnxM2bpS/geLrSDHAAwhHTpkwat4sYpIf5EDty15CC+KHtQAwBG7DKZpWu7sUpI/iMH7IZy
+        4PL6/QAwTmma3isz9UNuvBKS3zQajb+UA/Yp7UAGAIyezNTn4jj+327MEpK/yIH6FfFO+4ELAOiIt5Ik
+        +bIbt4TkJ3Jwbi5KbQcrAKCzBtI0/Zobu4T0P3JAbisHZj1zoAIAOq8qM3dLN34J6V+azeauckDaaAcq
+        AKDzYlkCdnBjmJDeRw7CfxNL2g5KAEBvJHIDbCc3jgnpXeTg+1nmYAQA9FaaJMlebiwT0v3IQXdI5iAE
+        APSH/SnsgW48E9K9yIHGU/sCQP4c5sY0IZ1PmqZHKQcdACAHZEZPc+OakM5FDqyp2gEHAMgPmdVHurFN
+        yPjDLX8A8MrP3fgmZOyRA+mXmQMLAJB//+7GOCGjjxxAP80cUAAAPyxJkmQfN84JGXnk4DkwczABAPyS
+        8mRBZFSRA2Y3OXB4hj8A8F+Spum2brwTMnTkQNleDhgb7UACAPjHvnbAt9yYJ2TFyAHyL3Kg8Kp+ABCe
+        qvgnN+4JWRY5ML4iBtyBAgAIT5QkyZfd2CdkwoRGo7GpHBhvZw4UAEB43pWZ/9du/JMixxizYZqmTysH
+        CQAgQDLzn5LZv4GrAVLEyAGwphwMt2UPDgBA2GQJuFM6YC1XB6RIkSt+FTkIZmcPCgBAYfzWdoGrBVKU
+        yPbHi/sAAA53tUCKkCRJpigHAQCgeJY0m83vuXogIUeu7M1F3HblAwCKzT5b4BauJkiIieP4M3JFL8pc
+        8QAAlJIk+byrCxJSjDEflSv4lcwVDgBAy0vSFZu42iAhRK7QtdM0fUC5sgEA+DPpivulM3h4YCiRK3SW
+        dkUDAJAlnXGmqw/ic5Ik2Ve7ggEAGIp0x16uRoiPkSvRvsBPo/1KBQBgBOwrw/6dqxPiU4wxG8mV91Lb
+        lQkAwGi8Il3yIVcrxIfIFbaaXHG3ZK5IAABGa57tFFcvJO9J0/QE5UoEAGDUpFOmunoheY5cUd+WK2xJ
+        9goEAGCMlki3THI1Q/KYOI4/JVdUKXPFAQAwXmX7bLKubkieYoz5gGxoTytXGgAA4yYd84R0zbqudkhe
+        IlcOr+0PAOgqWQJmudoheYj93Yx2RQEA0GnNZnMnVz+knzHGfEKukPeyVxAAAF2ySLrnf7oaIv2IXAGr
+        yhUxP3PFAADQVWma3ikdxPMD9CtyJRyavVIAAOiRg10dkV4mSZIvy4UfZ64MAAB6JRFfcbVEehFjzDo8
+        5A8A0G/SRc9JJ/HQwF7FPgxDuyIAAOg16aQZrp5INyMX9A7aFQAAQL9IN23vaop0I8aYj8sFvSB7wQMA
+        0GfvSkd91NUV6XTkAr46c4EDAJAX17u6Ip1Ms9ncWbmwAQDIDemqf3W1RToRY8yGcsG+lb2gAQDImQXS
+        WRu7+iLjjVyg52cuYAAA8upqV19kPEnT9GtyYS7JXLgAAOSWdNckV2NkLDHGvF8uxOe1CxcAgBx7Szps
+        A1dnZLSR8j9JuVABAMg96TCeIGgskQvv70XafmECAOCRpvg/rtbISGKMWV02p4czFyQAAF6RLntcOm0N
+        V29kuMiF9p/ZCxEAAE8d4uqNrCyNRuOv5MKqZy48AAB8VTXG/IWrOTJU5IK6NnPBAQDgu8tdzREtaZpu
+        qVxowIpqVZO8+IJp/O5eU7/rdlO/+fql5t08+P/xY4+Y+K03zeIk0f89APSYdNw3Xd2R9hhj1pQL52nt
+        QgOS11419RuvNdWTp5nyft8zpYlbmdKO3xreTtubgZ//m6med9bgspBUKurHB1ZQrZr4uWdN/e47TP2q
+        y0ztglmmetbppnr6r0115mmD/1+/8tKlC+ezT8uxNaB/HMCRjnuSOwQqkQvnP7IXFootefcdU7viEjPw
+        7z/Uy30MyrvsYKonHWsa99/DTwewvDg2jUf+YKrnzjQDhxxoSpO3VY+hIU3exgz87CemOmuGafzhAbO4
+        0dA/D4ru313tERvZiOzr/A9kLiQUVPLSC6Zyykly6307fdB2SPn7U0z9hmsGb+lpXweKIXnlpcFb9OUp
+        u6jHyViV99jJVGdMN8kLz6ufF4VVks7jxYJakQuEF/uBSRYtNNWzzzClSVurA7VbynvvaurzbuEnAgUT
+        P/G4qUz95ch/nTRW8vErRxw6eL8U7etA8aRpOtPVX7GTJMkX5QKxz5akXlAohsatN5rybpP0AdojA7/4
+        mYn/+3X160M4krffMtVfH9/94lfYhSPhGMPixal03+ddDRY3ckHMzVwwKJCkVDLVk6apw7Ifyt+daOrz
+        56pfK/xXv/E6U97l2+p13zM7bW/q11zJT5xwm6vBYiZN022UCwUFYW8JlX8wRR+SfVY9/2wGdECSRYtM
+        5bij1Ou6XypH/ZdJ3lugfr0ohsI+LNAsfb7/J7ULBeGzj+G3v3vXBmNeVH91vFncqKtfP/xhf+RfPnB/
+        9Trut/J+e5jk1VfUrxvhkw60rxOwmqvF4iRJkn21CwThi596wpR37e/v+0eqcszhZnGdJcBXPiya5T13
+        MfEzT6lfP8InXbiHq8ViRDaeteUbfzV7QSB88TNPm/Luk9VBmFf2R7WLazX1+0F+xc8/O/hQPO06zRt7
+        35P4yT+p3weC97J04lquHsOPfMMHZS4AFICP5d9if3/MrwP84VP5t7AEFNpPXD2GHdl01pNv9u3MN4/A
+        +Vz+LSwBfvCx/FtYAgrrHduNribDTZqmRynfPAIWQvm3VI8/mqd4zTGfy7+FJaCwfuFqMszIhvMh+SbL
+        mW8aAQup/FtYAvIphPJvYQkopEg6cgNXl+FFbv1PU75pBCrE8m+pnjCVJSBHQir/FpaA4pGOPMLVZViR
+        zWYj+Qa59V8QIZd/C0tAPoRY/i0sAYVjXygovJ8CyGZzjPLNIkBFKP+W6onHDL6MrHY5oPtCLv8WloDC
+        OdzVZhiRjWZD+aa49V8ARSr/lur0E3na4D4oQvm3sAQUSlj3BZBb/0cr3yQCU8Tyb6mcwhLQS0Uq/xaW
+        gEI5zNWn35FN5gPyzSzKfHMITJHLv6VyykksAT1QxPJvYQkojIXSneu6GvU38o38PPONITCU/zIsAd1V
+        5PJvYQkojB+7GvUzssGsJd/EG5lvCgGh/FdUOfVkloAuoPyXsS+mxRIQtjRNX5QOXd3VqX+Rb2K/7DeF
+        cFD+Q6ue/iuWgA6i/FfEEhA+WQImuzr1K7K5rCZf/LPaNwX/Uf7DYwnoDMp/aK0loF6v25eVVS8/+Es6
+        9AFXqX5FvvBJ2jcE/1H+I1c9+wyWgHGg/Idnl4DoDw+agYEBloAwfdXVqj+RBeA+5RuB5yj/0avOmqFe
+        llg5yn8UvjuRJSBcc1yt+hE5AL+sfBPwHOU/diwBo0P5jwFLQKiWxHH8N65e8x/5gi/OfAPwHOU/ftVz
+        zlQvWyyP8h8HloAgpWk6w9VrvmOM+Zh8wXH2G4C/KP/OqZ47U72MsRTl3wEsASGqS7du7Go2v5FNZary
+        xcNTlH/nVc87S72si47y7yCWgBDl++mB3RP/vJP5ouEpyr97quedrV7mRUX5dwFLQGjeth3r6jZ/aTab
+        uypfNDwUP/PU4MOL1MGCjqhdfIF62RcN5d9FLAFBkY7dxdVt/pKm6b3aFw2/JK+/ZspTdtEHCjqq9tvZ
+        6nVQFJR/D9gl4I+PsQQEQDr2Tle3+YocWF/QvmD4JVnwrinvv4c+SNAVtUsuUq+L0FH+PfS9nUz0zNMs
+        AQGQ6+9zrnbzE/swBe2LhUdkMFSm/lIfIOiq2qXFWgIo/z74wV4mevMNlgDPSddOd7Wbjxhj1pUvrJT9
+        QuGX+pzL9cGBnqhddrF6vYSG8u+jY48wURSxBPgtks5dx9Vv/yMH0j7KFwmP2N/7l3baTh8a6Jn6lZeq
+        108oKP8cuOEalgDPyfW2h6vf/idN0/u1LxL+qBx7uD4s0HO1y3+rXke+o/xzYrdJJnrtNZYAj+XmzoBx
+        HH9KvqAl2S8Q/mg8+rA+KNA39auvUK8rX1H+OXPqyYMLAEuAt5Y0Go2/djXcv8gmcrzyxcEjlcP/Qx8S
+        6KvaFZeo15dvKP8cmrS1iZ56giXAY9K9R7sa7k+MMavLF/JG9guDP5IXnjeliVvpQwL9JddL/bo56vXm
+        C8o/v6JfH//nBYAlwEuvSwev5uq495ENZFvli4JHqmdMV4cDcsIuAddfo153eUf559xO25no5ZdYAjwm
+        HfxNV8e9j3wBl2W/IHik0ZABvbM+HJAfHi4BlL8nfnvhcgsAS4B3LnJ13NsYY9aTT17LfDHwSOOh3+tD
+        Afljl4CbrlOvx7yh/D3y7z9YYQFgCfBKxT4Pj6vl3qXZbH5P+WLgkeqsGfpQQD7ZJeDGa9XrMi8of/9E
+        zz7DEuCxvrxAkHziW7JfCPwycNCP1YGAHBtcAvL5kwDK30/RNVeqC4DFEuCFa10t9ybGmI/IJ7XRvhh4
+        IKkMmNLkbdSBgJyTJaAx92b1eu0Xyt9jJx6jln8LS0DuJdLJG7l67n7kE/4k8wXAM/GzT+vDAH6wPwmY
+        l48lgPL33P57qMXfjiUg9/Z39dz9pGl6j/IFwCP1u27XhwH8MbgE3KJev71C+QdAjqPo3XfV4m/HEpBr
+        t7l67m6MMZvIJ2tmPjk8U7viEn0YwC+Ttjb1+XPV67jbKP9wtD8r4MqwBORWan8172q6e5FP9IPMJ4aH
+        ahecow4CeGhwCbhVvZ67hfIPS3T3nWrha1gC8kmuk71dTXcv8oluy35i+Kc68zR1EMBTPfxJAOUfnmju
+        zWrZD4UlIJducjXdndh7GsonsdE+OTxSOe1kdRDAY5O3Gbxvh3Z9dwrlH6jrr1aLfmVYAnLHPhpgA1fX
+        nY9c2XsqnxQeqp51uj4I4Df7k4A7blOv8/Gi/MMVzblCLfnhsATkS7PZ3M3Vdecjn+Ca7CeEn2qzuQ9A
+        sLqwBFD+YYtuvE4t+JFgCciVy11ddzbGmLXkgw9kPhk8Vb/qUnUQIBCTtzWN++5Rr/vRovwL4PZ5armP
+        FEtAbgzYrna13bmkabqV8sngqfrdd+iDAOHowBJA+RfEg79Xi300WALyQbp6C1fbnYt80DO0TwY/xc89
+        qw8ChOU7sgTcP7YlgPIvjuiVl9VSHy2WgP6Trv6Vq+3ORT7wy9lPBI9Vq4PloA0DBGan7Uzjgfv142AI
+        lH+B7LKDiRYtUgt9LFgC+ksWgBdcbXcmcmV+QftE8NvAwQfoAwHhsT8J+N196nGQRfkXzCEHqkU+HiwB
+        /RXH8addfY8/8gEPzn4C+K963ln6QECY7BLw+5UvAZR/Ac06Uy3x8WIJ6KsDXX2PP/LB5mY+OALQePRh
+        fSAgXPbXAUMsAZR/MUV33a4WeCewBPTNDa6+xxdjzNrywWqZD44QyIlZ3ntXdSggYDtvbxqPPLTcsUD5
+        F9S/7mBKI3glwPFgCeiLSkceDpim6ZbKB0cgeEbAYirv8u3BnwDZY4DyL7ATpqql3WksAX2xuavxsUcW
+        gBOUD4xAJK++Mvh64OpwQNDsElC7+XrKv8junK8WdjewBPSWdPdUV+Njj3yQR7UPjnBUph6mDweEb6Ly
+        dyiGH0zp6MP/RoIloHekux9wNT62GGM2lA/UzH5ghCV+4nF+CgAUTHT12F4AaLxYAnqmKR2+vqvz0Uc2
+        iG8rHxQBqp48TR0SAAK07+4mevcdtaB7gSWgN6TDt3Z1PvrIPz5Z+6AIT/zWm6a8yw76sAAQlOi2W9Vi
+        7iWWgO6TDj/O1fnoI//4D9oHRZjqN1+vDgsAATn0ILWQ+4EloLukw3/n6nx0McZ8QD5Amv2ACFv1pGP1
+        oQHAf7tONNHzz6ll3C8sAV21WLp8PVfrI49sDrz8bwElckKWf7yvPjwAeC265Ua1hPuNJaB7pMu/4Wp9
+        5JF/dIz2wRC+5O23zMC+u6sDBICnuvSc/53CEtAd0uVHulofeeQfzs9+IBRH8uILPEEMEIrjj+75Y/7H
+        giWgK25xtT6yGGNWlX9UynwQFEz8wnMsAYDnoiN/YaL3FqiFm0csAR0X2U539T585ML/gvJBUEAsAYDH
+        jjjURF1+sZ9uYAnorDiOP+PqffjIBb+P9kFQTCwBgH+iqYd5dcs/iyWgc+RynOLqffikaTpL+yAoLpYA
+        wCPHHO51+bewBHSGdPpMV+/DR975j9oHQbGxBAAeCKT8W1gCxk86/VFX7yuPMWZt+Qc26gdCsbEEADl2
+        7BFS/u+pReozloBxS2y3u5ofOvKOX8n8Q2A5LAFADgVa/i0sAeMjl91mruaHjrzjftl/CGSxBAA5Mu3I
+        oMu/hSVg7ORy28vV/NBJ0/RM7R8DWSwBQA4cd1Qhyr+FJWBspNtPczU/dOSdHtD+MaBhCQD66LijTbRw
+        oVqUIWMJGD3p9ntdzesxxqwm71jL/kNgZVgCgN6LTj7Oi6f37RaWgFEbWOkzAsZx/EnlHwHDYgkAeqfo
+        5d/CEjA6jUZjU1f3KyZN0x20fwSMBEsA0H3Rr4+n/NuwBIycdPw2ru5XjLzDodl/AIwGSwDQRdNPoPwV
+        LAEjdrCr+xUjb7w4887AqLEEAF1A+a8US8CInO/qfsWkafqI8g+AUWMJADrolJMo/xFgCVg5+yg/V/fL
+        x947UN6BRwCgY1gCgA44lfIfDZaAlbKPBFjF1f6y2HsHKu8MjAtLADB20YxTKP8xYAkYmuQTrvaXJU3T
+        b2jvDIwXSwAwetGZp6rlhpFhCRjS5q72l0X+8vuZdwI6hiUAGLlo5mlqqWF0WAJWJJfH3q72lyVN0xO1
+        dwY6hSUAGF501ulqmWFsWAKWJ11/rKv9ZZE3XJ19R6DTWAKAoUVnnaGWGMaHJWA5l7vaXxbZCv6kvCPQ
+        cSwBwIqisyn/bmIJWEq6/hFX+0tjHxYgb6hm3xHoFpYAoM2sGWppobNYAgaVXfUvjSwAH1beCegqlgBA
+        UP49xRIw+FDADVz9T5ggF8Zm2jsB3cYSgCKLZp+jlhS6q+hLgHzvX3D1P/j7/+21dwJ6gSUARRTNPlct
+        J/RGkZcA6fytXf0PPgLgR9l3AHqJJQBFEl1I+edBgZeA77v6H/wJwHHKOwA9xRKAIoguOk8tI/RHEZcA
+        6fxjXP3zMsDID5YAhCy66Hy1hNBfBVwCLnT1P7gA3J55I9A3LAEIUXTxBWr5IB8KtgTMc/U/+CuAJ5V3
+        APqGJQDBmLiVKV1xiVo6yJeiLAHS+Y+7+h/8CcB72XcA+o0lAN6T8o8u/61aNsingiwBbw+WvzFmDfmf
+        JZk3ArnAEgBv2fLnlr+XCrAENKX7V7cLwMeVNwK5wRIA79jyv/JStVzgh9CXAMnG9lkA/1Z7I5AnLAHw
+        xmD5X6aWCvwS8hIg39cX7B0At9TeCOQNSwByz5b/VZR/SEJdAqT7vz6h2WzupL0RyCOWAOSWLf85l6sl
+        Ar+FuATIAjDRPgJgv+wbgDxjCUDuSPmXbrhGLQ+EIbQlQL6Xve0C8PPsG4C8YwlAbkza2pRuvFYtDYQl
+        sCXgIHsfgGOVNwC5xxKAvhss/+vUskCYQlkCpPuPsgvADO2NgA9YAtA3Uv4R5V9IISwB0v2n2V8B/Cb7
+        BsAnLAHoOVv+N1H+RRbAEnCRXQCuzfwl4B2WAPTMYPlfr5YCisXzJWCOXQDmZf4S8BJLALrOlv/NN6hl
+        gGLyeAm4xd4H4F7lDYCXWALQNbb8b6H8sSIflwDp/rvsAvCI9kbAVywB6LjJ25rS/Lnq8Acs35YA6f6H
+        7ALwjPZGwGcsAeiY70j53z5PHfpAO5+WAOn+J+19AF7NvgEIAUsAxo3yxyh5tAS8ZBeAdzJ/CQSDJQBj
+        Zsv/jtvUIQ+sjCdLwFt2AViY+UsgKCwBGDXKH+PkwRKwwC4A5cxfAsFhCcCI7bSdKd05Xx3qwGjkfAlY
+        ZBeAauYvgSCxBGBYUv7RHZQ/OifHS8CAXQAamb8EgsUSgKFEtvzvvVsd4sB45HQJqNkFwEZ7IxAklgCs
+        YOftTXQf5Y/uyeESkNgFYEnmL4Hg2SWgtNskvQxQLDtta6L771GHNtBJOVsCmiwAKKT4+WdNmQUA1sSt
+        ucc/eiZHS8DgAmCjvREI0mD58ysAtJu4FUsAeiYnS8DgrwC4EyAKg/LHkOwSwLP+oUdysAQM3gmQhwGi
+        ECh/DMsuAfNZAtAbfV4CBh8GyBMBIXiUPwbtoPxd1uASwCv/oTf6uAQMPhEQTwWMoFH+GLVJLAHonT4t
+        AYNPBcyLASFYlD/GbOLWJrrtVnVgA53WhyVg8MWAeDlgBInyx7hN3MpEt9ygDmyg03q8BLw0IU3TZ5Q3
+        AF6j/NExdgm4mSUAvdGrJUC6/0m7ADyivRHwFeWPjrNLwE3XqwMb6LReLAHS/Q/ZBeBe7Y2Ajyh/dM3g
+        EnCdOrCBTuv2EiDdf5e9D8C87BsAH1H+6Dq7BNzIEoDe6PIScItdAK7N/CXgHcofPSNLQIklAD3SxSVg
+        jl0AfpP5S8ArlD96bnAJuFYd2ECndWkJuMjeB+AM5Q2AFyh/9NUN16gDG+i0Ti8B0v2n2AXgGO2NQN5R
+        /ug7e5+AOZerAxvotE4uAdL9R9pfARycfQOQd5Q/csMuAVddpg5soNM6uAT8dIJ8oH2VNwC5Rfkjd1gC
+        0EOdWALk30+Z0Gw2v6O9Ecgjyh+5ZZeAK1kC0BvjXQLSNN3R3gfgG9obgbyh/JF7g0vAperABjptPEuA
+        dP/X7a8AvqS9EcgTyh/esEvA5b9VBzbQaWNdAuTffG6CMeaj2huBvKD84R1ZAkpXXKIObKDTxrIESD5i
+        F4DV5X+a2TcCeUD5w1t2CeAnAeiRUS4BqXT/ahNs5H/ezbwR6DvKHyGILr5AHdhAp41iCXhrsPxt0jR9
+        QnkHoG8of4Qkuuh8dWADnTaSJUA6/zFX/4M/AZiffQegXyh/hCi66Dx1YAOdNoIlYK6r/8EF4OLMG4G+
+        oPwRsujCc9WBDXTaMEvAbFf/g78CmKa8A9BTlD+KgPsEoFeGWgKk84929T/4E4AfZt8B6CXKH0USzT5H
+        HdhApw2xBOzn6n/wJwDbZd4I9AzljyKKLpilDmyg07JLgHT+Vq7+J9hnA/zb9oEM9Arlj0KbNUMd2ECn
+        tS8B8ufnXP1PsE8GtFF2MAPdRvkD3zLR2WeoAxvotNYSIPmgq/+lkYFczQ5ooFsof2CZ6CyWAPRGrVZr
+        uNpfljRNH9cGNdBplD+wouis09WBDXSSLACvutpfFhnMc7KDGug0yh8YWjTzNHVoA50iC8AdrvaXJU3T
+        E7SBDXQK5Q8MLzrzVHVwA50Qx/GprvaXRQb0/tmBDXQK5Q+MHEsAuqFUKtk7Ae7tan9Z0jT9hja4gfGi
+        /IExOPUkEy1apA5yYCzK5bKdyZu72l+WRqOxaXZwA+NF+QPjcApLADqnUqnYhwB+wtX+sshfrioDu5Yd
+        4MBYUf5AB0w/kSUAHVGtVmPp+lVc7S+fNE0f1gY5MFqUP9BB009gCcC41Wq1F1zdrxgZ3BdlBzkwWpQ/
+        /mwH5e8wJtGvj2cJwLgkSXK9q/sVI8P7P7PDHBgNyh9/Rvl3XPQrlgCMXRzHh7m6XzFpmn5bG+rASFD+
+        QPdFJx/HEoBRsw8BlI7f2tX9ipHt4JPaYAeGQ/kDvcMSgNGyLwRkH+3n6n7FGGNWk2HOiwJhVCh/oA+O
+        O9pECxeqwx7Ico8AWNXVvZ40TX+nDXlAQ/kDfXTcUSZ67z114APt6vX6U67mh44sADO0QQ9kUf5ADkw7
+        kiUAw4rjeLar+aGTJMm+2rAH2lH+QI4cewRLAIbkXgNgL1fzQ0eG+99lhz3QjvIHcoglAEOwdwCUBeBv
+        Xc0PHWPMWjLkk+zQByzKH8ixwSVggVoCKK5qtZrabnc1v/KkafqYNvxRbJQ/4IFjDmcJwHIajcYrrt6H
+        jywAZ2kFgOKi/AGPTD2MJQB/JgvA5a7eh4+9s4BWAigmyh/w0BGHmujdd9VCQLFIp+/t6n34yDt/TisC
+        FA/lD3iMJaDwyuWyfQjgp129Dx/7bEEy/KNsGaBYKH/Af9GRv+DXAQVWrVYbwz4DYDZSAPOyhYDiSF58
+        gfIHQmGfNpjXDiiker3+sKv1kSdN06O1YkD44rfeNAP77q4PEgBeis4+Qy0IhC1JkhNcrY88sgB8SysH
+        hC2RWwnlH++jDhAAfotuuUEtCYTJvQTwFq7WRx5jzHpSCDZqUSBM1ROPUQcHgADsOtFEzz+nlgXCU6lU
+        mtLl67haH11kc3hQKwmEqX7jdfrQABCO//ipWhYIT61We87V+egjC8BJWlEgPPGbb5jyLt/WBwaAoERz
+        b1YLA2FJkuRMV+ejjywA22tlgfDwo3+gQPbZzZR4foCgud//b+XqfPQxxmwo5dDMlgXCEj/xuClN3Eof
+        FACCFM25XC0OhKFSqSyRDl/f1fnYIhvEw1ppIByVo3+pDggAAdvveyZauFAtD/ivVqu97Gp87JEF4Dit
+        NBCG5NWXufVfUNGvjjel445U34aCuHO+Wh7wX5Ikp7saH3tkAdhCKw6EoXrW6fpgQNimn7j0meFE6fij
+        9fdB+OwzBCrlAb/Z3//LfP9nV+NjjzFmbflAtfbSQCDi2JSn7KIPBoRr+gnLPy2s/e8Tpurvi7Dt/G0T
+        vfP2cuUB/1Wr1US6ey1X4+OLlMWtK5QHvNd45CF9KCBcrVv+2aFh/45HghRSxK8BglOv1x9w9T3+SFn8
+        LFse8F/13JnqQECgTjlJL/82pV8fr/9bhGvWmeqxAH/FcfwzV9/jT5Ikn9MKBH4bOPgAfSAgPKcOX/4t
+        pV+foH8MhOmQA9XjAH4aGBiwC8CnXH13JmmavqiVCPyUVCqmNHlbfSAgKNGZp6qDYmXs/QS0j4UA7bLD
+        iJdD5F+9Xl/gartzkQXgVK1I4Kf4uWf1YYCgjKX8W0qnnKh+TIQneuVl9RiAfxqNxmxX252LLAD/VysS
+        +Kl+9x3qIEA4opmnqQNiNPh1QEE8+Hv1+odf3NP/ft3VdudiH1IgxVHOFgn8VL/yUn0QIAwdvGOXvfOg
+        +jkQjtvnqdc9/FKpVOzD/9Z0td3ZSHFclS0S+Kl2wTn6IID3orPPUIfDuMw4Rf1cCEN043X69Q6v1Gq1
+        u11ddz5JkuyhlQn8wzMABmrWDHUwdMRpv9I/J7wXzblCv87hDfvj/2azuaer687HvrKQlEecLRP4p3La
+        yeoggMcuOEcdDJ1U4icBYbr+avX6hj8GBgaa0tEbuLruTqQ8eFbAAFRnnqYPAngpumCWOhS6oTTzVPVr
+        gL+iuTer1zX8Ua/XH3I13b1IeeyXLRP4h/sAhCOa3f1b/ivgJwFBie6+U7+e4QX74/9Go7G/q+nuxRiz
+        sRRImi0U+KV2xSXqIIBfoosvWGEY9EqJ+5EEI3rqCfU6hh8GBgaWSDd/yNV0d5Om6Z1aqcAf9btuVwcB
+        /BFdeK46DHqJJSAM0bvvqtcv/FCv1//o6rn7kQL5UbZQ4Jf42afVQQA/RBedrw6CfiidfYb6NcITe++q
+        Xq/wh8z0n7h67n6MMR+WT2izQrHAD0llwJQmb6MPBOTbpRerQ6CvzjtL/1qRfydM1a9TeKFSqdh7/2/k
+        6rk3kRK5KVsq8MvAQT/WBwJyK/pN/37nP6zzz1a/ZuRbdM1V+vUJL9Tr9T+4Wu5dms3mblqpwB/VWTPU
+        gYAcmriVKV1xiToAcuXcmfrXj9yKnntWvy6Re/be//YJ+lwt9y7GmHWkRCrZUoE/Gn94QB0IyBkp/+jK
+        S9UBkEvn8ZMAb/xgL/06hBcqlcpi28WulnsbKZFLsqUCjzQaprznLvpgQD7Y8vfhln9GafYs/ftBvuT5
+        V0oYVr1ev9XVce+TpunWarHAG9UZ0/XBgP6z5e/xc7SXZvNkU7k2aWsTvfKyet0h/8rlsn3p3y1dHfc+
+        xpjVpERey5YK/JG8+MLS3y9rAwL9Y8v/qsvUE98npQtZAnLr2CPU6wx+qFarJdvBro77E9lApmnFAn9U
+        jjhUHxDoj0DKv6U0+1z9+0T/2GPs6SfV6wt+iOP4dFfD/Yt8EZ+UElmSLRX4I37sEX1IoPfsT2NCfGW2
+        38zWv1/0x9Rf6tcTvGB//N9oNP7K1XB/k6bpvVqxwB+V447SBwV6x5b/DdeoJ3wQLrlQ/77RW9/Z1kSv
+        vaZfR/BCvV5/2tVv/5MkyV5aqcAfyRuvm9JO2+sDA903aWtTuvE69WQPysXn698/euey3+jXDbwhM7v7
+        r/w30hhj1pUvqNReKPBP/Zor9YGB7ipK+bdccpF+OaD7Dvy+fp3AG5VKJZbOfb+r33wkTdPTtVKBR5LE
+        VKYepg8OdId9KFaRyr+FXwf03i47mOiNN/TrA95oNBqXudrNT+I4/oyUCHcG9Fzy3gJT/v6e+gBBZ03e
+        xkS33Kie5IUw+JMAHoLaE5PkWHvsUf16gDfsnf+SJPmsq918JU3Tu7VSgV+S/37dlKfwDIFdZW/533S9
+        epIXyqUXy+XBEtBV9iF/82/TL394pVar5efOf9k0m83vaoUC/8TPPGXKu07SBwrGZ/K2Jpp3i3qCF9KV
+        l0pJKZcTOkDK/4Zr9csdXnEv/LO7q9v8xRizlpTHO9kygZ/iZ5425d0nK0MFY2bL/7Zb1RO80K5iCeg8
+        Kf/r5uiXN7xTlUjHrunqNp9J0/RIrUzgJ5aADpLyL82fq57cEFddJpcTvw7oDMo/NI1G4xRXs/mNbCgf
+        leKIs0UCf7EEdMB3pPxvn6ee2Ghz1eVyebEEjA/lH5qBgYGmdOsmrmbzHSmNC7MlAr+xBIzDYPlzJ6wR
+        m3OFXG4sAWND+YcojuNbXL3mP0mSbKaVCPzGEjAGtvzvoPxH7WqWgNGj/EPk7vy3matXP8JDAsPEEjAK
+        tvzvnK+e1BiBa+wSoFyuUFD+oarX68+4WvUnsgDsqBUI/McSMAI7bUf5dwJLwAhQ/qGyt/7jOJ7satWf
+        GGNWlSXgCa1A4D+WgJWQ8o8o/44pXX+NXK78OkBH+YdMbv2/Y7vU1apf4VUCw8YSsKLIlv99d6snM8aO
+        JUBD+YfM3vqXOftDV6f+RTaXNeQbeLW9NBAWloA2O29P+XdR6QaWgGUo/9DVarWydGi+n/hnuEhJHJQt
+        DYSFJUDY8r//XvVERueUbriWZwyk/AuhXq8f7mrU38gGs56UxMJsaSAshV4CKP+eKvYSIOV/7VXq5YJw
+        VCqVhnTnuq5G/U6apkdopYGwFHIJ2PnbJvrdfepJjC66sYhLAOVfFF487e9II5vMB6UgFmULA+Ep1BJg
+        y//3lH/f3HSdXA9FuU8A5V8Ucus/kc5c39VnGEnT9CitMBAeuwSUdgv8pYSl/Eu/v189gdFDhVgCKP8i
+        ieP4TFeb4cRuNFIO/BSgAOr1uokefSTcJeC7E0300APqyYs+uPUmU5oY6hJA+RdJuVxeHNyt/1bSNJ2q
+        FQbCkSTJsgM6xCXAlv8fHlzupEUOBLkEUP5FIzeeZri6DC+y2WwkJVHKlgbCMvgTgNZBHdISYMv/4YeW
+        O2GRI0EtAZR/0VQqlTjYW/+tSEEcli0MhCe4JWBXyt8Lc28OYAmg/Iuo0Wic7Goy3MiGs64UxFvZwkB4
+        glkCbPk/8oflTlbkmNdLAOVfRNVqtSbduJ6rybAj5XBgtiwQJu+XAMrfT14uAZR/Ucmc/IWrx/Ajm86a
+        aZq+qBUGwuPtEiBfZ/Tow8udqPDIPJ+WAMq/qOTWf0k6cS1Xj8VIkiRTtLJAmJZfAh42pT12VoZgjuz1
+        XVN64k/LnajwT2n+PFOatLV+HefFxK0Hn89A+/oRNveKfz92tVicyMazWpqmj2WLAuFabgl4/llT+sEU
+        fSD224/2MdGLLyx3osJfpcceMaWdttev636bvI2J7rtH/boRvlqt9qbtQleLxYosAF/TigLhWm4JeO1V
+        UzriUH0w9suxR5jozTeWO0kRgBdeWPpTHe0675Noj51N9NRT+teL4Nlb/3Ecb+XqsJiRUpiTLQmEbbkl
+        YNEiU7rikv7fQttlB1PiJVbDd8Ix+vXfQ5E19TATLVyof40ohGq1+qCrweKm0Wj8pZRCI1sSCNtyS4D1
+        0oumdKIM517fact+Pnurnx/5F8bgrwR+uLd+PHTbnnKr/0FeQ6LoBgYGmtJ9f+VqsNhJ0/Q4rSQQthWW
+        AFF64HemdNjPu78IyMePjvovntynyOy97qf06M6oe+xkSlddqn8dKJxarTbb1R+xT4AghfBGtiAQPm0J
+        sOw98Eun/arjjxaIpvyric6YbqKn+d0rnHvuMqUDv2+iTj9aYJIssT/Z15TumKd/XhRSpVKxT/qzrqs/
+        YpMkyV5aQSB8Qy0Bg+zvSe+/x0QzTzOln/3ElCZvqw/boey0nSkdcqApzTpz8KcL9j4H6ucB5FgrXX6J
+        HGc/NqXv7qgfTyslhf+vO5ropz8y0SUXm2jBAv3zoLDcw/4OdLVHWpGNaNU0TR/IlgOKYaVLQJvSu++a
+        6PHHTHTbraZ02W+WFvuMU0xp+omDt+xL585c+ve3zzOlPz1uIvv+yscBhvXmm6Z021w5xmaY0lG/GFxA
+        owP2X3r/gQO/v3Qhtb9GOut0E829yZTe4NEjWLlqtfq6dN0qrvZIe6QI/o9Y0l4MKI6RLgEA4Bt767/R
+        aGzh6o5okSK4NFsMKA6WAAAhqtVqd7uaI0PFGPMXUgS1bDGgOFgCAISkXC6n0m2fcDVHVhYpgUOypYBi
+        YQkAEAq59T/N1RsZLrIprZ6m6UNaMaA4WAIA+K5Sqfy3dFoxn+9/rEmS5ItSAkm2FFAsLAEAfFUul+2d
+        2v/B1RoZTXiGQFgsAQB81Gg0LnR1RkYbY8z7ZAl4TisFFAtLAACfVKvVSDpsbVdnZCyR4b+54LkBwBIA
+        wAvupX63dzVGxpM0Tc/RCgHFwxIAIO9kTt3q6ouMN8aYD8rwfz1bBigmlgAAeTUwMNCQzlrf1RfpRNI0
+        nayVAYqJJQBA3tgf/SdJso+rLdLJyOCfky0CFBdLAIA8kZn0e1dXpNMxxnxUBv+72SJAcbEEAMiDSqVi
+        f/S/sasr0o2kabq9VgQoLpYAAP3kfvS/q6sp0s3IEjBTKwIUF0sAgH5pNBrXuXoi3Y4x5v2yBDylFQGK
+        iyUAQK9Vq9WFtpNcPZFeJEmSzWTox9kSQLGxBADoFftc/zJz/n9XS6SXkYH/82wBACwBAHpBZs1pro5I
+        r2OMWVUG/m3ZAgBYAgB0U7VafdF2kKsj0o/IFfBxGfjvZQsAYAkA0A3lcnmxdM+mroZIP5Om6Y5aAQAs
+        AQA6yT7kr9Fo/MDVD8lDZAk4TysAgCUAQKfIPLnR1Q7JS4wx68oS8IRWAABLAIDxqtVqb0vXrONqh+Qp
+        cRx/UoZ9lB3+gMUSAGCsBgYGFkvHfMrVDclj0jTdTob9kuzwByyWAACj5X7vv5erGZLnyBJwjDb8AYsl
+        AMBoSPlf6OqF5D32sZky6G/KDn6ghSUAwEjUarXnpVNWc/VCfIhcYRumafqiNvwBiyUAwMoMDAzUpEs+
+        4mqF+JQkSb4kg76WHfxAC0sAAE2pVLLP87+5qxPiY5rN5m7a4AdaWAIAtLN3+pO58HNXI8TnpGl6pjb4
+        gRaWAAAtMg+udfVBfI8xZi1ZAn6nDX6ghSUAQK1Wsy/ys6arDxJC5ArdRIb8y9mhD7RjCQCKq1qtDkhX
+        bOxqg4SUOI7/Rob8wuzQB9qxBADFUy6X0yRJNnN1QUKMDPh/Fo32gQ9ksQQAxSHlv0RuIE5yNUFCTrPZ
+        3EWGPE8XjJViCQDC5+7xf6irB1KEpGl6hDb0gXYsAUDY5Bw/39UCKUqMMavIgL8gO/CBLJYAIEyNRuM+
+        2wWuFkiRIlf8GjLg52UHPpDFEgCExT3H/1quDkgRIwfAB9M0fVwb+kA7lgAgDJVKZaHM/g1cDZAiRwb7
+        /5IB/1Z24ANZLAGA36T861L+m7rxT8jgCwd9WQZ8lB34QBZLAOCngYEBOYUXf8WNfUKWRQ6MfxT2CFEH
+        P9DCEgD4Rcq/2Wg0/q8b94SsmDRNvy4Dvp4d+EAWSwDgB/vSvrVajSf6IcNHloBvyoDn2QIxLJYAIN/s
+        s/wlSTLFjXdCho8sATvKgLdRBz/QwhIA5JN9lr84jn/ixjohI0+z2fyeDPhmduADWSwBQL64p/j9LzfO
+        CRl9ZLj/MDvsAQ1LAJAPtvxrtdpRbowTMvbIcD8wO+wBDUsA0F+2/BuNxilufBMy/qRpepQ28IEslgCg
+        P9yP/c92Y5uQzkWG+yHZYQ9oWAKA3nJ3+LvQjWtCOh8Z7gdnhz2gYQkAesPd8p/pxjQh3YsM9/0Fjw7A
+        sFgCgO5yd/g7zo1nQrqfZrP5XRnwNurgB1pYAoDucLf8f+7GMiG9iywB35EBn2QHPpDFEgB0ln2Gv0aj
+        8UM3jgnpfdI03VoGfC078IEslgCgM+SWvy3/Pd0YJqR/keH+z6LcPuwBDUsAMD5yy78Zx/FEN34J6X9k
+        uP+9eK992AMalgBgbOzr+cst/y3d2CUkP0mS5Msy4N/KDnwgiyUAGJ1KpVKv1Wr/nxu3hOQvsp1umqbp
+        k9rQB9qxBAAjU61WFxhjNnVjlpD8Rg7UDWTAz88OfCCLJQBYObnV/4zM1PXdeCUk/5EDdk0Z8BdkBz6Q
+        xRIA6OTcuN3OUjdWCfEncuCuIgP+cLGkfeADWSwBwDLuef3PsTPUjVNC/Eyz2fyeDPk4O/SBdiwBwNIn
+        +JHy/5kbn4T4nzRN/0WG/KLs0AfasQSgyOzD/KT8t3djk5BwIgf2Z2TIv5Qd+kA7lgAUUbVaLSdJ8gU3
+        LgkJL8aYTdI0vV8b/EALSwCKpFarPS+z8SNuTBISbuRAX12WgGna4AdaWAIQOntnv0ajca3MRO7pT4qV
+        ZrO5qwz6anbwAy0sAQjVwMCAfU7/g9w4JKR4SZLkS2mavqgNf8BiCUBoKvZ5fev1r7oxSEhxY4zZSAb9
+        zdnBD7SwBCAU1Wr1aZl5G7rxRwiRE8I+adAhotk++IEWlgD4zP2+/yKZdau6sUcIaU+aptvIsOf5AqBi
+        CYCP7OP7kyTZ0405QshQieP4f8si8LhWAABLAHxSq9XelfL/rBtvhJDhYoxZV5aAc7QCAFgCkHflctn+
+        yP8amWXruLFGCBlNZAnYUQb+gmwBACwByKtKpSI3+pO93RgjhIw1skFvIgP/pmwBACwByJtqtWpfv/8T
+        bnwRQsYbOaHsowQOEI32AgBYApAH9lX85Fg8U2YV9/InpBtJkuRzaZr+USsCFBdLAPpJbvW/J8fhP7gx
+        RQjpVmTDfp8sAdPlhFvSXgIoNpYA9Jp9bH+tVrtFZhJ39COkl5El4Jsy+N/MFgGKiyUAvWKfzTeO48lu
+        HBFCeh3ZvD8qg/+abBGguFgC0E3u4X13yezZ2I0hQkg/k6bpZBn+72bLAMXEEoBusLf6kyT5nhs7hJC8
+        RDbyj8jwn50tAxQTSwA6xf6uX46neTJjeBEfQvKcNE0nSQFw3wCwBGDcqtXqwkajsaUbL4SQvEc29Q+6
+        Rwqk2VJAsbAEYCzc4/pnySxZ240VQohPSZJkM1kEHtKKAcXBEoCRcg/te02Om793Y4QQ4mtkg19DTuZD
+        RLVVCCgelgAMp1KpyKGy+BcyM1Zz44MQEkLkpP64nNzcSbDAWAKgcXfyu0NmxF+4cUEICTFpmn5NPK4V
+        BMLHEoCWth/3b+7GAyEk9Mimv7qc9PbFhaJWMaA4WAJQqVSqcRz/VGYBL95DSBEjJ//GaZrOlFLg0QIF
+        wxJQTAMDA0257mfKuc/z9xNCJkyQWwKfllK4LFsSCBtLQHHYH/c3Go3fi03daU8IIcuSpukW4lGtLBAm
+        loCwud/zvyLXNb/nJ4SsPMaY1ZIk2VMGxsvtRYFwsQSEx92z/z05l/fm9/yEkFFFhsaaMjz2lYLgaYUL
+        gCUgDLb4q9VqLY7jw+Qc5ln8CCFjj72zkBSEfSKhRe2FgfCwBPjLFX8sS/uv5Zz9gDt9CSFk/JGhsp6U
+        BItA4FgC/NJW/KfKObqBO10JIaTzaVsEFrYXB8LBEpB/7s59tvhPo/gJIT2NDJ31pSwOE++1lwfCwBKQ
+        T63f8UvxHyvn4Afd6UgIIb2PDKG1m83m7mmaPq0VCfzFEpAf7hZ/SYp/KsVPCMlVZCitKkvAtuJerUzg
+        J5aA/iqXy/Y6eEuui3+Tc2wtd7oRQkg+I8Pqq2KOaNoSgd9YAnrPFf8fZaHeTop/FXdqEUKIH2k0Gn8p
+        A2y6lEg1WyrwC0tA99kf81cqlWYcx7fIZf4P7jQihBB/I7dgPiwD7Zfi7VahwD8sAd3hfr9fTpLkGDlX
+        NnanDSGEhBMZbmumaTpZymSuWNJeLvADS0DnyK19e3k+K5frfnJuvM+dJoQQEnbiOP6ULAPTZPgtaC8Y
+        5B9LwNjZ3+1Xq9WGXI6z5Rb/593pQAghxYvc8llHBuEesgzcJUORnwp4giVg5OyP+AcGBuxl9niz2dxT
+        jvn3u8OfEEKIjQzG/yHlcogsAy9mCwf5wxKwcvbWfq1WWyQL7smNRuOv3WFOCCFkqMgiYJ9T4JtSMheJ
+        SnvpIF9YApbnnqkvlsK/So7hb9hj2R3WhBBCRhMZoGvLIN1WyuYyEbeXD/Kh6EuA+73+kjiO77fPiinH
+        7Lru8CWEENKJyGDdSApnP3GbSFsFhP4r2hLgbuk35Zb+g0mS7CvH5obuMCWEENLN2IFrb21J+Vwn+MlA
+        DoS+BLjSt7f0H5bv9wA5BnnMPiGE9DMyiNeXZWA3GcpXiHKrkNB7oS0B7t77dbmlf70cY7vKscYL8RBC
+        SB4jA3o1KaKvpmk6TTyZLSh0n89LgL2Vb5+gRwrfvgDP+fb+J3JMrekOL0IIIb4kjuNPyyA/UNwgeERB
+        j/iyBLQeo1+r1RpyrMyXr/0A+fOT7vAhhBASQuwtORnwm8utumPEg/Lf3JGwi/K4BLQVvr0D35NyHEyV
+        r/WfuZVPCCEFigz9daUAtpACOFzY1yfgzoQd1u8lIFP4T8v1fZqYLNc999onhBCyNG4h2FIcKeVlX5I1
+        ai8zjE0vl4DW7/Cl8KtS+PfI5z/cLnly3a7jrmZCCCFk5ZHSWDWO488kSbKnlMhM8agUStJebhiZTi8B
+        tujtE/C4V9RL5Tqyr6p3jn1dCbnO/kauu1Xc1UgIIYSMP1Isa0jJfNY+B4EsBNOFvZU50F520I11CWj9
+        GN+VvX1I3hPy8S4UB4ivynXCS+kSQgjpT6SEPibLgL0/wQHyp/1pgV0MeE6CjKGWgPaSr9Vq9mF4smcl
+        L4g58u/sj/En28XL/lTGXeSEEEJIPmN/DC3+h5TX16S89pY/p0mZXSF/PiJ/FnY5sEuALXn5s2bvmGdL
+        Xi6TY+1lJG/fXC6zT9jLzl2MhBBCSFiRkttASu/zUn7bSPF9X/60D0mbLebJfz8uf9ono2kKtUhzzH7N
+        b7nvYZ6Y7b63/e33ar9n+d7XdxcDIYQQQrKRolxNbOIWhX8Rk9wt5YPkv48Wp8l/25dNvkrMlf+/Wzwk
+        nhIvyN8tEAvb1ES2sO3ftb/PAvtv3cewH+su+Tv7MEn7OS6S/7cPpTta/vsg+Vr2kv+eKP7FFfsmgh/T
+        E5LrTJjw/wDx2GFAd41c2wAAAABJRU5ErkJggg==
+</value>
+  </data>
+</root>

--- a/Vistas/frmExito.cs
+++ b/Vistas/frmExito.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace VistasMrTiendita
+{
+    public partial class frmExito : Form
+    {
+        public frmExito(string mensaje)
+        {
+            InitializeComponent();
+            lbl_Mensaje.Text = mensaje;
+        }
+
+        private void frmExito_Load(object sender, EventArgs e)
+        {
+   
+        }
+
+        public static void confirmacionForm(string mensaje)
+        {
+            frmExito frm = new frmExito(mensaje);
+            frm.ShowDialog();
+        }
+
+        private void btn_Aceptar_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+    }
+}

--- a/Vistas/frmExito.designer.cs
+++ b/Vistas/frmExito.designer.cs
@@ -1,0 +1,148 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmExito
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        //protected override void Dispose(bool disposing)
+        //{
+        //    if (disposing && (components != null))
+        //    {
+        //        components.Dispose();
+        //    }
+        //    base.Dispose(disposing);
+        //}
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmExito));
+            this.bunifuElipse1 = new Bunifu.Framework.UI.BunifuElipse(this.components);
+            this.lbl_Mensaje = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.btn_Aceptar = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // bunifuElipse1
+            // 
+            this.bunifuElipse1.ElipseRadius = 5;
+            this.bunifuElipse1.TargetControl = this;
+            // 
+            // lbl_Mensaje
+            // 
+            this.lbl_Mensaje.AutoEllipsis = true;
+            this.lbl_Mensaje.Font = new System.Drawing.Font("Roboto", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_Mensaje.Location = new System.Drawing.Point(26, 160);
+            this.lbl_Mensaje.Name = "lbl_Mensaje";
+            this.lbl_Mensaje.Size = new System.Drawing.Size(278, 71);
+            this.lbl_Mensaje.TabIndex = 1;
+            this.lbl_Mensaje.Text = "Mensaje";
+            this.lbl_Mensaje.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label1
+            // 
+            this.label1.Font = new System.Drawing.Font("Roboto Light", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(120)))), ((int)(((byte)(120)))), ((int)(((byte)(120)))));
+            this.label1.Location = new System.Drawing.Point(12, 219);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(306, 82);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "La tarea se ha completado exitosamente.";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // btn_Aceptar
+            // 
+            this.btn_Aceptar.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(172)))), ((int)(((byte)(192)))), ((int)(((byte)(39)))));
+            this.btn_Aceptar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_Aceptar.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_Aceptar.BorderRadius = 4;
+            this.btn_Aceptar.ButtonText = "Aceptar";
+            this.btn_Aceptar.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_Aceptar.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_Aceptar.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_Aceptar.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_Aceptar.Iconimage = null;
+            this.btn_Aceptar.Iconimage_right = null;
+            this.btn_Aceptar.Iconimage_right_Selected = null;
+            this.btn_Aceptar.Iconimage_Selected = null;
+            this.btn_Aceptar.IconMarginLeft = 0;
+            this.btn_Aceptar.IconMarginRight = 0;
+            this.btn_Aceptar.IconRightVisible = true;
+            this.btn_Aceptar.IconRightZoom = 0D;
+            this.btn_Aceptar.IconVisible = true;
+            this.btn_Aceptar.IconZoom = 90D;
+            this.btn_Aceptar.IsTab = false;
+            this.btn_Aceptar.Location = new System.Drawing.Point(101, 318);
+            this.btn_Aceptar.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.btn_Aceptar.Name = "btn_Aceptar";
+            this.btn_Aceptar.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_Aceptar.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(172)))), ((int)(((byte)(192)))), ((int)(((byte)(39)))));
+            this.btn_Aceptar.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_Aceptar.selected = false;
+            this.btn_Aceptar.Size = new System.Drawing.Size(130, 33);
+            this.btn_Aceptar.TabIndex = 3;
+            this.btn_Aceptar.Text = "Aceptar";
+            this.btn_Aceptar.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_Aceptar.Textcolor = System.Drawing.Color.White;
+            this.btn_Aceptar.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_Aceptar.Click += new System.EventHandler(this.btn_Aceptar_Click);
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.BackColor = System.Drawing.Color.Transparent;
+            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
+            this.pictureBox1.Location = new System.Drawing.Point(113, 26);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(102, 90);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox1.TabIndex = 10;
+            this.pictureBox1.TabStop = false;
+            // 
+            // frmExito
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("$this.BackgroundImage")));
+            this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.ClientSize = new System.Drawing.Size(335, 403);
+            this.Controls.Add(this.pictureBox1);
+            this.Controls.Add(this.btn_Aceptar);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.lbl_Mensaje);
+            this.DoubleBuffered = true;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Name = "frmExito";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "frmExito";
+            this.Load += new System.EventHandler(this.frmExito_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Bunifu.Framework.UI.BunifuElipse bunifuElipse1;
+        private System.Windows.Forms.Label lbl_Mensaje;
+        private Bunifu.Framework.UI.BunifuFlatButton btn_Aceptar;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.PictureBox pictureBox1;
+    }
+}

--- a/Vistas/frmExito.resx
+++ b/Vistas/frmExito.resx
@@ -1,0 +1,512 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="bunifuElipse1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="$this.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAVUAAAGZCAYAAAA5JqLhAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAGLpJREFUeF7t3UGvJUd5h3Ew916b+FrEIoyxNBKONE4YW4IFhLEXweyzTFDycSxZ
+        YsMCATb+CiibZEEklA2LZAULBPkgVsSG3aTe9vs21XX6jqerr6JI+T3SQ/fpru5zZjz89VZ3dfXngh/9
+        6Edv/OxnP/vVRx999ElbPiVJ7vovH3/88RstNj+fXhKBGmH681/8w9Nf/vb1p//+X6+SJAcjH//5l38X
+        wfrJBx988OZbb7118/7777/QYnQbri1Q/zUa7p2EJLn157/4+6c/+clP/qPF55eaL0e4tuWfwjVKWhUq
+        ST6fkZcffvjhf7f4jMsAD5qvNK+bEayfhuregSTJfSM3W3x+s/no9vb2K235xeYXmkKVJI+aofrOzc3N
+        N9rya6+++uqXvve9710JVZKcMHLz6urqu9fX13/TYvSvml9+9OjRi235glAlyYNmpfrd5neaf317e/vg
+        jTfeeEmokuSEFaqtUn2nLR8LVZI84RCqb7388suvtaVQJckZM1Tfi1C9ubl5q62/9vDhwxgBIFRJ8qiR
+        m1dXV++1EI1QfdyWMV5VpUqSM1al2nzSXCrVZoTq54UqSR60QrWuqTarUhWqJHnUDNUYUuXuP0meNXIz
+        r6lW9/+Bwf8kOWlfqeaNqrr7r/tPkkfNUF3u/jf7a6oqVZI8al+pNt+Ka6pClSQnjdyMCVUiVKv7L1RJ
+        ctIM1XVIVfeYqmuqJHnUqlQrVA2pIskTRm62AF3HqTZ1/0ly1qpUK1Sj+69SJclJh0q1f/ZfqJLkUStU
+        r6+vn9TUf0KVJCftKtUlVHX/SfKEXaVaN6rMUkWSs3aVqmuqJHnWyM3hiaqoVL1OhSRnzEp1mfrPjSqS
+        PGlWqpsX/wlVkpw0K9X1mqpn/0nyhFWpthCN7r/HVEnyjFmp9i/+895/kpw1K9VN91+okuSkWamOQ6p0
+        /0lyxgzV/h1VrqmS5Kx9pdpcpv4TqiQ5aeRm3v1fxqmaUIUkT9hVqk+aKlWSPGNfqTZr8L+7/yQ5Y1Wq
+        9ZiqIVUkecIK1Wbd/X+QoeoxVZI8aoZqdf/7x1SFKkkedQjVfkIV3X+SPGqGar1OxeB/kjxjVarDfKpu
+        VJHkjH2lGs/+G/xPkieM3KyZ/1uQVqX6olAlyQmrUm3B+m52/81SRZKzVqg2DakiybNmqJr6jyTvw75S
+        je7/7e2t9/6T5Kx9qDbNUkWSZ4zc7N9R1TROlSRnzVDdXFM1oQpJThq52QJ0CdXuiSrdf5KcsSrVGvzv
+        mipJnrBCtYXoOKRK958kjxq52QJ0HVIlVEnyhBWqNaFKWzdOlSRnjdzMIVXxNtWoVD37T5KzZqUaN6q8
+        opokz5qh2l9TVamS5KxdqC6ValOlSpKzZqjGkKoKVZUqSc4auZnjVJcbVXFNNR9TFaokedSqVLvXqRhS
+        RZKzVqg2a5xqXFM1oQpJzhi5meNUo1LtQ1WlSpJHrUq1nqiKmf+9opokJ81QrUq1f52K7j9JHrUP1bqm
+        qlIlyUkjN++Y+k+okuRRM1SXWapakC7XVNtS958kZ4zcbAG6GVKl+0+Sk2al+l7z3Rak/YQqKlWSPOpQ
+        qb7dlipVkpy1KtUI1WYNqVKpkuSMGap786kKVZI86lipdqGq+0+SR43cbAG6TFKdlWqNU1WpkuRRM1T7
+        qf8M/ifJWStUm8vg/6ZQJclZM1Triapl5n9Dqkhy0q5SjWuqUak+8DoVkpy0KtXuiSrdf5Kcta9Um491
+        /0nyhFWpRqgOQ6qEKkketSrVfJ2KUCXJM0Zu9k9U6f6T5AmzUl0nqW5WqHqiiiSPmpVqhGrcqFq6/ypV
+        kpw0K1Xdf5K8DzNU6xXVS/ff4H+SnDRyM25U7VxTFaokedS+Uo3HVM38T5InzFA1SxVJ3od9pdrs31El
+        VEnyqJGbNfg/Z6mqSlX3nySPmpXq+phqDKnKu/9ClSSPWqHaXK6pRqi2pSFVJDljhup6TTVD1TVVkpxx
+        qFTNUkWSZ4zcjGf/I1SHqf9cUyXJo2alunb/m4ZUkeSsfaUaoRrjVD37T5KTVqWaz/67pkqSZ6xQbS4v
+        /msaUkWSs2ao9nf/XVMlyVkjN2vqv7r7b+o/kpw0Q3Xs/gtVkpwxcrMF6N4k1capkuRRs1KNa6pPapYq
+        3X+SnDQrVeNUSfI+zEp1E6ptqVIlyRkzVNchVWapIskTRm62AF0qVTP/k+RJM1Tr7r/HVEnyjBWqzf6a
+        qhtVJDljH6rR/XdNlSRPOFaqTddUSXLWyM1+SFWEqsH/JDnpHZWqa6okOWOG6maSapUqSU7ahWrMUtU/
+        UeWaKkkeNXKzJlRpLoP/89l/oUqSR81Q7bv/D3T/SXLSyM0WoDVO1TVVkjxjVqrV/a+7/0KVJGfMSnUz
+        TrUpVElyxjtC1ThVkpwxQzVmqYrXqbydoWpIFUnOWKHaVKmS5FmHUI1xql6nQpKz3lGpClWSnDFDtV6n
+        0oeqa6okedQK1XqiKiepdk2VJGfMUF3fUWXmf5I8YeRm/4rq5rb7T5I8ZgvQu5+oAgA8Pzuhup1PFQDw
+        /GSobq6pbmapAgA8PzuV6vbuPwDg+RGqAHCPZKiud/+7d1QJVQA4Sh+qNzc3yzuqMlTdqAKAo0Ru1jjV
+        3cdUAQDPT1+pNt39B4AzjKHadKMKAGYRqgBwj1SoxuD/vKbq7j8AzLJTqQpVAJilD9W6+//w4cPo/rv7
+        DwBHUakCwD0SuXl1dbU+puqJKgA4QYbq5u6/caoAMEnkZgvQCNUnzctXVAMAnp8K1evr6yd1o0qlCgCT
+        ZKgu11SFKgCcpA/V5tL9z1A1pAoAjjKG6sUrqgEAz88Yqt2QKpUqABwlcrMfpxqVaj5RpVIFgKMMlWp/
+        o0qlCgBHqVCtV1RHqDaFKgDM0IXqMk7VjSoAOEGG6maWKuNUAWCSyM3h2X+PqQLALFmpbu7+t6X5VAFg
+        hqpUm+9W97+pUgWAGbJSXbv/blQBwAn6UM1KtZ79F6oAcJQM1c04VaEKAJNUqDbX7r8X/wHAJBmq/ZAq
+        j6kCwCyRm8apAsA9kZVqdP/jHVWuqQLAGTJUN93/plAFgBmqUs0JVd6OUFWpAsAkXaVab1N1TRUAZulD
+        tdl3/939B4CjRG7G61Ry8P/y4j9DqgBgkqxUN69Taer+A8AMGap193+pVL34DwAm2alU3agCgFkiN4cn
+        qnT/AWCWvlK9ubl5LFQB4AQVqnH338z/AHCSvlJtmvkfAM4QuZnXVGPwf3X/3f0HgBmyUt3cqDJJNQBM
+        kqHaT/1XQ6qEKgAcJXIzH1P17D8AnKUq1bz7H9dUDf4HgFkyVN+rIVV599+NKgCYIXIz7v7r/gPAPZCV
+        aj1R1d+oUqkCwFGqUo1QbS6zVAlVAJikr1QjVJveUQUAs/SVaj37bz5VAJhkr1JtqlQBYIYMVddUAeA+
+        6EM1B/8bUgUAs3ShGu/9f3x7e+vZfwCYJUO1n1BF9x8AZqlKNR5TjVD1mCoAnGAM1aZQBYBZIjdj6r8W
+        okuo5jVVoQoAM2SluoZq0zVVAJglQ3VvnKq7/wBwlCFUl1mqPKYKAJN0oboOqcoJVVSqAHCUyM26UVUT
+        qjRVqgAwQxeq8URV3f13owoAZojcbAE6Dv4XqgAwQ1ep1oQqKlUAmCVDdb37r1IFgBNEbrYArVmqhCoA
+        nGGsVJu6/wAwy06oqlQBYJbIzRagcfe/Bv+rVAFglgzVmlClXqdi8D8AzBC5Gd3/rFS9owoAzpCV6iZU
+        89l/lSoAHKUq1RaiblQBwFn6UK1xqipVAJgkcrMF6DL4vxmh+tW2jBtVrqkCwFEqVGNClZqlSqUKAJN0
+        lar5VAHgLJGbV1dX362p/zJUVaoAMEOFagvRfuo/lSoAzBC52QJ0DdVulio3qgDgKBmq68z/TUOqAGCW
+        yM3q/meouvsPALNUpdqFqhtVADCLUAWAeyRDddP9b3qiCgBmqEq1ZqnKu/+GVAHADH2lenNz83ZbuvsP
+        ALNUpXp1dfVuW7qmCgBnqFBtroP/VaoAMEmGanX/jVMFgDP0lWrT3X8AOMMYqt2z/ypVADhKhureOFWh
+        CgBHqVCtmf9VqgBwgsjNfkKVeJ2KUAWASTJUx2uquv8AMEPkZgvQ/prqaw8fPhSqADBDhmpUqsuz/0IV
+        AE5QlWrdqGrr7v4DwCyRm3mjKirVpfvfdKMKAGbISnV5R1U8+9+FqieqAOAoVal68R8A3ANDpWrwPwCc
+        ISvV9RXVxqkCwAmyUu2n/qtQdU0VAI7Sh2qzD1WVKgAcZahU3f0HgDNUqOY11eV1Ko8ePXqxratUAeAo
+        kZtxo6q5vvjPY6oAMElVqs2lUo2p/4xTBYBJKlRrSJVQBYATjKFq8D8AnCBDdX2iqq27pgoAs0Ruxo2q
+        FqI1pMrrVABglqpUm+PUf8apAsBRKlTrmmqzKlWhCgBHyVA1pAoA7oPIzbymWt3/B56oAoBJ+kq1nv3P
+        u/+6/wBwlAzV9b3/TXf/AWCWvlJtLk9UCVUAmCRy8+rTt6mOU/8JVQA4Sobq+DoVQ6oAYIaqVE2oAgD3
+        QORmC9B1nGpT9x8AZqlKtUI1uv8qVQCYZKhU+2f/hSoAHKVC9fr6+klN/SdUAWCSrlJdQlX3HwBO0FWq
+        daPKLFUAMEtXqbqmCgBnidwcnqiKStXrVABghqxUl6n/3KgCgJNkpbp58Z9QBYBJslJdr6l69h8ATlCV
+        agvR6P57TBUAzpCVav/iP+/9B4BZslLddP+FKgBMkpXqOKRK9x8AZshQ7d9R5ZoqAMzSV6rNZeo/oQoA
+        k0Ru5t3/ZZyqCVUA4ARdpfqkqVIFgDP0lWqzBv+7+w8AM1SlWo+pGlIFACeoUG3W3f8HGaoeUwWAo2So
+        Vve/f0xVqALAUYZQ7SdU0f0HgKNkqNbrVAz+B4AzVKU6zKfqRhUAzNBXqvHsv8H/AHCCyM2a+b8FaVWq
+        LwpVAJigKtUWrO9m998sVQAwS4Vq05AqADhLhqqp/wDgPugr1ej+397eeu8/AMzSh2rTLFUAcIbIzf4d
+        VU3jVAFglgzVzTVVE6oAwCSRmy1Al1DtnqjS/QeAGapSrcH/rqkCwAkqVFuIjkOqdP8B4CiRmy1A1yFV
+        QhUATlChWhOqtHXjVAFglsjNHFIVb1ONStWz/wAwS1aqcaPKK6oB4CwZqv01VZUqAMzShepSqTZVqgAw
+        S4ZqDKmqUFWpAsAskZs5TnW5URXXVPMxVaEKAEepSrV7nYohVQAwS4Vqs8apxjVVE6oAwAyRmzlONSrV
+        PlRVqgBwlKpU64mqmPnfK6oBYJIM1apU+9ep6P4DwFH6UK1rqipVAJgkcvOOqf+EKgAcJUN1maWqBely
+        TbUtdf8BYIbIzRagmyFVuv8AMElWqu81321B2k+oolIFgKMMlerbbalSBYBZqlKNUG3WkCqVKgDMkKG6
+        N5+qUAWAo4yVahequv8AcJTIzRagyyTVWanWOFWVKgAcJUO1n/rP4H8AmKVCtbkM/m8KVQCYJUO1nqha
+        Zv43pAoAJukq1bimGpXqA69TAYBJqlLtnqjS/QeAWfpKtflY9x8ATlCVaoTqMKRKqALAUapSzdepCFUA
+        OEPkZv9Ele4/AJwgK9V1kupmhaonqgDgKFmpRqjGjaql+69SBYBJslLV/QeA+yBDtV5RvXT/Df4HgEki
+        N+NG1c41VaEKAEfpK9V4TNXM/wBwggxVs1QBwH3QV6rN/h1VQhUAjhK5WYP/c5aqqlR1/wHgKFmpro+p
+        xpCqvPsvVAHgKBWqzeWaaoRqWxpSBQAzZKiu11QzVF1TBYAZhkrVLFUAcIbIzXj2P0J1mPrPNVUAOEpW
+        qmv3v2lIFQDM0leqEaoxTtWz/wAwSVWq+ey/a6oAcIYK1eby4r+mIVUAMEuGan/33zVVAJglcrOm/qu7
+        /6b+A4BJMlTH7r9QBYAZIjdbgO5NUm2cKgAcJSvVuKb6pGap0v0HgEmyUjVOFQDug6xUN6HalipVAJgh
+        Q3UdUmWWKgA4QeRmC9ClUjXzPwCcJEO17v57TBUAzlCh2uyvqbpRBQAz9KEa3X/XVAHgBGOl2nRNFQBm
+        idzsh1RFqBr8DwCT3FGpuqYKADNkqG4mqVapAsAkXajGLFX9E1WuqQLAUSI3a0KV5jL4P5/9F6oAcJQM
+        1b77/0D3HwAmidxsAVrjVF1TBYAzZKVa3f+6+y9UAWCGrFQ341SbQhUAZrgjVI1TBYAZMlRjlqp4ncrb
+        GaqGVAHADBWqTZUqAJxlCNUYp+p1KgAwyx2VqlAFgBkyVOt1Kn2ouqYKAEepUK0nqnKSatdUAWCGDNX1
+        HVVm/geAE0Ru9q+obur+A8AsWal6ogoA7oOdUP3TfKofffTRJ3/84x+zKQDgWUReZqhurqmus1R9/PHH
+        v/r1r3+dzQEAz+J3v/vd0x/84Af/2QK0KtUa/P/p3f+f/vSnf9lS95Pf//73SwIDAC6JfPzNb37ztGXm
+        H955551/bAEaoVoz//+p+x//88EHH7z54x//+N+ipCVJXvrhhx/+4Yc//OFvnzx58k8tN+POf4Tqt5tv
+        vvLKK19uyxebS6gGN6+++uqX2vKN5jea7zb/thkHhXWCxXiNQAwnyCEFm32dy/ZoW9vqmNjWb2+u5xj2
+        9ds33zMcH46/Y+/7a/vyG3J93f9ZxjF1vrZczlPbxzaxv9ZrX3P9vtify7FN/7nabJbj9lyvY5b1+lxt
+        +v1l7cv1i2PusmtX689sv2edozPOMf7W9d/L3r5crvbn7I672Ndvq3Zl7lt+S33u97XlxXnTve/b/Oau
+        zabt89i1v/hzp4fPHe2GY+rc43dsPudxcUxsv/P3xDLPu1jHxLZ+e3M9x7Cv3775nuH4cPwde99f28c/
+        73MZx9T52jLyMXLymy+99NLX2jLy87r5Kd///ve/0BZ/1oxhAY+ur6+/2ZaRwE9iaqtcvhPr9TmN6wn9
+        52Vbtqllf47VbPudXMa25VxtuW6rz9W+9nWf13bN/vetvyuO6drt/d4Lh/OGcVz9vv7cF9t23Ozbaxvf
+        F9b+Wm9u/i7L3Ldr7e/bDdt2f+vYvtq25TN/f33ujtn890vXY8bj98zz9OsXx3Tft9nWlhffX+3uaF/u
+        /q7x2G7Z/7nHf7OxrPP17cL1c7e9/+74O+//zdf2i893tKnz9+dcjHZlt33z7y2W/bG1L7bFetd2bT9Y
+        51vP2y/LbLv+vbVt9d3j3+X/xf//x+/4dluPnHwzB/5HfkaOfsrTp0+jZL1p3jYfZPL+1c3NTVwreBzL
+        Wv8s72rbn2vctrfef37Wtm4Zwxo220frHN3+rw/LtV3/ufn1u85ZDue907HNeFyt1/a9z+n65y1r37i9
+        3zfub5/XP3u/r1vf/N303nG+Z27r93Xblu+odn2b0WfsH3/nes5+WdZ5yn7fjHedf9y2s7z4txWf+zbV
+        bmwzrrfl3rnWbeO+MtoMny+Wdx07elfb/lzjtr31/vOztnXL/83//0f7N5uRk3Et9fZb3/rW9fvvv/9C
+        W98QG6J8fbn5582v5LusI4Vfa2n81VofPn81kzq21fbV+Fz7q02t9+5sX86f5xv3XXxPbe9cvjvW49xD
+        +37besze52jX1pdlrde+apfbemv/+hsGx20Xf0f5udqt7Yd2y/Zcbs6Rnzf7u33LeWp/fu739+3X9e58
+        1a7Wq+1mPfb1bWNfnqPaXJwvttU5s23sX8852h178ee/az3Ol+csxzZ7nxeH7xi/fzlfbtss0/q+2rdY
+        +9L6vO6P9tVu3Fbr/b62Xu2rzWYZ23faX7TdabP3eW0Xy9y+Gp9rf7Wp9d6d7cv583zjvovvqe2dy3fH
+        epx7aN9vW4/Z+xzt2vqyrPXmg1deeeUv2jK6/FGhRm5Gfq7XU4vYEEYJe51jrsIYJvBZvpTvvI4v+GKu
+        L/bbh23P9K42sf1599V6v8z13d+Zf+bNMeP6Z/n6669fnDu29ecu+zaxPz7Xtlg+65hcrvvH317tmhfn
+        KHfOv3yOY+M3d+fYWMf1+3P94rvqPDvnqn8zh9z5zr1z77brrW313+tZ7hz/0l1/B3vflV78Gxj/m/X7
+        PmtbLnePH9f7Y/p9fZtcf+bveYb/3/7/H+3iplSEaeTlbqD2VLi+kOXsYqznZYI6wbovjH3d/k2bOras
+        z/3503VbLPv12Bfre9/RbVu/o9arTVjnjO117tpf+6rtXVab+s7uuPVzLYfvr2Wt9477+8/Lsv++ne3V
+        du93rW275bq/2ue+zd/LHedY1ut7u+PXc8Wy9vfHx7b8vC774zvHY5dz1jHpxZ+xa7Nx+I71+Ny++U39
+        +XI5fl6WQ7t1X2yP8w7f2Tse329f/wy1v35j7RvOuzmm317bhvbr/lg+z/7aNrS9OCb2Deda1+vYsj73
+        50/XbbHs12NfrO99R7dt/Y5arzZhnTO217lrf+2rtndZbbrvaIuez33ufwBpEueGW9tIzAAAAABJRU5E
+        rkJggg==
+</value>
+  </data>
+  <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAYAAAD0eNT6AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAA/H0lEQVR4Xu3dCZzcdX3/8XCDgkIAuTzA
+        AxQRENRWay0qYBUQRfGoUg/OtlTQIljtvyIgYm1raWmVelbxwtYLrdWcBMIRQiJkk2yuzZ1Nspvdneu3
+        Mz++k+//8535jll++Wyyu3P9jtf78Xg+NpDNHjPz+7w/Mzv7m2mEkHjHWnuAOD4MwzONMedXq9X3yJ+v
+        euqpp26S//6C+Ir8+fvi52KG/PdDYqFYJf+9VgxFhMJGuP/3tPeTf9/nPob/WA/J/5sh3Of4vvz3f4jb
+        5c83uq9F/nypOE/+fIb7WsX+/ssnhBBCSDRSlEdLab5SyvPtUqbXyts75O09Yo78eam83S6iZZ0U2+V7
+        6JG3c8R3/ffmvseL3DIj3/tR/mIghBBC0hUpuf3K5fJJUnrnSfldI2//Ud7+VN4ukbeB0IozSwK5LJ6U
+        t+4y+ZK8vVrenjs6OnqiXHb7+ouREEIIiW+ksI535SUldp28vVs8KH8uCq34sHcVuQzdoyD3ipvlz5eG
+        Yfhyt1T5i5wQQgjpXKSADnBFVK1W/1xK6U5f9CVfWmi/0C8G3xHXidfLdfIMf/UQQgghzcfd25Syf4W4
+        Qkrn68I9XO2iFRO65ym5bp4QX5Pr6nJxmlx3/AiBEELIxCKl8SwpkbeJz0unzBZ5XzBInpyYKdflbeKt
+        ct0e5q9mQgghWY8rBSmHc8Udwj2Ur/2KHNJBrmKzVLjnZ1wq1z2/hUAIIVmJDP1DZPifJ/5BLJZS2Bkp
+        CWRHVW4Di8QXxbly2zjY30wIIYSkIWEYniHD/kbhTmQz6oc/EOV+LfM34gb3vA9/8yGEEJKUuHty7h6d
+        uFOG+Xo/3IHJWie3Iffjgot4dIAQQmIaGdBHyr22j8rQ/pngd+/Rau429RO5jX1YbmvT/c2OEEJINyKD
+        +Cj3u/gymO8TPHkPnWIk7gmj18lt8Dh/cySEENLOyMA9RgbvX8sAfkDeVv1ABrrFLQP3y9u/ktvm0f5m
+        SgghpBWRweqeuX+pDFnu6SPO3DLwYBiGV8ltlnMOEELIVCIDdH8ZphfKUP2R4EVzkDTu1NA/kNvwBXJb
+        5rULCCFkb6lUKqfI4LxZ8Ox9pMUWWQTuDMPwdH8zJ4QQ4uIeLpXheKUMyYeU4Qmkhv8RweVymz/U3/wJ
+        ISR7kXv7L5WBeIcMxqHooARSLi+3/btlGTjDHw6EEJLuyD2fA2XwuSf0ubPyaYMRyBQ5Hhb6Jw4e4g8T
+        QghJT2S4HS+D7jYZeNujAxBAzTY5Rm6VY4VzCxBCkh+5Z3OWe6hThhvn4AcmpiLuFa/1hxEhhCQjcg9m
+        Xyn9d4v5Y4YagEmSY+gBcYk7pvzhRQgh8YsMqQPdqXllYC3XhhmAqZFjao28dace5kWJCCHxiQylw9xw
+        EpsaAwtAW2wVN8sxd7g//AghpPORITRd7pncKgNpZMyAAtB+w3LsfU6OwSP84UgIIe2PDJ0jZQC5s/UN
+        jxlIADqvIIvAHW4Z94cnIYS0PjJkjpKB44qfe/xAvLhF4E45Ro/xhyshhDQfGSqHyoC5SVD8QLw1HhF4
+        tj98CSFk8pEhcqA7Q5kMFffEI23YAIinQXGTHMP81gAhZOKRobG/FP+VMkA2jhkoAJJnvRzLH5Vjmpck
+        JoTsOcaYc8WTyiABkFByTC8Xb/WHOSGE7EqlUjlVBsWvooMDQKrcVy6XX+QPe0JIlmOtPUHuGXxLBkM1
+        MigApFNZjvkvyrH/LD8GCCFZihz8B8ggcGfvy48ZDACywz1R0J1emOcHEJKVyPb/ZrE0MgwAZJDMgkXy
+        9g1+PBBC0hj3sz850N3LjKqDAECmuecHnOTHBSEkDfEP939a8Jr8APYkEDfKzNjfjw9CSFIThuGZxpiF
+        kYMcAMYlM+MJeftqP0YIIUmKbPCHyEF8hxzEZuyBDQAT9JTMEPf6As/0Y4UQEvfIcfsGOXBXjDmQAWBK
+        ZJasEef68UIIiWNkUz9cDtS75aDdGT2IAaBJ98qMOdKPG0JIXCLFf5EcoJsiBywAtNLWarX6537sEEK6
+        GdnIT5CD8r7IQQoA7fQzmT3H+TFECOl05F7/O+VAdGfz0g5QAGin4Wq1+j4/jgghnYhs3u4Z/ncqByQA
+        dNp3ZCYd6scTIaRdkYPtVVL+PMMfQGzITOqTt6/1Y4oQ0srIhr2PHGDuxXsqjYMOAGLE5WaZVby4ECGt
+        ihxQz5cDa67QDjoAiA1jzEO8pgAhLYgcTO+Wg2pH9CADgBgbqVarH/BjjBAymci9/mfJQfSdyEEFAIkh
+        d2C+xRMECZlEKpXKKXLg8Hr9ABJPZtmKMAxf7scbIWS8yMHydjloRqIHEQAkWN79ONOPOULI2LhnzsoB
+        4l69j/P4A0ijnTLj3KsL7u/HHiFEDoij5OD4beRgAYA0misz7xg//gjJbsIwPEsOiLWRAwQA0myj+AM/
+        BgnJXtyraslBEIw5KAAgK8pyB+hKPw4JyUastQcZY/5TOSAAIGvcawkc4scjIemN3NCPl/JfoBwEAJBJ
+        MhMfkdl4rB+ThKQvYRieJjf29dEbPwDgqU0yI8/045KQ9EQ23HPlBs7v9wPA+Nz5At7qxyYhyY9stR+R
+        G3YYuaEDAHbncrUfn4QkM7b+Er43C+1GDgAYh6mfNGgfP04JSU7khnuQ3Ijvid6oAQATdq/M0oP9WCUk
+        /pEb7HS54fL6/QDQJGPMfJmpR/nxSkh8Uy6XXyg32OXaDRkAMHkyU1dVKpWX+DFLSPwiN9TXiO1jb7gA
+        gJbYGobh2X7cEhKfyI3zHJEbc2MFALRWwRjzRj92Cel+5AZ5kdwwRyM3VABA65Vk5p7vxy8h3Uu1Wv2g
+        3CBdtBsqAKD1KrIEvNOPYUI6H7kRflzsHHOjBAB0Rih3wN7rxzEhnYvc+D4ZuTECADrLhGF4uR/LhLQ/
+        cqO7KXIjBAB0h3sU9no/nglpX+SGxql9ASB+PuvHNCGtjzHmVuVGBwCIAZnRd/hxTUjrIjesz2s3OABA
+        fMisvsWPbUKaD/f8ASBRPuXHNyFTj9yQ/j5ywwIAxN8n/BgnZPKRG9DfRG5QAIBk2BmG4ZV+nBMy8ciN
+        5/rIjQkAkCyGkwWRSUVuMJfJDYcz/AFA8oXGmIv8eCdk/MgN5WK5wbhoNyQAQPK41w54qx/zhOweuYG8
+        SW4ovKofAKRPSbzBj3tCdkVuGK8RBX9DAQCkz0gYhmf7sU/ItGnlcvkkuWFsi9xQAADpMyAz/8V+/JMs
+        x1o73RjTq9xIAAApJDN/ucz+I3wNkCxGbgAHyo1hVvTGAQBIN1kC7pcOOMjXAclS5IrfR24E34neKAAA
+        mfED1wW+FkhWItsfL+4DALjZ1wLJQsIw/KhyIwAAZM/OarX6IV8PJM2RK/scURlz5QMAss2dLfBcXxMk
+        jalUKqfKFT0cueIBAMiFYfgKXxckTbHWHidX8PrIFQ4AQMNa6YpjfW2QNESu0IONMQuUKxsAgN+TrnhY
+        OoNfD0xL5Ar9unZFAwAQJZ3xVV8fJMkJw/Aq7QoGAGA80h2X+xohSYxcie4Ffspjr1QAACbAvTLsq3yd
+        kCTFWnukXHlrx1yZAABMxnrpkqN8rZAkRK6w/eSK+03kigQAYLJmuk7x9ULiHmPMl5QrEQCASZNO+byv
+        FxLnyBX1DrnCdkavQAAApmindMu7fc2QOKZSqZwiV1QucsUBANCsvDubrK8bEqdYa58lG1qvcqUBANA0
+        6Zil0jWH+tohcYlcOby2PwCgrWQJ+LqvHRKHuJ/NaFcUAACtVq1W3+vrh3Qz1trnyhWyI3oFAQDQJsPS
+        Pc/3NUS6EbkC9pUrYnbkigEAoK2MMfdLB3F+gG5FroTPRK8UAAA65EZfR6STCcPwbLnwK5ErAwCATgnF
+        a3wtkU7EWvtMfuUPANBt0kWrpJP41cBOxf0ahnZFAADQadJJX/H1RNoZuaDfqV0BAAB0i3TTxb6mSDti
+        rT1BLujB6AUPAECXDUhHHefrirQ6cgH/LHKBAwAQF7/0dUVamWq1+j7lwgYAIDakq/7M1xZpRay10+WC
+        3Rq9oAEAiJlB6axjfH2RZiMX6LcjFzAAAHH1M19fpJkYY94oF+bOyIULAEBsSXe929cYmUqstc+QC3G1
+        duECABBjW6XDjvB1RiYbKf9/Ui5UAABiTzqMEwRNJXLhvVqYsRcmAAAJUhWv87VGJhJr7f6yOS2KXJAA
+        ACSKdNkS6bQDfL2RvUUutE9HL0QAABLqJl9vZE8pl8svkgtrNHLhAQCQVCVr7Qt8zZHxIhfULyIXHAAA
+        SfdjX3NEizHmfOVCAwAg8aTj3uLrjoyNtfZAuXB6tQsNAPB0xdFNdiB3v90w+F92Zf/ttnfz/7M9Gz9W
+        s3zzp+3KLbfa9QNfs9tGZthCsFr+Tbjbx0BnScct4wmBSuTC+dvohQUAqCuN9kuhf9M+seEKO6/3NPvb
+        JUdMypxlL7KL1r7f9m37V1kI1qifAx3xCV97xEU2Ivc6/4XIhQQAmRaGo3bTjnvtwr532hk9R6vFPlWP
+        rHqTXbf9K7ZcGVE/N9omJ53HiwU1IhcIL/YDAF4lLMo99bvknv7panm30pxlJ9neLZ+1QXmr+rWg9Ywx
+        d/v6y3bCMDxDLhB3tiT1ggKALOkf/qUU/5lqWbfT7GUn2jVb/1mWj5L6daGljHTfK3wNZjdyQcyIXDAA
+        kDml0S328bWXquXcSQ+tfL3NlZaqXyNaapavwWzGGHOhcqEAQKZsG5lp5y4/RS3kbpi19PjaEw61rxWt
+        k9lfC7T18/0v0y4UAMiKjYPfbfkT/Fpl6aYbbPhURf260TzpQPc6Afv5WsxOwjC8SrtAACArVvXfrhZv
+        nPxu/YdrT0rUvn40T7rww74WsxHZeA6Wb3xD9IIAgKxYseUWtXDjaGHfu1gC2meddOJBvh7TH/mGb4hc
+        AACQGSu2fE4t2jhjCWirj/l6THdk0zlMvtltkW8eADJhxZab1YJNApaAttnuutHXZHpjjLlV+eYBIPWS
+        XP4NLAFt83e+JtMZ2XCOkm8yH/mmASD13Nn2tEJNIpaAthiRjjzC12X6Ivf+71C+aQBItTSVfwNLQOtJ
+        R37O12W6IpvNkfINcu8fQIaEdtmmm9QCTQOWgJZzLxSUvkcBZLO5XflmASCl0l3+DSwBLXezr810RDaa
+        6fJNce8fQEa48r9RLcw0YgloqXQ9F0Du/d+mfJMAkEKhXbrpk2pRphlLQEt91tdnsiObzLPkmxmOfHMA
+        kELZLP8GloCWGZLuPNTXaHIj38inIt8YAKSQK/8b1GLMEpaAlvlrX6PJjGwwB8k3sSXyTQFAylD+Y7EE
+        NM8Y0ycdur+v0+RFvomro98UAKSLlP/Gv1GLMMtYAponS8Clvk6TFdlc9pMvfqX2TQFAOrjy/4RagGAJ
+        aJZ06AJfqcmKfOHv1r4hAEgHyn8iWAKa9npfq8mJLAAPKd8IAKQA5T8ZLAFN+amv1WQkDMOzlW8CAFIg
+        tD0bP64WHcbHEjBlOyuVyst8vcY/8gV/L/INAEAKUP7NYAmYGmPMV3y9xjvW2uPlC65EvwEASDZX/ter
+        xYaJYwmYklHp1mN8zcY3sql8XvniASDBXPlfpxYaJo8lYErifXpgf+Kf7ZEvGgASK3yqYpds+Au1yDB1
+        LAGTts11rK/b+KVarX5Q+aIBIJEo//ZiCZgc6dj3+7qNX4wx87UvGgCSJgzL9skN16jFhdZZtO7Pape1
+        dh3g6aRj7/d1G6+EYXi69gUDQNJQ/p21ZMO16vWA3UnXnuZrNz5xv6agfbEAkCT18r9KLSq0z+qt/6Be
+        H3g66do7fe3GI9baQ+ULy0W/UABIknr5X60WFNprxpIj7fbcHPV6wdOMSOc+09dv9xOG4ZXKFwkAieHK
+        /4kNV6jlhM6Y13uaDcoD6vWDXaRzP+zrt/sxxjysfZEAkAQ87B8f7jUWtOsIu8TmyYCVSuUU+YJ2Rr9A
+        AEgCyj9eZvQcZUeKT6jXFX5vZ7lcfrGv4e5FNpF/UL44AIi9MBy1T6z/iFpE6J6FfZeo1xd2ke69zddw
+        d2Kt3V++kC3RLwwA4q5+z/9KtYDQfUOFRer1ht/bJB28n6/jzkc2kIuULwoAYo0n/MXfor4r5HoK1esP
+        ddLBb/F13PnIF3Bv9AsCgDirlf/6y9XSQXzM7DnG7hjewBKwZ/f4Ou5srLWHyScPIl8MAMQW5Z8sq7d8
+        w+ZyOVupVNTrE08V3Xl4fC13LtVq9UPKFwMAsRSGgV287jK1aBBPC1a/y46MjLAE7EFXXiBIPvFvol8I
+        AMRRvfw/qJYM4mtmz/F2eHjw90tAucyLBil+4Wu5M7HWPkc+qYv2xQBAbFD+ybZ5+7zaAtAwOjqqXs8Z
+        FkonH+nruf2RT/ixyBcAALFTCUu1l5vVigXJ0Lvxy09bAFgCVNf4em5/jDEPKl8AAMSGK//F6z6glgqS
+        44m1H9ttAXBKpZJ6vWfULF/P7Y219lj5ZNXIJweA2OCef3o8uurt6gLgFItF9frPION+NO9run2RT/SX
+        kU8MALFRCYt20dr3qmWC5JnXe5Za/g0sAXVhGF7ha7p9kU80K/qJASAOavf8175fLRIk05xlJ6vFP1ah
+        UHAFqN4mMuTXvqbbE/dMQ/kkLtonB4CuofzTaWbPCWrpR7EE1H4b4Ahf162PXLgfUT4pAHSVe9j/8bWX
+        qgWCZHOnBNYKX5PP5zN9wqBqtXqZr+vWRz7Bz6OfEAC6qX7P/31qeSD5Zi89US378bgTBmX4kYAf+7pu
+        bay1B8kHL0Q+GQB0Tb38ecJfms1ddqpa9HuS4VMHF1xX+9puXYwxb1M+GQB0hXvYf2HfJWppID3mr/hj
+        teT3JqtLgHT1ub62Wxf5oP+hfTIA6DR+1S87Fq75oFrwE5HF1w+Qrv6yr+3WRT7wuugnAoBOqz/h7z1q
+        WSB9etZ/Ri33ycjSqYNlAVjja7s1CcPwdO0TAUAnVSoF+1jfxWpRIJ36tnxPLfXJCoJAvU2lUaVSeamv
+        7+YjH/DG6CcAgE6i/LNpYGilWuhTkaHXD7je13fzkQ82I/LBAaBjypU85Z9B9y8/Uy3yZmTk1MG/8vXd
+        XKy1B8sHCyIfHAA6gvLPrifXfVIt8WZlYAkotuTXAY0x5ysfHADajvLPtk3b56oF3goZOHXwOb7Gpx5Z
+        AL6kfGAAaKtyJWcXrLlQLQak3/3Lz5CiHt6tuFvJnTo4rUuAdPfnfY1PPfJBfqd9cABol9o9/zVvV4sB
+        2dC78ctqabdaWk8YJN29wNf41GKtnS4fqBr9wADQLvXyv0gtBWSDO///0PAWtbDbIaWvH1CVDj/c1/nk
+        IxvEO5QPCgBtUa6M2AVr3qaWArJj2Ybb1KJupzQ+EiAdfoGv88lH/vE/ax8UAFrN/cyfe/64f/npcu9/
+        m1rS7Za2UwdLh3/R1/nkI//4ce2DAkArjVaG7aOr/1QtBGTL2v4fqeXcSWk5dbB0+CO+zicXa+2z5AOY
+        6AcEgFbi2f5oWNR3pVrI3ZCSJeAp6fLDfK1PPLI58PK/ANqqXv4XqGWAbJm3/JV2x/BmtYy7JQ2vHyBd
+        fp6v9YlH/tHt2gcDgFYYrQzZR1efr5YBssU9679/8DG1hLst6a8fIF1+i6/1iUf+4ezoBwKAVnDl/8jq
+        89QyQLbM7DnWbtw2Qy3fuEj4qYN/42t9YrHW7iv/KBf5IADQtHr5n6uWAbJlZs8xdl3/j9XSjZsELwEj
+        rtN9ve89YRiernwQZEQlLNqRUo/tH/qFXT/wTdu37U67qv8Ou3rrl+TPd9kNg9+220Z+a/PBShuG2XmN
+        bTRvtLyD8keNK/+1/feqZRtXSX39gEqlcqqv971HvsErtQ+CdHJDedOOH9mejR+381e+1s5YcqR6wGrc
+        Qeweyu3d/Hd26/D/yfKQmdfbxiTVyn/Vm9XbEbIlieXfkMTXD5Cv96O+3vceY8zXtQ+C9AjDst0y9FO7
+        eN0Haj+D0w7SqZiz7CS7ZMNf2sH8g+rnRTZR/mhI0sP+40naWQOl0+/29b73yDs/qX0QJF+lUrDrtn/F
+        zus9Uz04W+mRVW+ym4d+Ip831S+5ib2g/NGQhvJvSNIjAdLpv/P1vudYaw+Wf+CifiAkV//wL6X4z1AP
+        zHZ6eNU5djA/X/2akG718n+TertAttTKf+t/q2WaVAl6JCB03e5rfvzIO74m8g+RcMVgg32s72L1oOyc
+        6bZn43W1V3rTvkakz2h5kPJHTRrLvyEprx8QhuFZvubHj7zj1dF/iOTqH77Pzln2IvWg7IYHV7zaDhcX
+        q18r0oPyR0O9/P9HLc80ifupg2UBuNzX/PgxxnxV+8dInrXb/10OwOm7HZDd5p50WH9ugP51I9lc+T+8
+        6o3qdY9syUr5N8R5CZBuv8vX/PiRd1qg/WMkSWiXb/6MekDGxYyeo+z6gW8oXzuSjPJHQ9bKvyGurx8g
+        3T7f17wea+1+8o5B9B8iSULbs/F69YCMn+m130jQvw8kDeWPBvco39r+7JV/Q0zPGljY4xkBK5XKyco/
+        QmIkqfwb3BLwVeV7QZIE5QHKHzWu/Nf1/0QtxiyJ44sIlcvlk3zd7x5jzDu1f4QkSGL5N8gSMHC38j0h
+        CSh/NFD+Txe3RwKk4y/0db975B0+E/0HSIIkl3+DWwL+U/neEGf18j9HuT6RNTOk/Dds/ZVahFkWs9cP
+        uNHX/e6Rv/xe5J0Re2ko/waWgCQpjfbb+Sv/SLkekTWU/57F6KyB3/Z1v3uMMYuVf4DYSlP5N0y36we+
+        pnyviJN6+b9Ouf6QNTN7jqP8JyAOZw10v+Xn6/7pcc8OlHfgNwASI43l3+CWgK8r3zPigPJHA+U/Oe6R
+        gC4vAe43Afbxtb8r7tmByjsjltJc/g1uCeA8AXFD+aOhVv7b/lctOoyv248ESJ7ra39XjDHnae+MuMlC
+        +dfNWHKk3TD4XeUyQDeURrdQ/qih/JvT5dcPOMfX/q7I//yLyDshdrJT/g1uCdg4eI9yWaCT6uX/WvU6
+        QrZQ/q3TjVMHh2F4ha/9XTHG/KP2zoiL7JV/gztt8MbB7ymXCTqB8kdDvfx/rZYZpqbTS4B0/Rd87e+K
+        /MXPou+IuMhu+TfUl4DvK5cN2qlW/iv+UL1OkC2Uf/t0+KyBP/a1vyuyFfQo74iuc+V/nXpAZg1LQGdR
+        /miY2XM85d9mnTproHT9Yl/79bhfC5C/KEXfEd1G+UfVl4AfKJcVWonyR4Mr/43b/k8tLbRWh5aAvK/+
+        emQBOFp5J3QV5T8etwRsGvyhcpmhFVz5P7jiD9TLHtlC+XeeWwLafdZAyRG+/qdNk092lvZO6BbKf29q
+        S8COHymXHZpB+aOhXv6/UUsK7dXu1w+Qj326r//az/8v1t4J3UD5T1R9CbhXuQwxFaXRzZQ/aij/7mvn
+        6wdI51/g67/2GwDXRt8B3UD5T9aMnufYLUM/Vy5LTEa9/F+jXsbIllk9z7Obts1WSwmd5U4Y1KYl4C98
+        /dceAfii8g7oKMp/qlgCmkP5o2HW0udL+c9Rywjd0Y5TB0vn3+7rn5cB7j7Kv1kze46x/UO/UC5b7Ekh
+        WG8f6D1LvUyRLZR/fLVhCfiur//aAjAn8pfoGMq/VWpLwPB9ymUMTSFYR/mjplb+2+eq5YN4aPHrB8z0
+        9V/7EcAy5R3QdpR/q9WXgF8qlzXGcuU/r/eV6mWIbKH8k6UVpw6Wzl/i67/2CMCO6Dug3Sj/dmEJ2DPK
+        Hw2UfzK1YAnYVit/a+0B8h87I3+Jtgrtkg3XqgckWmNmz7F228hvlcs+2yh/NNTL/361YBB/Tb5+QFW6
+        f3+3AJyg/CXaaMWWm9UDEq3lloCtw/+rXgdZVAjWUv6ombX0BZR/CjRz6mDJMe4sgK/U/hLtsX7g6+oB
+        ifaYufQ4u31klnpdZEm9/M9ULyNkiyv/zdvnqYWC5JnqElA7G6Ax5nztL9F6I8Una/dKtYMS7ZP1JYDy
+        RwPln05TOXWwdP+bp1Wr1fdqf4nWKldy9sEVr1YPSrTfrKXH2+252ep1k2b18j9DvUyQLZR/uk12CZAF
+        4F3uNwCujv4FWq9389+pByU6J2tLQCHoo/xRQ/lng3v9gImeMEiWhSvcAvCp6F+gtQrBKh76j4n6EjBH
+        vZ7ShPJHw+ylJ1L+GTKJ1w+4wT0H4AvKX6CFFq+7TD0w0R2zlj7XDuQeUK+rNKD80UD5Z9NETh0s3X+r
+        WwC+ov0lWiNfWmFnLDlSPTjRPbOWniBLwFz1Okuyevmfrn7PyJZ6+T+gFgTSb29LgHT/Xe5HAN+P/gVa
+        p2fjx9SDE91XXwLuV6+3JMqX1lD+qJmz7MW2f+ARtRiQHXt5/YB73ALwi8j/RIuUKyO1nzlrByjiYfbS
+        59sd+YfV6y9J8sEKKf+Xq98jsqVe/o+qhYBsGufUwT91C8DMyP9Ei2wa/KF6gCJe6kvAI+p1mASu/O/v
+        PVX93pAtlD/GEwRBdHb8xj0HYH7kf6JFFq/7gHqQIn5mL3uB3VFYoF6PcUb5o2HOspdQ/tijsa8fIN0/
+        zy0Ai8cOFLRGGJblnuXz1AMV8ZS0JYDyR0O9/BeoQx8Yq3HqYOn+hW4BWBEdLGjeUGGheqAi3pKyBLjf
+        LqH84VD+mCy3BEj3L3fPAdgQHS5o3rrtX1UPVsTfnGUnyQL3uHq9xkGt/Je/TP3akS2UP6aqUCgEbgHY
+        Hh0waF7Pxo+rByySYfayE2UJeEy9brspV+ql/FFTK//Bx9ThDkyEWwCGokMGzVvY9w71oEVyxG0JoPzR
+        QPmjFdwCkI8OGjTvgd6z1QMXyeJ+rWq4+Dv1Ou4kyh8NlD9axS0ApeiwQfPmLj9ZPXiRPG4JGCk+qV7P
+        nVAv/5eqXxuypf4zf8ofreEWgHJ04KB5nAEwXeYuf0lXloBcaTnljxrKH63mFgAXdfhg6mb0HK0exEgu
+        96jOSKlHvb7bgfJHw5xlJ1P+aDm3AOyMDh40j5MApVNtCSguUa/zVnLlP3f5KerXgGypl/9CdYADzWAB
+        aBPuuaVXux8JyJWWUf6oofzRTvwIoE3mr3ytekAjHVxBu3vp2nXfDMofDXOXvcxuHfydOriBZrmXCuZJ
+        gG2yaO371YMa6eEeCciVlqrX/1SMFJ+Qe3wvVj8XsmXuslMpf7SdWwD4NcA2WL75b9UDG+lSXwKWqbeB
+        yXDnGqD84bjy3zb4hDqwgVbJ5XI73QLAiYDaYMPgd9WDG+njXpQnH6xUbwcTQfmjgfJHp8gCUHULAKcC
+        bgNXCNoBjnSa1/vyKS0Bw8XFlD9qKH90UmMB4MWA2oTfBMiWeb2n2UKwWr0taOrl/yL1YyFb5i57OeWP
+        jpIFwLgFgJcDbpMlG/5aPdiRXvUlYJV6exiL8kdDvfyfVIc00C6yAITTjDErtAGF5m0fmaUe8Ei3vT0S
+        QPmjgfJHtxQKhVG3ACzWhhSaF4Zlfqc7o+b1ni5LQN9ut4nh4iLKHzX18l+iDmeg3WQBKLoFYH50SKF1
+        VvXfoR78SL95va+QJWDN728LlD8a5i47jfJHV+Xz+Zx7DsDMxoBC6wXl7XbW0hPUIYD0c48E5Etr7FDh
+        cSn/F6rvg2yh/BEHxWJx0C0Av4iWFlpr+eZPq4MA2TB3+al29tIT1b9DtlD+iItCobDJLQDfjxYWWmu0
+        MsRzAYCMu3/5K6T8e9RhDHSaLACr3HMA/kMrLbTWhsFvqUMBQPpR/oibYrH4uFsAbtcKC60W2kVr36cO
+        BwDpNW/5WXb7jl51CAPdUiqVZrkfAdy4e1mhHUqj/ZwdEMgQV/4DO1aoAxjopmKx+D/TwjC8SisrtMdg
+        /kE7s+dYdVgASA/KH3EmC8Dd06rV6nu0okL79A//0s7oOVodGgCSj/JH3AVBcKt7DsB5WkmhvepPCpy+
+        2+AAkGzzeil/xF+5XL7W/QjgTK2g0H4bBr8tA4MlAEiLWvkPrVQHLhAnQRBcNM1ae5xWTugMHgkA0uGB
+        3rMpfySG3Pl/uVsA9pciqkaLCZ2zfuCbMkBYAoCkovyRNJKDprlICQ1ESwmdtXb7v8sgYQkAkobyRwJV
+        a+XvYoxZqpUSOmvt9rvUAQMgnlz5b99B+SNZCoVCydd/7RGA2dEyQnewBADJ8EDvqyh/JJIsANt9/dcW
+        gO9Fiwjd07eNJQCIM8ofSZbP53t9/dd+BHCHVkTonr5t/6YOHgDd5cp/YMcqdbACSVAqlWb7+q89AvBX
+        0QJC9/Vt+1d1AAHojgd6X035I/GCIPimr//aIwBv1woI3de37U51EAHoLMofaVEqlf7W1/80dzbAV2rl
+        g3hYs+1f1IEEoDMe7H2dHRzqU4cpkDSVSuUCX//T3MmAjtSKB/GxZtuX1cEEoL0of6RNEATH+/qvR0qm
+        FC0dxMvK/tvVAQWgPSh/pE0ul9vpa39XjDFLtNJBvKzs/7w6qAC01oO9f0T5I3WedhKgRqRcfhotG8TT
+        yv7b1IEFoDXq5b9WHaBAkskCsMHX/q4YY76klQ3iaeWWW9XBBaA5lD/SrFgsPuBrf1ekVK6JlgzibcWW
+        W9QBBmBqHux9PeWPVJMF4Gu+9nfFGHOeVjKItxVbPqcOMgCTQ/kjC4IguMbX/q6Uy+WTtIJB/K3YcrM6
+        0ABMTL3816kDE0iTSqVyqq/9XbHW7itlEkTLBcnQu+Wz6mADsGfzV/wx5Y9McL8CKF2/j6/9p8cYs0gr
+        FyRD75a/VwccAB3ljywpFAp5X/e7R0rknmipIElCu2zTjeqgA/B0lD+yplQqrfB1v3ukRD69e6kgWUK7
+        dNMn1YEHoG7+ijdQ/sicYrH4K1/3u8cY8w69VJAsbgm4QR18QNbVy3+9OiCBNJMF4BZf97unUqmcrBcK
+        kkeWgI1/ow5AIKsof2RZPp9/na/73WOt3U/KgxcFSg23BHxCHYRA1jy08s12x/AmdTACaed/A2BfX/d6
+        jDGP6GWCZAptz8aPqwMRyIqHV55L+SPTCoXCsK/58SMLwFf0IkFyuSXgenUwAmlH+QO1n/8v9DU/fsIw
+        vEovESSbWwKuUwckkFYPrzxPyn+zOhCBLJEF4Ku+5sePlMWrdi8PpINbAj6mDkogbSh/YJcgCN7ha378
+        WGsPkrIIdy8PpEH4VMU+ueEadWACaUH5A7vkcjmpdnuIr/k9xxjzhFYeSIcwLMsScLU6OIGke2gF5Q+M
+        VSgUir7e9x5ZAP5TKw6kB0sA0ojyB3YnC8CTvt73njAML9dKA+lSXwKuUgcpkDSu/IeGt6gDEMiyYrH4
+        dV/ve48sAKdphYH0qS8BV6oDFUiKh1eeT/kD4yiVShf4et973NmCpBxGomWBdHJLwBMbrlAHKxB3j6x8
+        m5T/VnXwARhxZwDcz9f7xCLFMDNaFEiv2hKw/nJ1wAJx9fDKt3DPH9iDQqGwzdf6xGOMuU0rCqRXGAZ2
+        8brL1EELxM0jqy7knj+wF8Vi8Te+1iceWQDeqpUE0q2+BHxQHbhAXNTv+ferAw/ALkEQXOtrfeKx1h4m
+        heCiFgXSqxKW7KJ1f6YOXqDbHl11kR0e3qYOOwC7+BMAHeFrfXIxxjymFQTSzz0SwBKAuHl01dspf2CC
+        CoXCiK/zyUcWgH/SygHZUHskYO171UEMdBrlD0xOsVh80Nf55CMLwMVaMSA76kvA+9WBDHTKo6sutkOU
+        PzApo6Ojn/Z1PvlYa6dLCVSjpYBsqS8B71MHM9BulD8wNUEQPNfX+dRijFmklQKypRIW7cK+d6kDGmgX
+        yh+YmoLE1/jUIwvAF7VCQPa4RwIeX/sedVADrbZg9SWUPzBFxWJxnq/xqUcWgHO1MkA2uUcCWALQbo+u
+        egflDzQhCIK/9DU+9VhrD5bBH0SLANlVqRTsY30Xq4MbaNaC1e+k/IEm5HI5d/7/Z/gaby4y9H8bLQFk
+        G0sA2mHBqndL+W9XhxqAiSkUCpt9fTcfGfifjBYAUK7k7YI1F6qDHJgs7vkDrSELwPd8fTefMAxP0woA
+        cEvAY2suUgc6MFE84Q9oHVkA/tjXd2tijOnTCgBgCUAzKH+gdaT8y762WxdZAP5NG/6AU66M2EdX/6k6
+        4IHxLFj9LsofaKFisfior+3WRRaAP9UGP9BQruTsgjUXqIMeiHps9fvs8PCAOsQATE0QBB/3td26WGsP
+        kiGfjw59YKz6EvA2deADDY+tfj/lD7SY//W/Z/rabm1kwP8kOvCBqNHKkH1k9bnq4Acof6A9CoXCOl/X
+        rU8Yhh/WBj4QVVsCVr1ZLQBk18LVf0b5A21SKpW+7Ou69bHWHi7DvRId9oBmtLyDJQC/R/kD7ZPL5dzP
+        /4/3dd2eyGDnrICYsNHyoH141RvVQkB21Mt/UB1cAJrX0rP/jRcZ6ldHhzywJ+6RAJaA7Hp8zWWUP9Bm
+        xWLxP3xNty/W2mNkqJvokAf2hEcCsmnhmg9Q/kCbuYf/R0dHX+Brur0xxtyvDXlgT4LydvvQyj9WiwLp
+        s3DNByl/oAMKhcI2X8/tjwzza6PDHZiI+iMB56iFgfR4vO/DUv471GEFoLWKxeI3fD23P9bao2WYu6hD
+        HtiToDzAEpBi/Mwf6KxyuXySr+fORAb5r6ODHZio0mi/nb/ydWqBILkof6CzCoVCv6/lzqVarV6mDXZg
+        olgC0mVR3+U87A90WFtP/jNe3PmGZYgXo0MdmIzS6Bb74Io/UAsFyfH4mj/nnj/QYf7c/9N9LXc2MsB/
+        GB3owGS5JWD+ij9UiwXxVy9/7vkDnVYsFnt9HXc+xpgLtIEOTBZLQDIt6rvSDo8MqcMJQHuVy+VrfR13
+        Ptba/WR4b4wOc2AqiqOb7IMrXqUWDeJnUd9VlD/QJfl8PnQd7Ou4OzHG3KENc2AqeE5AMiym/IGuKpVK
+        M30Ndy+VSuVkGdw7o4McmKr6EvAatXjQfZQ/0H2jo6Ov9TXc3Rhj5muDHJiqQrDePtB7llpA6B7KH+i+
+        YrE46Ou3+wnD8HJtiAPNcEvAvN5XqkWEzuNn/kA8yL3/u3z9dj/W2kNlYOeiAxxoViFYJ0vAmWohoXMe
+        XXUR5Q/EQFd/93+8GGP+XRvgQLNYArrrgd5XyeAZ3m0QAei8YrH4mK/d+KRSqZwqw5onA6ItCsFaloAu
+        mNXzPDs4vFEdRAA6r1wun+9rN14xxjygDW+gFfKlNbIEnK4WFVpvRs+xtn9ggTqEAHSe3Psf8HUbv1Sr
+        1Q9ogxtolfojAWeohYVWOspu2j5DHUIAukPu/d/m6zZ+sdYeJEN6e3RoA61UCFbLEnCaUlpohRk9R9p1
+        /feqAwhAd+RyOeM61tdtPGOMuUUb2kArFYI+fhzQBq781/b/SB1AALonCIL/9TUb38iGcpwM6Ep0YAOt
+        lg9W2vt7T1WLDJNH+QPx5c6662s23pHh/N3osAbaIR+sYAloCcofiKtisbjc12v8E4bhWdqwBtqhtgQs
+        f1mk0DBxR1H+QIwVCoVLfb0mI/xKIDopX2IJmBpX/jzhD4grKf8dvlaTE1kALtEGNdAuuVKvLAEvVUoO
+        mhm1h/0pfyDOSqXSp32tJifW2n1lCViqDWqgXVgCJobyB+JP7v0Hrkt9rSYrvEoguiFXWm7nLj9FLT40
+        nu1P+QNxNzo6+mVfp8mLbC4HyEDeEB3QQLuxBIyD8gcSIZ/Ph9KhB/s6TWZkGN8QHc5AJ4wUn7Bzlr1Y
+        L8IsovyBxCiVSvf4Gk1uZIM5TIbxUHQ4A53AEtBA+QNJkcvlqtKdR/gaTXaMMZ/ThjPQCcPF38kS8CKl
+        FLOC8geSJAiCX/r6TH5kk3m2DOLh6GAGOmW4uDiTSwDP9gcSZ2epVDrO12c6Yoy5VRvMQKdkbQmg/IHk
+        kfKf4WszPbHWHi5DmEcB0FXDxUWyBLxQLcw0ofyBRNoZBMFzfW2mK8aYz2tDGeik1C8BPNsfSKRisfhr
+        X5fpi7X2SBnAuehABjptqPC4nb30RL1Ak4zyBxIpn89XS6XSsb4u0xkZvp+NDmOgG4YKC9O1BFD+QGLJ
+        vf+f+JpMb6y1h8rw3RodxkA37Mg/LEvA8/VCTRB+5g8kVy6XM9KN031NpjsyeK+PDmKgW+pLwPPUYk0C
+        yh9ItiAIvuXrMf2RTedAY0yfNoyBbhjMP5TIJYDyB5KtUChUpBMP8fWYjYRh+FFtEAPdMpifn7Al4CjK
+        H0i4Uqn0L74WsxPZePYzxjyhDWKgWwZy8+yspc9VyjZeZvQ8x67r/7E6UAAkQz6fL0kX7u9rMVuRBeCN
+        2hAGummo8Jids+wlavHGwcye4+z6rfepAwVAchSLxWt9HWYzMnB/Gh3AQLflg5X2gd6z1QLuprnLXmr7
+        Bx5RhwmA5CgUCut8DWY35XL5hTJwy9EBDHTbaGXYLtnw12oRd8OC1e+xg0Nr1WECIDlyuZx7+P91vgaz
+        HWPMF7UBDMTBhoEf2DnLTlZLuRPcyYpWbvqKOkgAJE+pVJrr649Yaw+TQbslOniBuCiUBuySdZ+yM3uO
+        VUu6HWb0HG2fWHud3Otfpw4RAMkj9/xNsVh8jq8/4hKG4eXa4AXiYnR01A7sWG2Xbvic3Cs/SS3tVpjZ
+        c4J9ct0n7PYdS9UBAiC55N7/Xb72SCPW2n2NMQu0wQvEhVsC3EE8NNxv12z+r9rP5VvxqID7tb4Fq99p
+        V2/+ut0xtHG3oQEg+QqFQt51na89MjYyYF8ndo4duEDcNJaAhqHhLXbD1l/VHhl4dNU77P3Lz6w9fK8V
+        vTOj5yh5n9PtI6sutD3r/59d1/8zu2N409M+JoD0kXv/V/q6I1pkwP4oOnCBuIkuAVHDwwN2+47ltn9g
+        kd28/YGa/oGF8v+WycKwXf03ANKrWCyu8jVHxou19gUyYIPowAXiZm9LAAA4uVxuZxiGp/uaI3uKDNeb
+        osMWiCOWAAB7EwTBPb7eyN7izo1sjFmoDVwgblgCAIzHP/Evm+f7n2rCMDxDhmsYHbZAHLEEANDIvf93
+        +lojkwlnCESSsAQAGKtUKs32dUYmG2vtIbIErNKGLRBHLAEAnHw+X5EOe5avMzKVyFA9R3BuACQGSwCA
+        IAg+5muMNBNjzDe0QQvEFUsAkF2FQqHH1xdpNtbaZ8tQ3RQdskCcsQQA2eNe7EeO/ef7+iKtiDHmUm3I
+        AnHGEgBkSxAEt/raIq2MDNSfRgcsEHcsAUA2cLrfNsZae5wM1IHogAXijiUASLdcLmfK5fILfV2RdsQY
+        c7E2YIG4YwkA0kuO7xt8TZF2RpaAu7UBC8QdSwCQPsVi8TFfT6TdsdY+Q5aA5dqABeKOJQBIj0KhMCqd
+        dLivJ9KJhGF4lgzTSnS4AknAEgCkgywAl/paIp2MDNJPRQcrkBQsAUCyFYvFX/g6Ip2OtXZfGaSzooMV
+        SAqWACCZ5J7/DumgA3wdkW5EroATZJDuiA5WIClYAoBkyeVyVfdjaF9DpJsxxlyiDVYgKVgCgOQIguAW
+        Xz8kDpEl4FvaYAWSgiUAiL9SqcSv/MUt1tpDZQlYqg1WIClYAoD4KhQKRekaXuM/jqlUKifLEB2JDlUg
+        SVgCgFjaKcfna33dkDjGGPN2uZLcFaUOVyAJWAKAeJFj8rO+ZkicI0vA7dpQBZKEJQCIh1KpNMfXC4l7
+        /PkBfh0dqEDSsAQA3ZXP5wf4ff+ERa6w6caYPm2oAknCEgB0h5R/WC6XX+RrhSQpYRieKQM0iA5UIGlY
+        AoDOC4KA8/wnOdVq9TJtoAJJwxIAdI4cb//ia4QkOcaYr2oDFUgalgCg/Uql0nxfHyTpsdYeJEvAI9pA
+        BZKGJQBon2KxOOg6w9cHSUPkCj1Whue66DAFkoglAGi9fD5fkWPrRF8bJE2pVCovk+E5FB2mQBKxBAAt
+        tVPu/Z/r64KkMTI4/0SUxw5SIKlYAoDm5XI5Wy6Xr/U1QdKcarX6fhmenC4YqcASADSnVCrd6euBZCHG
+        mM9pwxRIIpYAYGqKxeKvfC2QrMRau48Mzv+KDlIgqVgCgMmRe/5LXRf4WiBZilzxB8jgnBkdpEBSsQQA
+        E1MoFLZJBxzi64BkMXIDeLYxZok2TIEkYgkA9kzKvySz/1hfAyTLkYF5ogzOrdFBCiQVSwCgy+fzT4Vh
+        eLof/4TUXjjobBmcI9FBCiQVSwDwdFL+1VKp9BY/9gnZFRmarxWFsUMUSDKWAKAul8vtlOPhMj/uCdk9
+        xpg3y+AcjQ5SIKlYApB1rvzlnv9VfswTMn5kCXiLDE7OFojUYAlAVrmz/Mnt/xN+vBOy98gScIkMThd1
+        oAJJwxKArHHlHwTBLX6sEzLxVKvVD8ngrEYHKZBULAHIErm9c4pfMvXI0Pyr6BAFkowlAFlQLBa/6sc4
+        IVOPDM3ro0MUSDKWAKRZEATf9+ObkOZjjLlVG6RAUrEEII3kdv0TP7YJaV1kaN4UHaJAkrEEIE3k9nyf
+        H9eEtD4yNG+MDlEgyVgCkAalUukHfkwT0r7I0LxG8NsBSA2WACRZEARf8+OZkPanWq1+QAanizpQgaRh
+        CUDS+N/z/5Ify4R0LrIEvEcGZxgdpEBSsQQgKVz5l0qlm/04JqTzMcZcIIMziA5SIKlYApAEcju90Y9h
+        QroXGZp/IvJjhyiQZCwBiCv3wj5BEFzjxy8h3Y8MzVeLHWOHKJBkLAGIGyn/qtwu3+vHLiHxSRiGZ8vg
+        3BodpEBSsQQgLvL5fFgul9/sxy0h8YvcQE8yxizThimQRCwB6LaCpFKpnOrHLCHxjbX2CBmcs6ODFEgq
+        lgB0S7FY3CIz9Sg/XgmJf+QGe6AMzv+KDlIgqVgC0GmlUulJN0v9WCUkOZEb7j4yOG8WO8cOUiCpWALQ
+        KVL+97kZ6scpIclMtVr9kAzPSnSYAknEEoB24+x+JFUxxrxJhudwdJgCScQSgHZwv+YXhuGH/NgkJD1x
+        z2KV4bk2OkyBJGIJQCsVCgW54x/8gR+XhKQv1tpjjTEPawMVSBqWALRCsVjcKrPxBD8mCUlv5Ia+vywB
+        d2gDFUgalgA0o1Qq3S8zkWf6k2ylWq1+UAZoKTpQgaRhCcBk+XP6f9GPQ0KylzAMzzTG9GlDFUgSlgBM
+        VD6fr0j5X+THICHZjbX2SBmg/xcdqEDSsARgbwqFwiYpf37eT0gjsgS4kwbdJKpjByqQNCwB0ORyOfdk
+        v1/LrNvXjz1CyNgYYy6UIcr5ApBoLAEYy/1+v9zrv96POULIeKlUKi+RRWCJNliBpGAJgFMoFHKlUuks
+        P94IIXuLtfZQWQK+oQ1WIClYArJNiv8hmWXP9GONEDKZyBJwiQzSwehgBZKCJSB73EP+cr3f5McYIWSq
+        kQ36WBmkv44OViApWAKyo1gsbq5UKif78UUIaTb+twSuE+WxgxVICpaA9CuVSj/kWf6EtClhGJ5mjHlS
+        G7BA3LEEpFOhUChK+Z/vxxQhpF2RDfsQWQLulIG6MzpggbhjCUgP97v9UvwLZCYd6scTIaQTkSXgLTJQ
+        +6MDFog7loDkk3v9YblcvsaPI0JIpyOb93EyUH8eHbBA3LEEJFcQBD0ye473Y4gQ0s0YYy6VoToQHbJA
+        nLEEJIu71y/X2Y1+7BBC4hLZyJ8jQ/U70SELxBlLQPy5n/XLvf7HZcYc7ccNISSOMca8WwYrzw1AYrAE
+        xJd7hn+lUrnUjxdCSNwjm/qz/W8KmOiwBeKIJSB+5F7/L2WWHOzHCiEkSQnD8CxZBBZqAxeIG5aAeCgW
+        i8PlcvnNfowQQpIa2eAPkOF6kyiNHbZAHLEEdE8+n3fn8L9LZsZ+fnwQQtIQOahPkAHLkwQReywBneVP
+        6POkzIgX+3FBCEljjDFvFEu0wQvEBUtAZxSLxcFKpXKRHw+EkLRHNv39Zci6FxcaGTt0gThhCWifQqFQ
+        CYLgDpkFvHgPIVmMHPzHGGPulmHLbwsgllgCWiufz+8slUo/l2Of8/cTQqZNq1QqL5Vhe290+AJxwBLQ
+        PP9z/pXFYvHl/rAnhJBdMcacK36nDWGgm1gCpk6KfyAIgkv8YU4IIXqstfuFYfgRGbrrokMY6CaWgMmR
+        e/tFudw+yc/5CSGTigyNA2URuEoGCKcVRmywBOydf6neO+UY5ix+hJCpR4bIM2XwuhMJDY8dxEC3sATo
+        8vm8keL/nhyzz/KHLyGENB8ZKofJ8GURQCywBOzii/9eOUaP8IcrIYS0PmMWgaGxAxnotKwvAa745TL4
+        b4qfENLRyNA5XIbwZ8WOsUMZ6KQsLgHuZ/zyfX9NjsFn+8OREEI6HxlCB1er1T83xvRqAxpot6wsAVL8
+        Zfle/5PiJ4TEKjKU9pUl4CIxXxvSQDuleQkoFov5crl8uxxjB/nDjRBC4hkZyK8XPxXVxoAG2i1NS4A7
+        c58U/3op/o9K8e/jDy1CCElGZHi90BhzpwznUnRYA+2Q9CXAn6t/oXwfb/CHESGEJDdyD+ZoGc5/L7aN
+        HdZAOyRxCXA/3w+C4DtyrBzjDxtCCElPZLgdaIy5VIb0DLFz7NAGWikJS4B7mF9Kv1++1k/JsXGIP0wI
+        ISTdqVQqp8gycIcM68Ho8AZaIa5LgNzbf0q+tplhGJ7tDwdCCMle5J7PM2UQfliWgXkytHlUAC0VlyXA
+        P6lvgyy+fyO3+Wf4mz8hhBAXGYzPk6F9kywDfdFBDkxVN5cAKf1A8kMp/pf4mzkhhJDxIouAO6fAW2R4
+        3yPcS5qqgx2YqE4uAe4UvaVS6WEp/YvdbdnfrAkhhEwmMkAPlmXgIhni94rK2KEOTEY7lwD3EL+U/hop
+        fff6+4f6my8hhJBWRAbrkTLIrxazhGkMdmCiWrkE+N/Zd6X/GbltTvc3U0IIIe2MG7juNQhkqN8neGQA
+        E9bMEtB4Ml+5XL5NboP8zj4hhHQzMogPl2XgMhnu/y3yY4c9oJnMEuB/bW+R3NP/uNzWeCEeQgiJY2RA
+        7ycD/vXuHANiWXTwAw3jLQH5fN79PD8nfz8jDMP3yG3qQH/zIoQQkpTIvbaXyrC/XvxK8BsFeJrGEiCl
+        Xy0WiyuDIPhHuc2c4m8+hBBC0hB3T06G/jnGmNvFY/JnnkiYXXITMAvEbeI87uUTQkiGIkP/UBn+50oZ
+        3Czc6xPwZML0coW/UNwpLpXrnmftE0IIqccvBOeLW6QwfiNGxhQIkmVY/J+4Wa7Pc+W6faa/mgkhhJA9
+        R0pj30qlcmoYhh+RErlb/E4KJfQFg/gI5bpZLL7qXldCrrOXyXW3j78aCSGEkOYjxXKAlMzL3TkIpHDc
+        w8kPSgEVIoWE9inIZb5Q3n5HXCdeL9cJL6VLCCGkO5ESOl6KyT2f4Dp56x4tcIsB5ySYurJchkvlrTsF
+        tHsY/1K3eLlHZfxFTgghhMQz7mFo8TwprzdKeV0hb++QMvtvebtY3rIcPPVUzl8WP5a3X3CXkfz5HLnM
+        nusuO38xEkIIIemKlNwRUnqvkPK7UIrvL+Tt5+Wte2h7pvx5ibzdKqpCK884c1/zVv89zBTf8d/bNe57
+        dd+zfO+H+4uBEEIIIdFIUe4njvWLwpvEu/095Rvkz+532O+SP7uXTf6JmCH//YBwv+62XKyR/zcohsYI
+        RLSw3f8b+z6D7t/6j+E+1jz5f+7XJN3nuEf++y5xm/z5BvlaLpc/v0u8yRf7sYKH6QmJdaZN+/8+YwH/
+        IzzUEwAAAABJRU5ErkJggg==
+</value>
+  </data>
+</root>

--- a/Vistas/frmPrincipal.cs
+++ b/Vistas/frmPrincipal.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+//using MrTiendita.Controladores;
+
+namespace VistasMrTiendita
+{
+    public partial class frmPrincipal : Form
+    {
+        private Form formActivado = null;
+        public frmPrincipal()
+        {
+            InitializeComponent();
+            personalizarDiseno();
+            //frmPrincipalController controlador = new frmPrincipalController(this);
+        }
+
+        private void personalizarDiseno()
+        {
+            pnl_OpCajero.Visible = false;
+            pnl_OpEncargado.Visible = false;
+        }
+
+        private void hideSubMenu()
+        {
+            if (pnl_OpCajero.Visible == true)
+                pnl_OpCajero.Visible = false;
+            if (pnl_OpEncargado.Visible == true)
+                pnl_OpEncargado.Visible = false;
+        }
+
+        private void showSubMenu(Panel subMenu)
+        {
+            if (subMenu.Visible == false)
+            {
+                //hideSubMenu();
+                subMenu.Visible = true;
+                btn_Cajero.Normalcolor = Color.FromArgb(240, 240, 240);
+                btn_Encargado.Normalcolor = Color.FromArgb(240, 240, 240);
+            }
+            else
+                subMenu.Visible = false;
+                
+        }
+
+        private void ColorGris()
+        {
+            btn_CAlmacen.Normalcolor = Color.FromArgb(240, 240, 240);
+            btn_EAlmacen.Normalcolor = Color.FromArgb(240, 240, 240);
+            btn_EReportes.Normalcolor = Color.FromArgb(240, 240, 240);
+            btn_EProveedores.Normalcolor = Color.FromArgb(240, 240, 240);
+            btn_EAlmacen.Normalcolor = Color.FromArgb(240, 240, 240);
+        }
+
+        private void frmPrincipal_Load(object sender, EventArgs e)
+        {
+  
+        }
+
+        private void btn_Cajero_Click(object sender, EventArgs e)
+        {
+            hideSubMenu();
+            showSubMenu(pnl_OpCajero);
+            btn_Cajero.Normalcolor = Color.FromArgb(4, 208, 217);
+        }
+
+        private void btn_Encargado_Click(object sender, EventArgs e)
+        {
+            hideSubMenu();
+            showSubMenu(pnl_OpEncargado);
+            btn_Encargado.Normalcolor = Color.FromArgb(4, 208, 217);
+        }
+        
+        private void AbrirFormulario(Form FormHijo)
+        {
+            if (formActivado != null)
+                formActivado.Close();
+            formActivado = FormHijo;
+            FormHijo.TopLevel = false;
+            FormHijo.Dock = DockStyle.Fill;
+            Contenedor.Controls.Add(FormHijo);
+            Contenedor.Tag = FormHijo;
+            FormHijo.BringToFront();
+            FormHijo.Show();
+        }
+
+        private void btn_EReportes_Click(object sender, EventArgs e)
+        {
+            ColorGris();
+            btn_EReportes.Normalcolor = Color.FromArgb(218, 238, 86);
+            AbrirFormulario(new frmReportes());
+        }
+
+        private void btn_CAlmacen_Click(object sender, EventArgs e)
+        {
+            ColorGris();
+            btn_CAlmacen.Normalcolor = Color.FromArgb(218, 238, 86);
+            AbrirFormulario(new frmCAlmacen());
+        }
+
+        private void btn_CCaja_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void btn_EAlmacen_Click(object sender, EventArgs e)
+        {
+            ColorGris();
+            btn_EAlmacen.Normalcolor = Color.FromArgb(218, 238, 86);
+            AbrirFormulario(new frmEAlmacen());
+        }
+
+        private void btn_EProveedores_Click(object sender, EventArgs e)
+        {
+            ColorGris();
+            btn_EProveedores.Normalcolor = Color.FromArgb(218, 238, 86);
+            AbrirFormulario(new frmProveedores());
+        }
+
+        private void btn_EEmpleados_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void btn_ECaja_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void btn_CVentas_Click(object sender, EventArgs e)
+        {
+
+        }
+
+        private void btn_Cerrar_Click(object sender, EventArgs e)
+        {
+            DialogResult resultado = new DialogResult();
+            Form mensaje = new frmAdvertencia("Saldrá del sistema");
+            resultado = mensaje.ShowDialog();
+
+            if (resultado == DialogResult.OK)
+            {
+                Application.Exit();
+            }
+           
+        }
+    }
+}

--- a/Vistas/frmPrincipal.designer.cs
+++ b/Vistas/frmPrincipal.designer.cs
@@ -1,0 +1,601 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmPrincipal
+    {
+        /// <summary>
+        /// Variable del diseñador necesaria.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Limpiar los recursos que se estén usando.
+        /// </summary>
+        /// <param name="disposing">true si los recursos administrados se deben desechar; false en caso contrario.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Código generado por el Diseñador de Windows Forms
+
+        /// <summary>
+        /// Método necesario para admitir el Diseñador. No se puede modificar
+        /// el contenido de este método con el editor de código.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmPrincipal));
+            this.MenuLateral = new System.Windows.Forms.Panel();
+            this.pnl_OpEncargado = new System.Windows.Forms.Panel();
+            this.btn_EAlmacen = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.btn_EReportes = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.btn_EProveedores = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.btn_ECaja = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.btn_EEmpleados = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.pnl_Encargado = new System.Windows.Forms.Panel();
+            this.btn_Encargado = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.pnl_OpCajero = new System.Windows.Forms.Panel();
+            this.btn_CCaja = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.btn_CVentas = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.btn_CAlmacen = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.pnl_Cajero = new System.Windows.Forms.Panel();
+            this.btn_Cajero = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.pnl_Logo = new System.Windows.Forms.Panel();
+            this.pBox_Logo = new System.Windows.Forms.PictureBox();
+            this.btn_Cerrar = new System.Windows.Forms.PictureBox();
+            this.Contenedor = new System.Windows.Forms.Panel();
+            this.Header = new System.Windows.Forms.Panel();
+            this.MenuLateral.SuspendLayout();
+            this.pnl_OpEncargado.SuspendLayout();
+            this.pnl_Encargado.SuspendLayout();
+            this.pnl_OpCajero.SuspendLayout();
+            this.pnl_Cajero.SuspendLayout();
+            this.pnl_Logo.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pBox_Logo)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.btn_Cerrar)).BeginInit();
+            this.Header.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // MenuLateral
+            // 
+            this.MenuLateral.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.MenuLateral.Controls.Add(this.pnl_OpEncargado);
+            this.MenuLateral.Controls.Add(this.pnl_Encargado);
+            this.MenuLateral.Controls.Add(this.pnl_OpCajero);
+            this.MenuLateral.Controls.Add(this.pnl_Cajero);
+            this.MenuLateral.Controls.Add(this.pnl_Logo);
+            this.MenuLateral.Dock = System.Windows.Forms.DockStyle.Left;
+            this.MenuLateral.Location = new System.Drawing.Point(0, 0);
+            this.MenuLateral.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.MenuLateral.Name = "MenuLateral";
+            this.MenuLateral.Size = new System.Drawing.Size(236, 788);
+            this.MenuLateral.TabIndex = 0;
+            // 
+            // pnl_OpEncargado
+            // 
+            this.pnl_OpEncargado.Controls.Add(this.btn_EAlmacen);
+            this.pnl_OpEncargado.Controls.Add(this.btn_EReportes);
+            this.pnl_OpEncargado.Controls.Add(this.btn_EProveedores);
+            this.pnl_OpEncargado.Controls.Add(this.btn_ECaja);
+            this.pnl_OpEncargado.Controls.Add(this.btn_EEmpleados);
+            this.pnl_OpEncargado.Dock = System.Windows.Forms.DockStyle.Top;
+            this.pnl_OpEncargado.Location = new System.Drawing.Point(0, 507);
+            this.pnl_OpEncargado.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pnl_OpEncargado.Name = "pnl_OpEncargado";
+            this.pnl_OpEncargado.Size = new System.Drawing.Size(236, 386);
+            this.pnl_OpEncargado.TabIndex = 10;
+            // 
+            // btn_EAlmacen
+            // 
+            this.btn_EAlmacen.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_EAlmacen.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_EAlmacen.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_EAlmacen.BorderRadius = 7;
+            this.btn_EAlmacen.ButtonText = "             Almacén";
+            this.btn_EAlmacen.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_EAlmacen.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_EAlmacen.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_EAlmacen.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_EAlmacen.Iconimage = ((System.Drawing.Image)(resources.GetObject("btn_EAlmacen.Iconimage")));
+            this.btn_EAlmacen.Iconimage_right = null;
+            this.btn_EAlmacen.Iconimage_right_Selected = null;
+            this.btn_EAlmacen.Iconimage_Selected = null;
+            this.btn_EAlmacen.IconMarginLeft = 0;
+            this.btn_EAlmacen.IconMarginRight = 0;
+            this.btn_EAlmacen.IconRightVisible = true;
+            this.btn_EAlmacen.IconRightZoom = 0D;
+            this.btn_EAlmacen.IconVisible = true;
+            this.btn_EAlmacen.IconZoom = 45D;
+            this.btn_EAlmacen.IsTab = false;
+            this.btn_EAlmacen.Location = new System.Drawing.Point(11, 9);
+            this.btn_EAlmacen.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_EAlmacen.Name = "btn_EAlmacen";
+            this.btn_EAlmacen.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_EAlmacen.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_EAlmacen.OnHoverTextColor = System.Drawing.Color.Black;
+            this.btn_EAlmacen.selected = false;
+            this.btn_EAlmacen.Size = new System.Drawing.Size(209, 64);
+            this.btn_EAlmacen.TabIndex = 5;
+            this.btn_EAlmacen.Text = "             Almacén";
+            this.btn_EAlmacen.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btn_EAlmacen.Textcolor = System.Drawing.Color.Black;
+            this.btn_EAlmacen.TextFont = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_EAlmacen.Click += new System.EventHandler(this.btn_EAlmacen_Click);
+            // 
+            // btn_EReportes
+            // 
+            this.btn_EReportes.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_EReportes.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_EReportes.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_EReportes.BorderRadius = 7;
+            this.btn_EReportes.ButtonText = "             Reportes";
+            this.btn_EReportes.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_EReportes.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_EReportes.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_EReportes.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_EReportes.Iconimage = ((System.Drawing.Image)(resources.GetObject("btn_EReportes.Iconimage")));
+            this.btn_EReportes.Iconimage_right = null;
+            this.btn_EReportes.Iconimage_right_Selected = null;
+            this.btn_EReportes.Iconimage_Selected = null;
+            this.btn_EReportes.IconMarginLeft = 0;
+            this.btn_EReportes.IconMarginRight = 0;
+            this.btn_EReportes.IconRightVisible = true;
+            this.btn_EReportes.IconRightZoom = 0D;
+            this.btn_EReportes.IconVisible = true;
+            this.btn_EReportes.IconZoom = 45D;
+            this.btn_EReportes.IsTab = false;
+            this.btn_EReportes.Location = new System.Drawing.Point(11, 313);
+            this.btn_EReportes.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_EReportes.Name = "btn_EReportes";
+            this.btn_EReportes.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_EReportes.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_EReportes.OnHoverTextColor = System.Drawing.Color.Black;
+            this.btn_EReportes.selected = false;
+            this.btn_EReportes.Size = new System.Drawing.Size(209, 64);
+            this.btn_EReportes.TabIndex = 9;
+            this.btn_EReportes.Text = "             Reportes";
+            this.btn_EReportes.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btn_EReportes.Textcolor = System.Drawing.Color.Black;
+            this.btn_EReportes.TextFont = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_EReportes.Click += new System.EventHandler(this.btn_EReportes_Click);
+            // 
+            // btn_EProveedores
+            // 
+            this.btn_EProveedores.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_EProveedores.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_EProveedores.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_EProveedores.BorderRadius = 7;
+            this.btn_EProveedores.ButtonText = "             Proveedores";
+            this.btn_EProveedores.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_EProveedores.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_EProveedores.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_EProveedores.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_EProveedores.Iconimage = ((System.Drawing.Image)(resources.GetObject("btn_EProveedores.Iconimage")));
+            this.btn_EProveedores.Iconimage_right = null;
+            this.btn_EProveedores.Iconimage_right_Selected = null;
+            this.btn_EProveedores.Iconimage_Selected = null;
+            this.btn_EProveedores.IconMarginLeft = 0;
+            this.btn_EProveedores.IconMarginRight = 0;
+            this.btn_EProveedores.IconRightVisible = true;
+            this.btn_EProveedores.IconRightZoom = 0D;
+            this.btn_EProveedores.IconVisible = true;
+            this.btn_EProveedores.IconZoom = 45D;
+            this.btn_EProveedores.IsTab = false;
+            this.btn_EProveedores.Location = new System.Drawing.Point(11, 85);
+            this.btn_EProveedores.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_EProveedores.Name = "btn_EProveedores";
+            this.btn_EProveedores.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_EProveedores.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_EProveedores.OnHoverTextColor = System.Drawing.Color.Black;
+            this.btn_EProveedores.selected = false;
+            this.btn_EProveedores.Size = new System.Drawing.Size(209, 64);
+            this.btn_EProveedores.TabIndex = 6;
+            this.btn_EProveedores.Text = "             Proveedores";
+            this.btn_EProveedores.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btn_EProveedores.Textcolor = System.Drawing.Color.Black;
+            this.btn_EProveedores.TextFont = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_EProveedores.Click += new System.EventHandler(this.btn_EProveedores_Click);
+            // 
+            // btn_ECaja
+            // 
+            this.btn_ECaja.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_ECaja.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_ECaja.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_ECaja.BorderRadius = 7;
+            this.btn_ECaja.ButtonText = "             Caja";
+            this.btn_ECaja.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_ECaja.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_ECaja.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_ECaja.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_ECaja.Iconimage = ((System.Drawing.Image)(resources.GetObject("btn_ECaja.Iconimage")));
+            this.btn_ECaja.Iconimage_right = null;
+            this.btn_ECaja.Iconimage_right_Selected = null;
+            this.btn_ECaja.Iconimage_Selected = null;
+            this.btn_ECaja.IconMarginLeft = 0;
+            this.btn_ECaja.IconMarginRight = 0;
+            this.btn_ECaja.IconRightVisible = true;
+            this.btn_ECaja.IconRightZoom = 0D;
+            this.btn_ECaja.IconVisible = true;
+            this.btn_ECaja.IconZoom = 45D;
+            this.btn_ECaja.IsTab = false;
+            this.btn_ECaja.Location = new System.Drawing.Point(11, 236);
+            this.btn_ECaja.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_ECaja.Name = "btn_ECaja";
+            this.btn_ECaja.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_ECaja.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_ECaja.OnHoverTextColor = System.Drawing.Color.Black;
+            this.btn_ECaja.selected = false;
+            this.btn_ECaja.Size = new System.Drawing.Size(209, 64);
+            this.btn_ECaja.TabIndex = 8;
+            this.btn_ECaja.Text = "             Caja";
+            this.btn_ECaja.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btn_ECaja.Textcolor = System.Drawing.Color.Black;
+            this.btn_ECaja.TextFont = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_ECaja.Click += new System.EventHandler(this.btn_ECaja_Click);
+            // 
+            // btn_EEmpleados
+            // 
+            this.btn_EEmpleados.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_EEmpleados.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_EEmpleados.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_EEmpleados.BorderRadius = 7;
+            this.btn_EEmpleados.ButtonText = "             Empleados";
+            this.btn_EEmpleados.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_EEmpleados.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_EEmpleados.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_EEmpleados.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_EEmpleados.Iconimage = ((System.Drawing.Image)(resources.GetObject("btn_EEmpleados.Iconimage")));
+            this.btn_EEmpleados.Iconimage_right = null;
+            this.btn_EEmpleados.Iconimage_right_Selected = null;
+            this.btn_EEmpleados.Iconimage_Selected = null;
+            this.btn_EEmpleados.IconMarginLeft = 0;
+            this.btn_EEmpleados.IconMarginRight = 0;
+            this.btn_EEmpleados.IconRightVisible = true;
+            this.btn_EEmpleados.IconRightZoom = 0D;
+            this.btn_EEmpleados.IconVisible = true;
+            this.btn_EEmpleados.IconZoom = 45D;
+            this.btn_EEmpleados.IsTab = false;
+            this.btn_EEmpleados.Location = new System.Drawing.Point(11, 161);
+            this.btn_EEmpleados.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_EEmpleados.Name = "btn_EEmpleados";
+            this.btn_EEmpleados.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_EEmpleados.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_EEmpleados.OnHoverTextColor = System.Drawing.Color.Black;
+            this.btn_EEmpleados.selected = false;
+            this.btn_EEmpleados.Size = new System.Drawing.Size(209, 64);
+            this.btn_EEmpleados.TabIndex = 7;
+            this.btn_EEmpleados.Text = "             Empleados";
+            this.btn_EEmpleados.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btn_EEmpleados.Textcolor = System.Drawing.Color.Black;
+            this.btn_EEmpleados.TextFont = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_EEmpleados.Click += new System.EventHandler(this.btn_EEmpleados_Click);
+            // 
+            // pnl_Encargado
+            // 
+            this.pnl_Encargado.Controls.Add(this.btn_Encargado);
+            this.pnl_Encargado.Dock = System.Windows.Forms.DockStyle.Top;
+            this.pnl_Encargado.Location = new System.Drawing.Point(0, 436);
+            this.pnl_Encargado.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pnl_Encargado.Name = "pnl_Encargado";
+            this.pnl_Encargado.Size = new System.Drawing.Size(236, 71);
+            this.pnl_Encargado.TabIndex = 0;
+            // 
+            // btn_Encargado
+            // 
+            this.btn_Encargado.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(4)))), ((int)(((byte)(208)))), ((int)(((byte)(217)))));
+            this.btn_Encargado.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_Encargado.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_Encargado.BorderRadius = 7;
+            this.btn_Encargado.ButtonText = "             Encargado";
+            this.btn_Encargado.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_Encargado.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_Encargado.Font = new System.Drawing.Font("Roboto Medium", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_Encargado.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_Encargado.Iconimage = ((System.Drawing.Image)(resources.GetObject("btn_Encargado.Iconimage")));
+            this.btn_Encargado.Iconimage_right = null;
+            this.btn_Encargado.Iconimage_right_Selected = null;
+            this.btn_Encargado.Iconimage_Selected = null;
+            this.btn_Encargado.IconMarginLeft = 0;
+            this.btn_Encargado.IconMarginRight = 0;
+            this.btn_Encargado.IconRightVisible = true;
+            this.btn_Encargado.IconRightZoom = 0D;
+            this.btn_Encargado.IconVisible = true;
+            this.btn_Encargado.IconZoom = 40D;
+            this.btn_Encargado.IsTab = false;
+            this.btn_Encargado.Location = new System.Drawing.Point(13, 4);
+            this.btn_Encargado.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_Encargado.Name = "btn_Encargado";
+            this.btn_Encargado.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_Encargado.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.btn_Encargado.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_Encargado.selected = false;
+            this.btn_Encargado.Size = new System.Drawing.Size(205, 64);
+            this.btn_Encargado.TabIndex = 1;
+            this.btn_Encargado.Text = "             Encargado";
+            this.btn_Encargado.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btn_Encargado.Textcolor = System.Drawing.Color.Black;
+            this.btn_Encargado.TextFont = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_Encargado.Click += new System.EventHandler(this.btn_Encargado_Click);
+            // 
+            // pnl_OpCajero
+            // 
+            this.pnl_OpCajero.Controls.Add(this.btn_CCaja);
+            this.pnl_OpCajero.Controls.Add(this.btn_CVentas);
+            this.pnl_OpCajero.Controls.Add(this.btn_CAlmacen);
+            this.pnl_OpCajero.Dock = System.Windows.Forms.DockStyle.Top;
+            this.pnl_OpCajero.Location = new System.Drawing.Point(0, 200);
+            this.pnl_OpCajero.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pnl_OpCajero.Name = "pnl_OpCajero";
+            this.pnl_OpCajero.Size = new System.Drawing.Size(236, 236);
+            this.pnl_OpCajero.TabIndex = 6;
+            // 
+            // btn_CCaja
+            // 
+            this.btn_CCaja.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_CCaja.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_CCaja.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_CCaja.BorderRadius = 7;
+            this.btn_CCaja.ButtonText = "             Caja";
+            this.btn_CCaja.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_CCaja.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_CCaja.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_CCaja.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_CCaja.Iconimage = ((System.Drawing.Image)(resources.GetObject("btn_CCaja.Iconimage")));
+            this.btn_CCaja.Iconimage_right = null;
+            this.btn_CCaja.Iconimage_right_Selected = null;
+            this.btn_CCaja.Iconimage_Selected = null;
+            this.btn_CCaja.IconMarginLeft = 0;
+            this.btn_CCaja.IconMarginRight = 0;
+            this.btn_CCaja.IconRightVisible = true;
+            this.btn_CCaja.IconRightZoom = 0D;
+            this.btn_CCaja.IconVisible = true;
+            this.btn_CCaja.IconZoom = 45D;
+            this.btn_CCaja.IsTab = false;
+            this.btn_CCaja.Location = new System.Drawing.Point(13, 161);
+            this.btn_CCaja.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_CCaja.Name = "btn_CCaja";
+            this.btn_CCaja.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_CCaja.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_CCaja.OnHoverTextColor = System.Drawing.Color.Black;
+            this.btn_CCaja.selected = false;
+            this.btn_CCaja.Size = new System.Drawing.Size(209, 64);
+            this.btn_CCaja.TabIndex = 5;
+            this.btn_CCaja.Text = "             Caja";
+            this.btn_CCaja.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btn_CCaja.Textcolor = System.Drawing.Color.Black;
+            this.btn_CCaja.TextFont = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_CCaja.Click += new System.EventHandler(this.btn_CCaja_Click);
+            // 
+            // btn_CVentas
+            // 
+            this.btn_CVentas.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_CVentas.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_CVentas.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_CVentas.BorderRadius = 7;
+            this.btn_CVentas.ButtonText = "             Ventas";
+            this.btn_CVentas.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_CVentas.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_CVentas.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_CVentas.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_CVentas.Iconimage = ((System.Drawing.Image)(resources.GetObject("btn_CVentas.Iconimage")));
+            this.btn_CVentas.Iconimage_right = null;
+            this.btn_CVentas.Iconimage_right_Selected = null;
+            this.btn_CVentas.Iconimage_Selected = null;
+            this.btn_CVentas.IconMarginLeft = 0;
+            this.btn_CVentas.IconMarginRight = 0;
+            this.btn_CVentas.IconRightVisible = true;
+            this.btn_CVentas.IconRightZoom = 0D;
+            this.btn_CVentas.IconVisible = true;
+            this.btn_CVentas.IconZoom = 45D;
+            this.btn_CVentas.IsTab = false;
+            this.btn_CVentas.Location = new System.Drawing.Point(13, 9);
+            this.btn_CVentas.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_CVentas.Name = "btn_CVentas";
+            this.btn_CVentas.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_CVentas.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_CVentas.OnHoverTextColor = System.Drawing.Color.Black;
+            this.btn_CVentas.selected = false;
+            this.btn_CVentas.Size = new System.Drawing.Size(209, 64);
+            this.btn_CVentas.TabIndex = 3;
+            this.btn_CVentas.Text = "             Ventas";
+            this.btn_CVentas.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btn_CVentas.Textcolor = System.Drawing.Color.Black;
+            this.btn_CVentas.TextFont = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_CVentas.Click += new System.EventHandler(this.btn_CVentas_Click);
+            // 
+            // btn_CAlmacen
+            // 
+            this.btn_CAlmacen.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_CAlmacen.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_CAlmacen.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_CAlmacen.BorderRadius = 7;
+            this.btn_CAlmacen.ButtonText = "             Almacén";
+            this.btn_CAlmacen.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_CAlmacen.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_CAlmacen.Font = new System.Drawing.Font("Roboto", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_CAlmacen.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_CAlmacen.Iconimage = ((System.Drawing.Image)(resources.GetObject("btn_CAlmacen.Iconimage")));
+            this.btn_CAlmacen.Iconimage_right = null;
+            this.btn_CAlmacen.Iconimage_right_Selected = null;
+            this.btn_CAlmacen.Iconimage_Selected = null;
+            this.btn_CAlmacen.IconMarginLeft = 0;
+            this.btn_CAlmacen.IconMarginRight = 0;
+            this.btn_CAlmacen.IconRightVisible = true;
+            this.btn_CAlmacen.IconRightZoom = 0D;
+            this.btn_CAlmacen.IconVisible = true;
+            this.btn_CAlmacen.IconZoom = 45D;
+            this.btn_CAlmacen.IsTab = false;
+            this.btn_CAlmacen.Location = new System.Drawing.Point(13, 85);
+            this.btn_CAlmacen.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_CAlmacen.Name = "btn_CAlmacen";
+            this.btn_CAlmacen.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_CAlmacen.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_CAlmacen.OnHoverTextColor = System.Drawing.Color.Black;
+            this.btn_CAlmacen.selected = false;
+            this.btn_CAlmacen.Size = new System.Drawing.Size(209, 64);
+            this.btn_CAlmacen.TabIndex = 4;
+            this.btn_CAlmacen.Text = "             Almacén";
+            this.btn_CAlmacen.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btn_CAlmacen.Textcolor = System.Drawing.Color.Black;
+            this.btn_CAlmacen.TextFont = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_CAlmacen.Click += new System.EventHandler(this.btn_CAlmacen_Click);
+            // 
+            // pnl_Cajero
+            // 
+            this.pnl_Cajero.Controls.Add(this.btn_Cajero);
+            this.pnl_Cajero.Dock = System.Windows.Forms.DockStyle.Top;
+            this.pnl_Cajero.Location = new System.Drawing.Point(0, 129);
+            this.pnl_Cajero.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pnl_Cajero.Name = "pnl_Cajero";
+            this.pnl_Cajero.Size = new System.Drawing.Size(236, 71);
+            this.pnl_Cajero.TabIndex = 6;
+            // 
+            // btn_Cajero
+            // 
+            this.btn_Cajero.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(4)))), ((int)(((byte)(208)))), ((int)(((byte)(217)))));
+            this.btn_Cajero.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_Cajero.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_Cajero.BorderRadius = 7;
+            this.btn_Cajero.ButtonText = "             Cajero";
+            this.btn_Cajero.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_Cajero.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_Cajero.Font = new System.Drawing.Font("Roboto Medium", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_Cajero.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_Cajero.Iconimage = ((System.Drawing.Image)(resources.GetObject("btn_Cajero.Iconimage")));
+            this.btn_Cajero.Iconimage_right = null;
+            this.btn_Cajero.Iconimage_right_Selected = null;
+            this.btn_Cajero.Iconimage_Selected = null;
+            this.btn_Cajero.IconMarginLeft = 0;
+            this.btn_Cajero.IconMarginRight = 0;
+            this.btn_Cajero.IconRightVisible = true;
+            this.btn_Cajero.IconRightZoom = 0D;
+            this.btn_Cajero.IconVisible = true;
+            this.btn_Cajero.IconZoom = 40D;
+            this.btn_Cajero.IsTab = false;
+            this.btn_Cajero.Location = new System.Drawing.Point(13, 4);
+            this.btn_Cajero.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_Cajero.Name = "btn_Cajero";
+            this.btn_Cajero.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.btn_Cajero.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.btn_Cajero.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_Cajero.selected = false;
+            this.btn_Cajero.Size = new System.Drawing.Size(205, 64);
+            this.btn_Cajero.TabIndex = 0;
+            this.btn_Cajero.Text = "             Cajero";
+            this.btn_Cajero.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.btn_Cajero.Textcolor = System.Drawing.Color.Black;
+            this.btn_Cajero.TextFont = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_Cajero.Click += new System.EventHandler(this.btn_Cajero_Click);
+            // 
+            // pnl_Logo
+            // 
+            this.pnl_Logo.Controls.Add(this.pBox_Logo);
+            this.pnl_Logo.Dock = System.Windows.Forms.DockStyle.Top;
+            this.pnl_Logo.Location = new System.Drawing.Point(0, 0);
+            this.pnl_Logo.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pnl_Logo.Name = "pnl_Logo";
+            this.pnl_Logo.Size = new System.Drawing.Size(236, 129);
+            this.pnl_Logo.TabIndex = 3;
+            // 
+            // pBox_Logo
+            // 
+            this.pBox_Logo.Image = ((System.Drawing.Image)(resources.GetObject("pBox_Logo.Image")));
+            this.pBox_Logo.Location = new System.Drawing.Point(93, 34);
+            this.pBox_Logo.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pBox_Logo.Name = "pBox_Logo";
+            this.pBox_Logo.Size = new System.Drawing.Size(48, 48);
+            this.pBox_Logo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pBox_Logo.TabIndex = 0;
+            this.pBox_Logo.TabStop = false;
+            // 
+            // btn_Cerrar
+            // 
+            this.btn_Cerrar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btn_Cerrar.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_Cerrar.Image = ((System.Drawing.Image)(resources.GetObject("btn_Cerrar.Image")));
+            this.btn_Cerrar.Location = new System.Drawing.Point(1109, 6);
+            this.btn_Cerrar.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.btn_Cerrar.Name = "btn_Cerrar";
+            this.btn_Cerrar.Size = new System.Drawing.Size(35, 32);
+            this.btn_Cerrar.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.btn_Cerrar.TabIndex = 0;
+            this.btn_Cerrar.TabStop = false;
+            this.btn_Cerrar.Click += new System.EventHandler(this.btn_Cerrar_Click);
+            // 
+            // Contenedor
+            // 
+            this.Contenedor.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Contenedor.Location = new System.Drawing.Point(236, 44);
+            this.Contenedor.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Contenedor.Name = "Contenedor";
+            this.Contenedor.Size = new System.Drawing.Size(1151, 744);
+            this.Contenedor.TabIndex = 2;
+            // 
+            // Header
+            // 
+            this.Header.Controls.Add(this.btn_Cerrar);
+            this.Header.Dock = System.Windows.Forms.DockStyle.Top;
+            this.Header.Location = new System.Drawing.Point(236, 0);
+            this.Header.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Header.Name = "Header";
+            this.Header.Size = new System.Drawing.Size(1151, 44);
+            this.Header.TabIndex = 1;
+            // 
+            // frmPrincipal
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.ClientSize = new System.Drawing.Size(1387, 788);
+            this.Controls.Add(this.Contenedor);
+            this.Controls.Add(this.Header);
+            this.Controls.Add(this.MenuLateral);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Name = "frmPrincipal";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Form1";
+            this.Load += new System.EventHandler(this.frmPrincipal_Load);
+            this.MenuLateral.ResumeLayout(false);
+            this.pnl_OpEncargado.ResumeLayout(false);
+            this.pnl_Encargado.ResumeLayout(false);
+            this.pnl_OpCajero.ResumeLayout(false);
+            this.pnl_Cajero.ResumeLayout(false);
+            this.pnl_Logo.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.pBox_Logo)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.btn_Cerrar)).EndInit();
+            this.Header.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel MenuLateral;
+        private System.Windows.Forms.Panel Contenedor;
+        private System.Windows.Forms.Panel pnl_Logo;
+        private System.Windows.Forms.Panel pnl_Cajero;
+        private System.Windows.Forms.Panel pnl_Encargado;
+        private System.Windows.Forms.Panel pnl_OpEncargado;
+        private Bunifu.Framework.UI.BunifuFlatButton btn_EReportes;
+        private System.Windows.Forms.Panel Header;
+        public System.Windows.Forms.PictureBox btn_Cerrar;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_Cajero;
+        public System.Windows.Forms.PictureBox pBox_Logo;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_CCaja;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_CAlmacen;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_CVentas;
+        public System.Windows.Forms.Panel pnl_OpCajero;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_EAlmacen;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_EProveedores;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_ECaja;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_EEmpleados;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_Encargado;
+    }
+}
+

--- a/Vistas/frmPrincipal.resx
+++ b/Vistas/frmPrincipal.resx
@@ -1,0 +1,871 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="btn_Encargado.Iconimage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAIJJREFUSEvt0+ENQDAYhOGOYAQj2IwN2MAqRrCJEYzAHU5EhPZr/0j6JpeoxBM/
+        cLl/12D1fpmk05uxBWt5iIwGrYmHCkuBC6VFcysWf0SVFX9FVSjuhSpfPAhVX7gJVXec5xLrj3smVPFB
+        fpOEruM9M6r4lvybRmzAOqzAcrmgnFsBqaQ0KRAoL8IAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="btn_Cajero.Iconimage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAIJJREFUSEvt0+ENQDAYhOGOYAQj2IwN2MAqRrCJEYzAHU5EhPZr/0j6JpeoxBM/
+        cLl/12D1fpmk05uxBWt5iIwGrYmHCkuBC6VFcysWf0SVFX9FVSjuhSpfPAhVX7gJVXec5xLrj3smVPFB
+        fpOEruM9M6r4lvybRmzAOqzAcrmgnFsBqaQ0KRAoL8IAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="btn_EAlmacen.Iconimage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAZ1JREFUaEPtmT0vBFEUhqcQhYooKYho/AoJhdIvUCh1REEiaLbxAxQiOn9AdKJV
+        aBQalY9IRBS+QjQSnnezZ7Nk187Mnc2dlfMkT7En95x739m902ySgQV8wa8O+4FzWCgT+IbNNuyErziO
+        hTCEV6jB76hvIo3baAfaqtXauYE6vHpucBCDOUY7yLIKKZlC65tUISVLaH2HKoSwiTZMTzELeQOIHbTe
+        igp5mEcbcoY9mIWQAL14jtY/i5kYwXtU83Xtc1ZCAogxvEP1P+IopmIA7dJKHSQPoQHENNqMS+zHthyg
+        Na2rkJMiAohFtDl7KvzFGtpivQZDKCqAaHyoLd+E2sQW6evqwxCKDKCfjs6kWZ84gz/QJb1FLdCFyXNp
+        f1NkAKFL/ISa94DDWOcCbbNn1CUOVW8vm6mNm63JqgWQJ1hFbx0rdptVGgOcom56mdUZWwZYUaHkrKIH
+        iIkHiI0HiI0HiI0HiI0HiI0HiI0HiI0HiI0HiI0HiI0HiI0HiI0HiM3/DnCE+nO7zOqMLQN0m3X2sdmC
+        MrubJEnyDZbZFjwN8H8tAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="btn_EReportes.Iconimage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAZJJREFUaEPtmk8rBlEUh6+VnXwEX0Ap2Si9G1b2srOzk2JL78aHkBRLW0oosbFU
+        VnwH+Zeys+D3m4zOXHd0TVfn0HnqWcx5Z2738S/vzBsEM/Ac3sO3hC9wFeYyAW9haq2uPsETOAsbrMPU
+        BbFcIBd+MVJrlHINVszD1Alt5vLbAXQKhgsxoJtwRbgP5eu5yIBLKNfs6i6UezmG4VkMtjiI4IXyolxk
+        wB4HheAe63X5+/p5QLnZGGsBX/YjDzxA4AEteEAuHtCCB+TiAS0UDRiGy3ADjnAgMB0wBPuQ/17X81e4
+        DesQswHc+EM0i2XIlTg2FdBFswHXcAHyjcXRxyylasASlOfQG8h3cjFj8AzG56sGjMI7yNe58Tk4CL9j
+        Eh7Aet1FWIofBxD+ZeFdhoHqKB+G8LtSkk4BlvAAbTxAGw/QxgO08QBtPEAbD9DGA7TxAG3+X0B9x4Hy
+        GbF15LNi7r1xD5PuQFZaNH7QzZtpYVoM/prjsCL3wx6W5J4b9OApfISpCyzIn/lDWH3II4QQ3gEJx9ER
+        A4pprAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="btn_EProveedores.Iconimage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAkNJREFUaEPt2M1LFVEYx/FbSauKwFYu0oUboXJRBG6sRZuCNuELtOiFWkS1DAxc
+        aFHbiCCIoGyvgQSB/4NgQYs2aUEvphFaJEUb/f6k53K4zeTMOXMbBs8PPuCcOc8zPt7xep1aTExMTExo
+        DuEKrpZgAMFZwGqJ+hAUa7SCxf/IrnsOQSmsUY60IA5gKXuASdxIMYprOIjUlD1AVm+Q+D3ahrIG+ILX
+        KeZg+8xD7EI9dqKsATa67m6cwVtYzTjqydqoyPj8Eu/AE1jdZawnb6Mi4jOAsg2voLp5qE+lBlCOwmpP
+        aMG3UUhCBlDeQ7UPdFDFAR5DtdM6qOIA+gOn2s86qOIAw1Dtbx1UcYDrsPqgRr6JA8Dqgxr5Jg4Aqw9q
+        5Js4AKw+c6NW6MJFZKMBdH4Ptqwf/Z3MA2zHCD5Ce35An8U7EJK0AdpwD0vQuU94hHa4yTSApp+BnXd9
+        xT74JmmAvXD/aXFp3R0i0wC3YOee4SLu4NeftZfQ53OfJA0wAVsbg67n/gMzBUviAN+hW8X8hNafwk0/
+        rMbdn5f10G3pPh28CTe3Yee0T1Rja/X7LU3jK7MTSfuK0g03eqSStE8+oHYY+njaaBnapK/d7Ic10Evd
+        WOfjLqznKbhxX/H7cOt6kZrnUJEGuaQF0oUX0Po36K2uiGzFLNT3HXqgHIGOta7nQrnSiX/dXnp7LTLH
+        kXQdcxK5cwCNb20aagjNyFnYT9y93mkERU8CzmMQetDUzKj/MVyAnjo0+3oxMTExmze12hpVsrl86qT4
+        /AAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="btn_ECaja.Iconimage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABhtJREFUaEPtmQWodEUYhq9iY3eA9YPYgYUdiCgqil3YYmFgodiFYnf8dmIHYrdi
+        YqKCLSp2t2I+z/n3W2bnzu7ZvQt7Fe4LD7tnz5k550y83zezQ2Ma0/9bc8KucArcAW/B+w3egMfgPNgH
+        loT/jNaHR+Bv+KcH3oE9YHIYFc0GD0P+YB/BA3A5nAOnwaXwIDwD+fX20FIwUE0Hb0M8xLtwMMwLdZoR
+        dgBfKMp/C4vCwLQnxM1t4UlgJNoGfHjrsdcGpmvBm95bHfWn48C6fq6OBqRLwJt+Ad0Mm3aaHmIe6VQD
+        07LwO3jjj2F36FVrwotgHXIgDFR7wZ8QD/Ad3Ay7wOqwGOhUM8N8sBxsBRfAhxDlZDyMihaA5yB9mF74
+        FHypUddKcBa8BqUHTfkKroD1YDIYFU0Fjvv5q6NWTQxLwNqwNWwHm4LpwzSQa264DNaojgqaFhx/+8Lx
+        cBFc1eAMOBrsxsWhW+0EtqZRtB8X8mXtDet6yh9SOZFuhAgU3fAenA91D2XdUcaX2AJ61dJg8Ip6ToJK
+        zvqHIE4EJlsfwBPwaIPHofSCf8BR0En2XFrGF3EerAPLg8MsZKQeB547Fkz+0rK3wURQtZwVxYlv4GSw
+        xcxB2mku2BLsTh8+yl8InbQJpPfL+Q1+hHaZqo13AEwBlWI8iXm5SVevshHSLNMJWCdT6uvhc4hy7fgJ
+        TOT2AyNxi34AL7Ir+5EtYoZpXRf7Q0GO4XkmfG2RC5u1wIwzZTNwGOWykQ+BytGiBVz59KPZIYaGkzqX
+        1ui5N6Fkjb3ItYJ1OW8ri/RA/F5qoTqtDK9A1LMR5DKPifOvw4LQq2aC/HmrMfVq4wdx8milBhRjQSlv
+        tyIj6aGgQ0VZ0WnaKXehZ8FYo2FMCbmMugvB9nA7OMGjrI3QNBnHlO6RVh7oMFqpw0Nc/pUc4kvYDerk
+        Iv4TyMuLeU7cRyJ7TXFCm8gNm8xKN9FCYzLW4YsYG1waGr27lQ22I9wPpXpLvAQuZJzwLdI9VpnwtUVO
+        ynXBVNehYuFjwC7XIVaEfHfAVHhjaGfFpdzGYLQqbAva5BHgffR677Mh5K3tsLYnq+hvfuMbHuZBH5oU
+        7HbrOsgfMrmW9dwL1VF/Mh+zrns8MJh4IKYCPkivcvGRTmYnXS6DW5w3KNXlTiWZahhso56rYWgOiJYT
+        J6kxQWcwR2onH1qn0h2irLiv006urNJrb4HNoZOl6jQbwLmQ5mA+c9PybQ2tM61cnKSuXw0+z4PWZUEX
+        5vm1Lg+NjlWC1UEnwC+Ql/8a3Hlzsr4MGomN+Rfk194Jzrdh0vftFldAeaF2GMD09xmgW9lgTlZT8VKd
+        JWx9A9dqMEyzNj5T6Rg6g61q9/liroLOBPcnHT55tqpbGHHb9YLDNZdZrZFbBzodTC6vBNMR7VknKg0x
+        dzmqeRQz2h3gfhXpxM7VUatMzByS7jj3K23d+9znwd2Ng19B7x2JnOxhx2Kr5Uq3Fu3JUm90o/0h6nFL
+        vuqGNCd3ktoby0AnGZBMgR1STuAoX7VKQQ4ro3ZcpxGYdut2zcVJQZZzE/dwSDeHTV2aVqwl+udCnAyc
+        ODqCIf+mBvq9L+m+ZH69FtopVTZh06LzciZp3t/0WFs2Nt3V+E13yq+3IZoPn0pPNrrlBToR7rACdKuF
+        4RpIfb0O548N6dbLMLlVkcrEzCWfLqAjGDl9axfWt4KrNzNPU+rUcaYGc6Re5FpCV9NM3Ln2PmJDmnXu
+        DW5o5T3rPlK1CeBevRO4NPF6lePf1irV5YN+DzZIvwpDsEeaKa3daeY5EtkSZ0N0d+kFNIY4b7Y50j84
+        HOYx/6olpTvC6Vh8EtwucfuuTrqDCWDqYqYc+ZBUDq/UKDQCh8ciUCejvGvq1MV0vuZEdovQCuNkYA5k
+        DxkVTwQjpX9UPA3mSPn1zo/iSqkhG+U6yMt9Brqbw+tUcFGlMTgPfK48HzJncqnZIi3OIeS/HunFdbjf
+        r+Xp593K3TYTslJ9nfAfS9cttX+zuhdjHmQOpPPYdQ4tN1P9fgMcCe6ydWrxOs0CrrjcQA4HcuvSxb7f
+        bRifweVnN0N6TGPqTUND/wJ1hpHTTZ6NwwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="btn_EEmpleados.Iconimage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABCpJREFUaEPtmVvIZlMYxz8MoZyacuNMDskprjQYSYjCBQmJQo1TSbhwocl5xmEY
+        ouaCC4c7h0I5XCinhJCZySlGyUQxDnFh5PD7fc2j513e991r7z3vy1ffv359fWvv51lrv3ut53nW2jPz
+        msM6GM6CK+FqOB0WwzhtCUfAuXAVXAEnwWEwFS2EO2A9/DWC7+ER2AdCh8ND4LVhNvIZLIO9YCK6Dn6E
+        YZ2PYiXcD3+ktia+geths2lneA2GdTZJHgf77qXt4U0onb8Fzvu9YRfwvgPgAngKyvvlT3gRnP/a7QA7
+        gtPrEvgIShvv3wI66z7IDr+Ds6FJR8E6yLYfwzYwThfDD5Dt7oFOOhOyo28hL8wm7QZrIPuomdv2US72
+        o6G13oPs5BBoqz3hKwgfG6BmXi+C3Pcr0EpOgezAsNhV50H25dqpkX1mu4OgWjdBNt4XumoBOP3C17NQ
+        I5NbHkOr0Po8hKFRqK/uhvD3sw2V+gLC7mkbapVD2pM29NRFEP5kW6jRYxA2Zupq5VduJu2r8yH8ya5Q
+        I/sOG8NytT6HMHzUhp66EMKf1L6BnBTX2lCrbGg47au7IPz9ZkOlPoCwe8GGWt0GYWgJUPvKRymvqZds
+        qNB+EDZyI1TrWMjGRpGucp+QfV0KNXoAsp01Uyu9DWFsfXIotJVvLtdEhtCaer/89S0eW+s0yE4ciFVk
+        rbYGY3f2sQKa5ODLQvA46KQnIDvS8QnQJH/lsgzXdicYpxMh105S89AjZYefQnYoRinf0FaQ5dq5GX6B
+        0uYneBiOgSz3EqeCBVtp8z64b+ilM6B0nHGb6R7ZaDXs+ihMlu4vhl0LTobOsuwtI8F/wYOwHbSSi/VD
+        KJ1thFc3/S2vZd6FXI7UYKR7pmgLPoHqAOKO6EvIDpwezm2PVZQl8ilwOdwKZtprwD1xbFi8x5OMryH7
+        Euf77WDZvgSOB6OWcqCroLSpioLeUIYwS9ojoav0+TJkn79D0yGYO8BhYxmbR8pIYDLrfbSxSbkeEsOl
+        Jxrj5L76Hch2I2sij/ryjYawprjdVuVD1Ow1HIOVaLbzSHJAu4MnYnGDa6B60bSQ89yyIA/G+d8ks7MH
+        AmHjqcXAzHBBZae1BVcXHQg5Z9SeOBgw8hiXwj/Ki8WQNWndC3kwNScORrXVEDYmz1mZ2rMzd0+TllEt
+        91lb618G2W52+uXNy68QsX7SMtlFv6/bUCHnfdjIDTCbWaPBU+hp6U6Ifl2gZWE4Sm9A2D1nQ866y22Y
+        ks6B6Ff2hxrlEzsPjGenTTS02nf2lAs3+pWmzBy6BcLGEn0gpF1rw5Rknol+pSYfKMcYNn75GXBiQTYt
+        dX0Ax5jtBv6Zf4AWmsgDOKcsdadFl77LL56t97L/N/5VHc4l/Io5swdYffoFZC5hdbq5Nlvz6qiZmb8B
+        3CLp2BLQ7YsAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="btn_CCaja.Iconimage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABhtJREFUaEPtmQWodEUYhq9iY3eA9YPYgYUdiCgqil3YYmFgodiFYnf8dmIHYrdi
+        YqKCLSp2t2I+z/n3W2bnzu7ZvQt7Fe4LD7tnz5k550y83zezQ2Ma0/9bc8KucArcAW/B+w3egMfgPNgH
+        loT/jNaHR+Bv+KcH3oE9YHIYFc0GD0P+YB/BA3A5nAOnwaXwIDwD+fX20FIwUE0Hb0M8xLtwMMwLdZoR
+        dgBfKMp/C4vCwLQnxM1t4UlgJNoGfHjrsdcGpmvBm95bHfWn48C6fq6OBqRLwJt+Ad0Mm3aaHmIe6VQD
+        07LwO3jjj2F36FVrwotgHXIgDFR7wZ8QD/Ad3Ay7wOqwGOhUM8N8sBxsBRfAhxDlZDyMihaA5yB9mF74
+        FHypUddKcBa8BqUHTfkKroD1YDIYFU0Fjvv5q6NWTQxLwNqwNWwHm4LpwzSQa264DNaojgqaFhx/+8Lx
+        cBFc1eAMOBrsxsWhW+0EtqZRtB8X8mXtDet6yh9SOZFuhAgU3fAenA91D2XdUcaX2AJ61dJg8Ip6ToJK
+        zvqHIE4EJlsfwBPwaIPHofSCf8BR0En2XFrGF3EerAPLg8MsZKQeB547Fkz+0rK3wURQtZwVxYlv4GSw
+        xcxB2mku2BLsTh8+yl8InbQJpPfL+Q1+hHaZqo13AEwBlWI8iXm5SVevshHSLNMJWCdT6uvhc4hy7fgJ
+        TOT2AyNxi34AL7Ir+5EtYoZpXRf7Q0GO4XkmfG2RC5u1wIwzZTNwGOWykQ+BytGiBVz59KPZIYaGkzqX
+        1ui5N6Fkjb3ItYJ1OW8ri/RA/F5qoTqtDK9A1LMR5DKPifOvw4LQq2aC/HmrMfVq4wdx8milBhRjQSlv
+        tyIj6aGgQ0VZ0WnaKXehZ8FYo2FMCbmMugvB9nA7OMGjrI3QNBnHlO6RVh7oMFqpw0Nc/pUc4kvYDerk
+        Iv4TyMuLeU7cRyJ7TXFCm8gNm8xKN9FCYzLW4YsYG1waGr27lQ22I9wPpXpLvAQuZJzwLdI9VpnwtUVO
+        ynXBVNehYuFjwC7XIVaEfHfAVHhjaGfFpdzGYLQqbAva5BHgffR677Mh5K3tsLYnq+hvfuMbHuZBH5oU
+        7HbrOsgfMrmW9dwL1VF/Mh+zrns8MJh4IKYCPkivcvGRTmYnXS6DW5w3KNXlTiWZahhso56rYWgOiJYT
+        J6kxQWcwR2onH1qn0h2irLiv006urNJrb4HNoZOl6jQbwLmQ5mA+c9PybQ2tM61cnKSuXw0+z4PWZUEX
+        5vm1Lg+NjlWC1UEnwC+Ql/8a3Hlzsr4MGomN+Rfk194Jzrdh0vftFldAeaF2GMD09xmgW9lgTlZT8VKd
+        JWx9A9dqMEyzNj5T6Rg6g61q9/liroLOBPcnHT55tqpbGHHb9YLDNZdZrZFbBzodTC6vBNMR7VknKg0x
+        dzmqeRQz2h3gfhXpxM7VUatMzByS7jj3K23d+9znwd2Ng19B7x2JnOxhx2Kr5Uq3Fu3JUm90o/0h6nFL
+        vuqGNCd3ktoby0AnGZBMgR1STuAoX7VKQQ4ro3ZcpxGYdut2zcVJQZZzE/dwSDeHTV2aVqwl+udCnAyc
+        ODqCIf+mBvq9L+m+ZH69FtopVTZh06LzciZp3t/0WFs2Nt3V+E13yq+3IZoPn0pPNrrlBToR7rACdKuF
+        4RpIfb0O548N6dbLMLlVkcrEzCWfLqAjGDl9axfWt4KrNzNPU+rUcaYGc6Re5FpCV9NM3Ln2PmJDmnXu
+        DW5o5T3rPlK1CeBevRO4NPF6lePf1irV5YN+DzZIvwpDsEeaKa3daeY5EtkSZ0N0d+kFNIY4b7Y50j84
+        HOYx/6olpTvC6Vh8EtwucfuuTrqDCWDqYqYc+ZBUDq/UKDQCh8ciUCejvGvq1MV0vuZEdovQCuNkYA5k
+        DxkVTwQjpX9UPA3mSPn1zo/iSqkhG+U6yMt9Brqbw+tUcFGlMTgPfK48HzJncqnZIi3OIeS/HunFdbjf
+        r+Xp593K3TYTslJ9nfAfS9cttX+zuhdjHmQOpPPYdQ4tN1P9fgMcCe6ydWrxOs0CrrjcQA4HcuvSxb7f
+        bRifweVnN0N6TGPqTUND/wJ1hpHTTZ6NwwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="btn_CVentas.Iconimage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABIVJREFUaEPFmkvIVVUUx29RRIMoo4lU9lAaZQ+szKSHNckmPSYSSEWlkUJUphRl
+        pUHDzBr0kB4QFdEgcGJGghZFkQYVESSWPTR6ihYUvX+/y10f+zve+91799nn3j/8Bnt931l7n3323met
+        dW6rkGbAcngcPoAv4Sf4E/6CXzq2d+BRuAFOg7HqOLgXPoT/MtkOt8NJMDKdAk+BM1sd0PfwOjwBq+BW
+        WAbe6AbYCt9C9bp/4Fk4GRrT0fAwHIC0c5eFszgTDoFBdBa45FxuqS8n5UEorjPgU0g7ewUugro6B16C
+        1PcXUOxp3ATpcnEZnA6ldSp8BNHPr3Az1NIDEA5/gzugad0N0afcBVlKB+8ROAdGpXnwDUT/K2Ao+ejS
+        wft4Ry1Pu90Q47gOBpIXuv68yCOv0aOtjxyLR7Nj2QceJlPqCPAE8IJ/4XwYtzyl4il4Eh4KPbUW4p99
+        EdXVc/AYHN5u5eseiHHdr6GbXCpxXL6voaYuhuh0roaaegv05fKerqEqZys6LLFp0xu4RENNXQDhb52G
+        VAZT8cfnNdTUYXA5hM+rYVqHIyFXm0B/buhjNIRWQnQ2W0OmrgAf9e8Q/rph7JSj9KkaIE7IsFajwVWu
+        0hdfP4yjcvUe6MOJasvEIhwbIeboPAgfPt77wKSlF0a2uUonqr2MdBiGMzVk6DXw+h+g6Rff2RDjvV6D
+        57QN37q52gv6eKHdalbmHPF2Xq/h3U7DMDlXzrw+zNRGodgHm20YrNkw5cuVjvSxB47X0LBMWe3vMxtu
+        Ohu+rnN1GehDdsEiWFDBtVtKa8C+rHxMhA8m4HWUxlG9+Apug7oyb9afZZtiN6CWwteQDrobB4UCQypu
+        wLG3fuw0TOVK6Vww/km5EiJUF9/auYobsGA2kfW4MZqWsVDsOeOaXD0N+mhHzXGMvmFjBHoS7M/TL1eT
+        jn5fBjbc0YMWpurIOMj+Pm+38hRPsb2XjH9sSNPJu3GX69a+zD9yNB9ivNdosLIchtwwV50IXm8dpxvO
+        VszcHzALcpSG/idoUDtAg3XOXEVIPgi3QK5cevqwvwkZ/obzCzVkqF8+YGXvTTD0zpW5dfhboiFkrf9v
+        8A8bNWTqKIjU0fUZnS0E08y6ehX0tx8O+qYQYbVYi6mrSyH8lUjqLcmHv2c0VHUsxCbzfK07Y9Y3S92A
+        x/tO0JenWM8vOhaNotNJSXOG7PRl8LFPWU0bQOn+Wq2hl8xVo0bvpivx6OvKMcTgjaX6yvPZTeIF38E4
+        KtMhSzxRZv8ZBs63F0PctTHLOCrUaXndQvO1MJTSdWfCP8rlZAYXB4pkJ0FpVVjcQE0GfJ58D0Ha551Q
+        SzeC6y8cfgKeyaVlkJZ+dvUJXAVF5B5Isyl5EUrciJ9qt0Dq+2Pwu3Nx+Z6IcDgwuDLaHDTGcQlaoXCP
+        VX+m4Kz7YaXue2NK+TSM5eM7WnUAb4M1JvPWwDKIKaspoIlTt+v8EYgx1Mjk69yIcJgwuso2MBKeVOsf
+        h0xmjD4NCI2jvCln1bKHWPmwimYi/whYUC4w6Fbrfxa02Rhc0i2pAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="btn_CAlmacen.Iconimage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAZ1JREFUaEPtmT0vBFEUhqcQhYooKYho/AoJhdIvUCh1REEiaLbxAxQiOn9AdKJV
+        aBQalY9IRBS+QjQSnnezZ7Nk187Mnc2dlfMkT7En95x739m902ySgQV8wa8O+4FzWCgT+IbNNuyErziO
+        hTCEV6jB76hvIo3baAfaqtXauYE6vHpucBCDOUY7yLIKKZlC65tUISVLaH2HKoSwiTZMTzELeQOIHbTe
+        igp5mEcbcoY9mIWQAL14jtY/i5kYwXtU83Xtc1ZCAogxvEP1P+IopmIA7dJKHSQPoQHENNqMS+zHthyg
+        Na2rkJMiAohFtDl7KvzFGtpivQZDKCqAaHyoLd+E2sQW6evqwxCKDKCfjs6kWZ84gz/QJb1FLdCFyXNp
+        f1NkAKFL/ISa94DDWOcCbbNn1CUOVW8vm6mNm63JqgWQJ1hFbx0rdptVGgOcom56mdUZWwZYUaHkrKIH
+        iIkHiI0HiI0HiI0HiI0HiI0HiI0HiI0HiI0HiI0HiI0HiI0HiI0HiM3/DnCE+nO7zOqMLQN0m3X2sdmC
+        MrubJEnyDZbZFjwN8H8tAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="pBox_Logo.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAYAAAD0eNT6AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6
+        JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AABI3ElEQVR4Xu3dB5wkZZ3/8VEwIOz2U73L
+        rpwrmDBHDOcZMYc79dS/mVPPBJ6eOeuJKJ6C5ykY7sQICuoYOZZhumuGUU9dxdHd6Xp6FlwERCUcQVHC
+        knb/v6fnt7LUPFs7VV1PT3XX5/16fV+EmXmqup7qen6Vx+qmPRfdt23Nf7QTc4bkwjiJLieEEFK/yBhw
+        gYwHG1o2+sjUptV312ECo2ZiS3OldPhX2km0TbKdEEII+WtsdIP887OnzO53Ox02MAqmkzVrpdKbX9Th
+        hBBCyE6JbfTL9Z1GpMMHhtns7NitZPD/ma+jCSGEkEWx0dTh28duqcMIhlWr03yzt4MJIYSQXcU2X6nD
+        CIbRxJax28je/0XeziWEEEJ2nfPGx8f20OEEw6bdabzc06mEEELIbjNlm8/V4QTDRjrwF+kOJYQQQpaS
+        2EY/0uEEw6TVMY/xdSghhBCy1MTJyofosIJhIR33nXRHEkIIIXninh+jwwqGQdyN9m/b6HpfZxJCCCE5
+        snWmu+/tdXhB1cWJOdrTiYQQQkiBmPfr8IIqc49xlA67dHEHEkIIIQVio4vdbeU6zKCq4iQ6zNuBhBBC
+        SOGYQ3SYQVVJpdbxdx4hhBBSLO4dATrMoIratvlkX8cRQggh/aaVRI/Q4QZV07bmVF+nEUIIIX3Hmm/q
+        cIMqac+vODBOohu9nZY3NjpiqtO4CyGEkOFPOzEf827r88ZG17eS6I467KAqpGM+5e2wnImtuWqyu7Kp
+        zQIAhlx7bu81sn3fmt7eF0nLRh/RZlEFJ5+5aoVUeFf4OqtAPqvNAgBGhOwkftWzvc+dOIkub8+t3Vub
+        xXIr8Z3/22LbvJc2CwAYEZNzjYM82/xCaXWi12izWE6Hbx+7pXTI2ekOKhYzqc0CAEZMnJif+Lf9eWO6
+        27eP3UKbxXKJO+ZZ/g7KH6nqnqbNAgBGTJxEz/dt+4tkqtN8ojaL5SIderqvcwrk1+5ogjYLABgxMzNj
+        e8re+/me7X/uyNhzijaL5dCei+4rHbEt3TGFYs3rtFkAwIiSgftd3jEgf7ad1ll1D20WgyaV3Oc9nVIg
+        5oqJLc2V2iwAYESt7zQi2eZf6R8L8kWKiWO0WQySu1ff3bPv65S8kXY+rs0CAEacFADH+caCvIkT8+d4
+        NmposxgU6cB3+zokb6SCu9E9KUqbBQCMuMn56D6y/S/r9PEbtVkMQqkXctjoe9osAKAm2jaa8o0JuWOj
+        c8bHx/bQZhFaK4le4O2IAomTxsHaLACgJmTP/Rm+MaFQpC1tFqHJwv6ptxPyxpqEhzkAQP24bb+MAWd5
+        x4a8sdGUNouQWp3Gg70dUCCtpPkKbRYAUDOxbbzJNzYUyXRi7q/NIpTYRl/zLfwCuWTDhnV7abMAgJop
+        90Vy5jhtFiFMbl69X5xE1/oXfu4cqc0CAGqqZaNjPeND/lhz9dTmFau0WZRN9v4/6F3weWOj6yc6zXXa
+        LACgpia7K+/mbgf3jhU5454yqM2iTBNbxm7TTsxFvoWeN3Fivq7NAgBqTsaF9elxolCs+f3s7NittFmU
+        pd1pvNy7wAsk7jQfrs0CAGqulTSf5BsriiROoudrsyiLLNhfpBd0odhoVpsEAKBHxoaOd8zImTgxP9Em
+        UYZWxzzGt6CLJO5EL9ZmAQDokfHh0PR4UTST3ebDtFn0Sxbod9ILuFjMBePdsVtrswAA9Jwyu9/tZJy4
+        dPG4USA2+qo2i37E3Wh/d9W+dyHnTMua92mzAADcjOwkHuUbOwrkuulNzTtosygqTszRnoVbJFunkzVr
+        tVkAAG6mzB1OaecIbRZFlHxI5kvaLAAAXrLT+S3vGJIzsY3+b+bcA26rzSKvOIkO8y3YInHvENBmAQDw
+        irvRo3xjSJG0rHmZNou8ZK+9lNsyJD/QJgEAyNROzBmecaRIfqVNIo+2bT7ZszALpvFsbRYAgExuz90/
+        luTP5Jx5tDaLpWpbc6pvYRbIeePjY3toswAAZNJHz1/oGU8KxHxbm8VStOdXHFjWyxkkb9VmAQBYEncV
+        v2c8yR8b3dCea9xZm8XuyAL7lHdB5kxszVWT3ZVNbRYAgCVpz+29RsaRrelxpVjMx7RZZDn5zFUrZGFd
+        4V+IufNZbRYAgFxkZ/SrnnElf2z0x5nuvvtos9iVVqf5Zu8CzJ9tsW3eS5sFACCXybnGQZ6xpVBiG71W
+        m4XP4dvHbikL6uz0gisWM6nNAgBQiHu7n3+MyRlrznJjnDaLtLhjnuVdcAXS6kRP02YBACjEvd/fN8YU
+        SWybT9FmkSYL+nTfQiuQX1NpAQD6NTMztmc7Med7xpncia2Z0Gaxs/ZcdF9ZQNvSC6xQrHmdNgsAQF9k
+        5/Rd3rEmf7a1klX31Gaxg1RYn/csrAIxV0xsaa7UZgEA6Mv6TiOSseVK/5iTO5/WZuG4e/XdPfueBZU7
+        0s7HtVkAAEohBcBxvjEnb3g+TYos2Hf7FlTeuKcHTnUad9FmAQAoxeR8dB8ZZ8o5TZ1Eb9Fm663cCyyi
+        72mzAACUqm2jKd/YUyC8o8ZpJdELPAunUOKkcbA2CwBAqeKueaZv7CmSVtL4R222vtrW/NS3cHLHmmT7
+        9rFbaLMAAJSq97A6a87yjkH5M6PN1lOr03iwZ6EUSitpvkKbBQAgiNg23uQbg4qkZc0DtNn6iW30Nd9C
+        KZBLNmxYt5c2CwBAEGW+sC5OzBe12XqZ3Lx6vziJrvUtlAI5UpsFACColo2O9YxDRbJ1OlmzVputD9n7
+        /6BnYeSPja6f6DTXabMAAAQ12V15N3fbuXdMypnYmvdqs/UwsWXsNu3EXORbGHkTJ+br2iwAAAMh48/6
+        9HhULOYP492xW2uzo6/dabzcvyDyJ+40H67NAgAwEK2k+STfmFQoNnqRNjv65AP/YtECKBIbzWqTAAAM
+        lIxBHe/YlD+/0CZHW6tjHuP58IUSd6IXa7MAAAyUjEOHpselwplv/q02O7rkg35n0QcvFHNBrc6bAAAq
+        5ZTZ/W4n49Gli8enIjEnabOjKe5G+7ur9v0fPl9a1rxPmwUAYFnIwH2Ub4wqkOtG+o62ODFHez50kdTz
+        3kkAQKWUuWMrGc1n2pR6qMRGX9JmAQBYVrJz+y3vWJU/o/lU2ziJDvN82EJx7xDQZgEAWFaTc+bRvrGq
+        UGzzldrs6CjxdokfaJMAAFSCjE0l3d4+Ym+2lYrmyd4PWiiNZ2uzAABUQsual/nHrPxp2cbjtNnhJxXN
+        qb4PWSDnjY+P7aHNAgBQCfqI+ws941b+2Oj72uxwa8+vOLCslyZI3qrNAgBQKTJwH+EZt3LHjZmn25V3
+        1WaHlyyQT/k+YN7E1lw12V3Z1GYBAKiU9tzea2S82poev4ok7pj/1GaH08lnrlrRTswVvg9XIJ/VZgEA
+        qCTZ6f2qZ/zKnTgxf57Y0lypzQ6fVqf5Zt8HK5BtsW3eS5sFAKCSJucaB3nGsEKJO+b12uxwOXz72C3l
+        A5yd/kDFYia1WQAAKk323n/iH8ty59duLNVmh4dULs/yfJhCaXWip2mzAABUWpxEz/eNZQXzdG12eMgC
+        ON3zQYpkOCsgAEAtzcyM7dlOzPme8axATEubHQ7tuei+MuPbFn+QArHmddosAABDQXaC3+Ud0wok7kT3
+        02arTyqWz/s+RP6YK4b6KkgAQC2t7zQiGcOu9I9teWP+S5utNnevvrtn3/8h8kXa+bg2CwDAUJGB+zjf
+        2JY3bkyd2rxilTZbXfKB3+37AHnjnoQ01WncRZsFAGCoTM5H95HxrJTT4S0bvV2braYyL3yIbfQ9bRYA
+        gKEk49l0enwrmN+6MVabrZ5WEr3AM9OFEieNg7VZAACGUtw1z/SNcUUyZZvP1Warp23NT30znTuj9j5k
+        AEAtlflQvNhGP9Jmq6XVaTzYN8NF0kqar9BmAQAYarFtvMk31hVJnKx8iDZbHVKZfM03swVyyYYN6/bS
+        ZgEAGGplvhgvTqKvaLPVMLl59X4yU9f6ZrZAjtRmAQAYCS0bHesZ74pk60x339trs8tP9v4/6JnJ/LHR
+        9ROd5jptFgCAkTDZXXk3d3u7d+zLHfN+bXZ5TWwZu43MzEX+mcyXODFf12YBABgpMs6tT497hWKji93Y
+        q80un3an8XLvDBZI3Gk+XJsFAGCktJLmk3xjX7GYQ7TZ5SMz8ovFM1YgNprVJgEAGEky1nW8Y2DOxDb6
+        pTa5PFod8xjfjBVJ3IlerM0CADCSZLw7ND3+FY6NHqnNDp7MwHcWzVChmAvGu2O31mYBABhJp8zudzsZ
+        9y5dPA4WiDXj2uxgxd1of3fVvnemcqZlzfu0WQAARprs9B7lGwtzR8ZgNxZrs4MTJ+Zo7wzlz9bpZM1a
+        bRYAgJFW5g5025qParODUe4hjOhL2iwAALXQTsy3vWNizsRJdHl7bu3e2mx4MsHDfDNSJO4dAtosAAC1
+        MDlnHu0bE4uk1Yleo82GJ3vtpdzGIPmBNgkAQK3IGFjObfSJ6Q7kDbpt23yyfwaKpPFsbRYAgFppWfMy
+        /9iYP1Od5hO12XDa1pzqm3iBnDc+PraHNgsAQK3oo/Qv9IyPuRMn0SnabBjt+RUHlvcyg+it2iwAALXU
+        ttERnvGxSLad1ll1D222fDKjn/JMNHdia66a7K5sarMAANRSe27vNTIubk2Pk0UiO+jHaLPlOvnMVSva
+        ibnCN9G8kZn8jDYLAECtyc71V31jZd7EiflzPBs1tNnytDrNN/smWCDbYtu8lzYLAECtTc41DvKMlcVi
+        zRu12XIcvn3sltLw2YsmVChmUpsFAABC9t5/4h8zc8ZG55R6gX3cMc/yTqhAWp3oadosAAAQcRI93zdm
+        Foo1z9Bm+yczdrp3Ivnza3c0QZsFAABiZmZsz3ZizveMm/ljoylttj/tuei+0uC2RRMoEmtep80CAICd
+        SAHwbu/YWSDTibm/NluczNDnfY3nj7liYktzpTYLAAB24m6Pd7fJ+8fQvDHHabPFlDkz0s7HtVkAAOBR
+        2k63NVdPbV6xSpvNr6zDEe7pgVOdxl20WQAA4DE5H91Hxs1STrvL2PsubTafMi9IiG30PW0WAABkkHFz
+        Oj2OFoo1v5+dHbuVNrt0rSR6gbfBAomTxsHaLAAAyBB3zTN9Y2mRuNsLtdmlk8rhp77GcseaZCDvKQYA
+        YASU+fA994AhbXZp4mTlQ3wNFYptvlKbBQAASxDbxpu8Y2qBTNlVD9Vmdy+20dd8jRTIJRs2rNtLmwUA
+        AEtQ5gv4JMdrs9kmN6/eL06iaz0NFMmR2iwAAMihZaNjPeNqkWx1rx3WZndN9v4/6Pnj/LHR9ROd5jpt
+        FgAA5DDZXXk3dxu9d4zNmbgTvVOb9ZvYMnabdmIu8v1x3sSJ+bo2CwAACpDxdH16fC2Y32a+JbDdabzc
+        80eFEneaD9dmAQBAAa2k+STfGFsk7vZCbXYx+YVfpP+gUGw0q00CAIA+yJja8Y61uWNa2uTNTc6ZR/v/
+        IH9aHfMSbbZypuYbD2pb8x8yn78q63QHIYQQMgTZNrVp9d11OLxJnJhveX65QMwF492xW2uzlRHPRg2p
+        ok6UeSzn1caEEELI8OUTOiwumJ43B7ir9j2/mD8d82/abGXEZ676GylM5r3zSwghhNQlNvrjKbP73U6H
+        R3fu3xzl/cXcMdcs6V7DAdI7G87wzy8hhBBSr/z1NL2rBOR/XJr+hUKx0Zd6jVZInERv884rIYQQUsPE
+        iWnvGCAP8/1CkbgL7HqNVoS751H2/rnQjxBCCNG4hwvF3Wj/sdiaCd8v5E1sox/quFsZ8gEf5ZtXQggh
+        pM5pWfM+dwRgk++H+dN4to67lSFFyWv980oIIYTUOeYMdwTgTP8Pc+W8zEcMLhNX4XjmlRBCCKl3rLna
+        Pf3vvEU/yBl3oZ2OuZUiH/B1vvklhBBCap6z3SMGL/b8IFfccwR0zK2UuNN4gm9+CSGEkDonttHX3BMA
+        /+z7YZ5Mbl69n465leKeSOgeeuCbZ0IIIaSuiTvRi90pgOvSP8ibqhYAjlQ5H/TNMyGEEFLPmPNnZ8du
+        5U4B9P0I4CoXACefuWpF25qzfPNNCCGE1CzbprrRU3sD5KgXAE4rWXVPqXgu9M07IYQQUpNsa3Wab9ah
+        sR4FgDPRaa5zDyvyzT8hhBAy4rmu1Yleo0PigroUADu0rXmGZFzm+7L05yCEEEIqGRv9KU6iy+Xf3dj1
+        G82v5f/PLsRskMS9JNF6+X8nyu8f497Q6y746z36N01+caQvAsyyYcO6vdZ3GlFZaSXRHac6jbsQQpaW
+        0zqr7tHqNB5MyLBkcj66j29d3lVO29i4k2+8yMrMzNieOkyFVbcjAAAAQFAAAABQQxQAAADUEAUAAAA1
+        RAEAAEANyQBe27sAAACoLRnAKQAAAKgbGcApAAAAqBsZwCkAAACoGxnAKQAAAKgbGcApAAAAqBsZwCkA
+        AACoGxnAKQAAAKgbGcApAAAAqBsZwCkAAAComziJrvUN6nlCAQAAwJChAAAAoIYoAAAAqCEKAAAAaogC
+        AACAGqIAAACghigAAACoIQoAAABqiAIAAIAakgF8a3pAzxsKAAAAhowM4BQAAADUjQzgFAAAANSNDOAU
+        AAAA1I0M4BQAAADUjQzgFAAAANSNDOAUAAAA1I0M4BQAAADUjQzgFAAAANSNDOAUAAAA1E07Mdf4BvU8
+        oQAYbjPnHnDbVtJ8kvTloZK3yjpxyNSm1XfXH2NEzcyM7Tk+PraH/idG3MSWsdvov6IGltTfFAD1NbFx
+        n31bNjpW1oG/+PpVMhfbxnO2bx+7hf4Jhpz06dOlv0+S/CFOoht7seZ38v+Pn+o0n6i/hhGwYcO6vVrW
+        /Iv07XTbRn9c+E677b3pSo463a68q/4qRkArie4offxhyVzbmqu1v6+IbfRD2Y6/aaa77z76qzdZWCFu
+        ttHPHQqA4SMbhEdKLvb156LY6ER3lED/FEPIbRxkQ/Ajb//eLKYlG4rb659hSMW2+RQt7Dx9vJDei+Cs
+        +ShHgYab20Frd8y/7X4sNxe5HTr9swUUAPUTJysfclOFuMTY6PuHbx+7pTaBITLVbd5bvucXevvVG3N+
+        e65xZ/1zDJk4afyzfF9v8Pft4kghcIo7HaR/jiHitslxYr7u69ddZJt8v9+gf04BUDenzO53O+mz36b7
+        cIl5izaDITGzsWGk385O9ePuY03i1hVtBkNics48WvrvukX9uft8UpvAEJHi7UOevsyMO+031Y2e2msg
+        956gJxQAw0P2DN7h68OlRFacy+PZqKFNYQi4Q7y+vlxazHu0GQwBtzco3++Ovy+z4waFdrfxQG0KQ6A9
+        v+JA6bsixZ7L2ePdsVtTANRMnBjr68OlRv7+n7QpVJy7CEwG8St9/bjEXMKh4eEh/fX0VP/li42+qk1h
+        CEiffXpRH+aJjV5EAVAj7uIuX//liewpfEWbQ8W1rPkHXx/mSatjHqPNoeJkW/7fvj5catwRPi4IHB69
+        a3U8/bjUuGsHuAagRia7zYf5+i9PZCNxujaHiuvndM+OSH8fps2h4tztXr4+zJOJTnOdNocKc7f0+fov
+        T+S7vUlWGnOV74d5Mr2peQedL1RYqxM9zdd/uWKjjjaHipM9wv/w9mGOtJLoA9ocKk625Wf6+jBPpuyq
+        h2pzqLDJ7sq7+fovX8wFbi/hT/4f5sj8igN1vlBhUvE939t/eWKjc7Q5VJx8wT/v7cMciTvmP7U5VJz0
+        d45bPXeRbuPx2hwqbHKucZC3/3LEPSfCFQBLexhMRtzM6Hyhwtq2+Upf/+XMJdocKi5OzDc8/Zcz5vPa
+        HCpO+qqfCz57kYLvWdocKkz6+rG+/suZs91ho8ynRS0lcdI4WOcLFeYeB+nrv5zZqs2h4trWnOrpv1zp
+        XSiEynMX70l/bUv3X/6YQ7RJVJh8t5/h7788MfOukpj3/zBHZGZ0vlBhLWve5+2/nOndP4rKW9qjf3eb
+        9docKmxiS3Olp+9yR9aZ12qTqLC2jV7k6798MWeUspGIO9GLdb5QYdLhH/P1X97MnLXPam0SFSZ9tTHd
+        d3njrizX5lBh7kJsX//lTctGb9cmUWGtTvQaX//liznNbSS+u/gH+SIFwDt1vlBh0lffSfddkbQ6jQdr
+        k6gw6atL031XIL/R5lBhcaf5cE/f5U6cRMdok6gw6afcjwD25AS3V3ic5wf5YqMv6XyhwtrWJN7+y5lW
+        x7xEm0RFTW1escrXd7ljoxt4E2T1tax5mbf/cse0tElUmGzLx/39lyufKOW8cJyYn+h8oaJ6zwkv4aFP
+        vdjoCG0WFSV99Ehv3xXJXHRfbRYV1bLRR7x9lz/naZOoMPl+F3rnw85xF4WPub053w9z5jKdL1TUVKdx
+        F0+/FYq7vUybRUW1kuYrfH1XJFO2+VxtFhUl/dT3qVyXOIlu5C2Q1bbw0qf+H+Hfu+WzlUSP8P0wd+b2
+        XqPzhwoq5SmAN2WjNouKaifmKE+/FUpszXu1WVSU9HfX13dF0rLmAdosKqg917izr9/yZjox9x+b2LjP
+        vr4f5o5tPlnnDxUkG4j3ePutUMw1nBeuNumjSX/fFYg149osKqg9t3Zv2XO/1tt3BeKuJ9CmUUGtpPGP
+        vn7LE3ekx71PoNegbCwu8P1SnrhzUL3GUEltG035+q1oWrbxOG0aFeOe0yDf6b6fCrdTLnWHHbV5VExs
+        m0/x9Fnx2OjL2jQqyN2p4e23HJE2tmhz5ewtxIn5uTaHipnYMnabMs4Z7ZzYRh/U5lExk3Pm0b4+6ye9
+        w4WoJPluf9TXZ8VjztemUUHS32XczfUdba5XAPR/vtDdLrSxYbRJVIh7VLO3z/qK+bE2j4qRvnm/v8+K
+        p3fFMCpJ+vsMX5/1E/e2OW0eFeKutZP+6fuRzzd7y2c7aTzb90t5E3fNM7VJVIjbW/f1V1+x0fUnn7lq
+        hU4CFSL984NF/dVvbPR9bR4VEs9GDbfz5e2zPiLbjFfrJFAh0tcv9PVX7ux8zd50smat95dyx/yXNokK
+        CbGH4ELBVz3uKJz0zdZ0X/UfcwUXflZPu9N8nr+/+s53dRKokDiJvuLpq3yRgtEVjtrkAndRgPeX8+Uy
+        d75Zm0QFTG1afXdPP5UTa76pk0FFlPOMcH9kG/F8nQwqQvrl5HQ/lRHp62vd0yR1MqiADRvW7SWD9598
+        /ZUzi2/jjq35nOcXc4eHhlSL9MmH031UXsw1XPdRLdIv/7u4n0oLbwasEL2F+7pUH5UWKQIO00mhAtxL
+        93z9VCCf0CZvUsa9hb1wrrAytm8fu0Vso3O9/VRS3B6nTg7L7LSNjTtJn5TwTvhdxEbXz3T3vb1ODsss
+        Tsy/evuppPCI92qRHa5ynu3he2aPeyiA/LCMc4fXucpUm8Uycvfqe/qn7PyvTg7LTDbYh3v6p9RwN0B1
+        hLq2Z+ec1ll1D50cllHvOj0pwH19lCvWXO1OJWizNycbkLb3j3KG1wNXg2wgTvL1T8nZFtvmvXSSWCaz
+        s2O3kr44L9U3AWK6PBRo+U3ONQ7y90/ZMR/TSWIZtTvm3/z9kzsna5OLSYXxKs8fFIi5aJdVBgbidLvy
+        rqVUjEvL8TpZLJMyX/6zu8S28RydLJaJ9MN30v0SJubKmbP2Wa2TxTLoPerZRv/n7598yXyV+/pOI3JX
+        f/r+MG/c+SltFstAlv8Xff0SJO4+5PkVB+qkMWDj42N7tK05y9s3YbLRXV+ik8eAuSNusp2+0dMvYcLr
+        v5dVy0Zv9/ZL7phrJrY0V2qzfrIhOdX/x3ljznfPJNdmMUDT8+YA6YNgVwf7Y47TyWPAZAP9In+fhIt7
+        u6ROHgMme4Nf8/VJqEixcfluBw4E0bv1LzEX+vqlQG56/O+uuNv4PH9YKDxNannIF/Yzvv4IGXfkqJVE
+        d9RZwIDou8HLeDZ4rnCF+PJwj+jtHXHz9EnYmHfrLGCA4o55vb8/8ke20X+vze7awsVE5iJfA/ljLqBy
+        HCw9PFjaq0FzhbeIDZws85Ku2ymQTvN5OhsYEOnv73v7InRs9CduAR2s3in5ks79x9b8zp0q1KazyR5F
+        mW+X+qQ2i8B69/0n0emePhhUtrU65jE6OwjMPalNlvmlqT4YWNxGhfdBDE7Lmn/w9cOg4k496KxgAGQH
+        +r98/VAoea7jmOg018kflXMO2UY3TM03HqRNIyBZYQ7x9sEAEyfGuqNIOksISPr7874+GGy4TWwQFs4F
+        R79ZvPwHnG7j8TpLCKjVaTzYjZ3ePsifrZObV++nTS9NuReamDO4dzgsd6pFlvMf/Mt/wLHRO3S2EMiU
+        XfXQeJBXgu8qNrpe9kwfoLOFQKSvP+Rd/oOONWfxvpewetf1JOZn3uVfIO6OMG166dxeu6+xouG2wLBk
+        hTnOt9yXJ+ZK9xwCnTWUTF8K0vEv++WI+RlHfcJxBZYs5wBveCwYbgsMSpbxWxYt8+LZNjkf3Uebzkf+
+        eH2qsX6y1R3W0KZRItk7eL5neS9rZJ428TCoMKpV7O0IpwJCWHhEu9nsX+bLE3fkqZU0n6SziBLpkb0S
+        L+I239am89PHTZb5cpGzF72HGH3p3RaUmCs8y3rZIyvyZ3Q2UZIqFnuabXHHPEtnEyWRve2vepZ1BWIu
+        yn1eGZncm1Wlv8/xL+/8cYXadGLur80XIw2V+sjJODHf0qbRp5lzD7itLNNfpZdxtWIO0dlFn6pc7LnI
+        Budy9xAqnV30yb1p07ecK5SZJd9ahkzuDi5Znt9NLd/+YqMTtfni3NugpLGynyr3Vm0efZAO/pJn2fYR
+        c6FsxEu92EgKvj/zsqD+uSNn0t9ln/d3p/h+kPp//cWaDafM7nc7nW0UNNltPkyW5dXeZVwwsY0+6L6P
+        vp8VjbT57zrL6INsd9/lW759ZOtUp3EXbb4/0tgnUo33m23tTuPl2jwKkGV4ZGqZ9p3Ympe6xzdLIVDq
+        OUd3vzh7hsW5PpENdylv6twR2eBcO7Vp9d3dBUJSWJT90qj1MzNje+rsIyd92t/FnuXaT3618M6I6B2e
+        n/UVXhHdH/eCHlmOZZ5qL7cw652bSKJL0hPpM9fJnuFTdBLIwd1R4VmefUXa/MmOF7y4fvH9Tn8x87xV
+        LL/eRjsx3/Yv077yYZ2EO5L0Kc/P+4uNvswLg/Kb3tS8gyy/sl/rvK2VRI9w7fcK/JJfHOXONUv7L+h9
+        AOQiy+7vZRmWfITdXFD6A7pa1rzMP7HikT3Dq3asmFga2bC+yH3hfMuzaFx77upTnUSPTCfAI0fNGTw5
+        Lp+WjY71L8vicUdk3CtGdRKlPnL05jFH6SSwBO40j3wXN/mXZfFIm1/RSfS4K/h9v9dn2KHLqXeaJzFX
+        epZlXwlWjMnMtnwT7DOXxZ3mw3USyOBe1CRf5tKf8y8Dwsd1En/VnmvcWfr7L77f7ycy/6dTBOzewsNA
+        ok+ml18Z8b3PP04a/+z73X7jzjvrJJDBHR2LE/Nz3zLsM5f5nuEv0/q653f7jPnLVKf5RJ0EMrgdX9kW
+        Xu5fjsUjbZ6ikyifDgqlVyyuTV4vmq1lzb/IXnmAt4CZ+V3dry8/P3Tx7/cfGRR+OZ2sWauTQcrCYdro
+        RN+y6zsZVwa7jYf3b/qMFJif42rxXVt4fXege/1t9EKdzM0svEfCXOD9mz7idlA4HZDNvdPBHf32Lb/+
+        Yq6QZR/2jayy8X61f+J9xj1SNGm+QieDncSd6J3eZdZvZJm7w1A6mUX01pQyHwZ1U2x0jrvDRCcF5Q7N
+        y8ZhwrvM+o01v5/srmzqpBaZ2LjPvtIvZV98thAbfZ8HQy021W3eWzbc53uXWd8xJ+lkvNq2+WT5vVIv
+        PtO4NrnTyyNOzD/Jsin7rrpeZLvxUp1MWDKxUp8NsFO2yYbiHVw8tECv/v6iZzmVkqUcno3PXPU38ruX
+        pf+2jPTOO883/1YnVXvuwSqy0T7Dt6xKyLalPL2t1W3+P8/flpUfcCHoTVq28bgQh4EXYv6QVeztINuX
+        L/j/vv/I9/vfeQfMgoWdKfMeWS4hCq7t7pSOTio8PXwUqGqVyN6CuzBJJ1dL7nSLdGqIc4I78oOl3qrl
+        3vvu+fuyslXWpTfUvejrXZgVau9b4i4m1Entlvz+8em/Lyuyl/K7uBs9SidVS25QbFnzPunvAKf03GAQ
+        3bjUC/LcEae2NYmvnVJio6npmp/uc+NlqNNrvdjoHHennk5uMBauYAz5ggpzfl3vEGgljX8Mt2fgYi7M
+        +xjPuGP+099WaTnZfVF0crXhzo3Lev4Bt9H2LJNyYs1P87zBTV82NOttq4z0TvdFH6jj3mHvNEtiTvMu
+        l9Ji3q+TW5L2/IoDpU/+5G+r//SO9Nnmk3VyteLurnIDtG+5lBNzzbK9Yyf0oyplo3it5G11uYDIPUFN
+        Pvdn08uhzLhlOpVEf6eTXDJ3tED+9nRfm+XFnD85Zx6tkxx5sie8v3zucp/EtyjmAncaRye5ZO4pYvL3
+        QU797Ii71sF3hfqoclfIu/7wLYsSc3KRwsq9x0H+Nsjh6V7c0Q4bHVGXt0b2tpcL124FOd+/I+72fJ3k
+        8pCZCDpguUgF+ctRP1fsvoDyOc/1ff6Sc6hOMreFvZfot6n2Ss3CnrD5/CifK164tsM9+jPEHTU3xRV7
+        /RxF610kFugw9V/T2/M0bxjlIr93bUeouzpuFrN5YktzpU42N1lfPuRvt8yYeXftg05yJLnvnHzWjYs/
+        e+n5pE5y+bhKp23NqZ6ZKzW9gcGa/17KhS3DZOGxn+GXn0vLRh/RyRbmDjfJl7j05wN4cpn0+WGjNjC0
+        u43Hu42g5/OWHikoX62TLUzaeWu63UDZWOTIVJXptvGN0t/BX+Ak35XLW8mqe+qkC9G7fk5Itx0kUhCN
+        2tsE9VkO7qLtcEdSdsRG36/MtnHhndWDeSvdwvkk88Zhf+GI25t2A7JsHK7xfc4AOaGsC+3cnqHbu/RM
+        o/y4c9EjcP6wPRfdV9bbce9nDJJ854GzyHz/h38apcdtOI937yjQSQ8l9z3TQ+pzO322YHH3lJd1vZQ7
+        RC/rzqRvOqXHRn+SeX/vsL8i3o1/sj18m3ymoKfMboo5o3Ljn17c0vXPcJBc4i4kGvjVj32aTtaslQ3q
+        R2VZBT38u3Nk5Tw9z0VgS9FOGs+WL3DYw8M7RT7DJnef67AdEWhZ8wCZ/xMGvKw+o5MvRW9AC3i7WDoy
+        /zdKTlm2i5sK6j290Zpn9IpWz+cKFHeO+ek6C6XoXYtkzYbUdIJF1q0/S38fM2zXg7gnmspyckd4LvR9
+        rhCRbeCZbgzRWagWfZHFb9IzHTKy4lweu9dcdqP9dTYqqbcHmJjjZJ4D3jnhzczOz30vU+/phP5pBoyZ
+        d4+trfIRIFek9I6ShHqgT2bMSSGuru8dzk6ikxdPL2i2yXf7e9LfB1f5jgF33l0G/Ve5jbPnM4TMNunv
+        Q3Q2SuV26GTbWvp7CbLjTi2aj7m7EnQ2Kum0jY07yfx+WPo82J0Tvkh/bKn8aRNdOAMtAlxk4bi9htPd
+        a4ar8qz5hQe7RG+RDOKCkMWxJg49ULY6zTfLtMKf81qU3nUIx7v756tyVMAVebI3c7Qs998vnt8BxJrx
+        kFdZ924PDPVkyN3HvSHvyKo8PdKtc+7x5TIInCjLvdT39i8pC1fVv0pnJ4je/evuAmzf9EPHmp/KtF9b
+        lWu+3GmKhSIv+qHM38C3d27wH5pXqi8cCRjMhU6+SCV+lWyIv+6KgUEfGXCP9ow75vXy+Vu9L6ln/gYT
+        MzmoR6/Kl+LVrgDzz8cgYv4g//ykzMPfD7L4c4Ote6iNTP/9Mv2BXAOzq7iLjwZRCPU+c2K+4ZuHwcX8
+        TPJu9xIxd2RCZy04d7qxd26/9/rk4LfzZeU6mQfvM/7L5h7IJp811NMplxJ3xPS77pZzd8G0ztZA9N59
+        Y5uvdIW1LINBXau1ONYkQ3fBZHtu7zWykg7yXNgu46onKQo+J/Pzosn56D5lnQ93h9an5hsPcgOgrCAn
+        SQZ2LigzssKWfc5/d+JO9GJZvtd752eQ6c2D+Zm7wNLtobmquayLH3sXbnbMY6Ttt8s0TpMM7DqO3eQT
+        ZX3GpXCFhhQBA7smIDvmCvl+n9I7EmWjR5b1MKne+fze0zjd+9rNUTKtX0j7y1jQ74i5xr1MRmdzIPQ1
+        xYGfAbLUmPNlXr4i2/OXtruNB5a1k+O2l9OJub98v1/SW7eDPrxn6ZF5+fnQPiBNr44M9wjEoln4Ip8t
+        A+WpsiJ93G3Qew81kgJB/t8z3H2q7gIk9+AO91Q+t1LI7x8qn+Vd8s/Pyu9NuRXxr+1VKuaoQQ4GO3PL
+        TqY/iFsE88Waq6XvNsmX6Vvy3x92g0WvaOs0nzfVjZ7q9uLd3mTvQS3uscfuyFHHvF4f1/pl+fsN8vcB
+        n8xYONvcPOriHyi3jrl1zTNPVcilMm8/dhty+X6/V/rvdbKcXubec9Dr4/nm37oHTvUO4Ut/u3VBT2Ud
+        qeuIu3p/0NfqLCWXyed6rHbBQOkbKr/smafljrtO5FxZLi35jh7jHr7jtuVuh6T3bJVO4wm9W5e7jcfH
+        XfNMt43Xbf075G8/IX93mvz7OfK3y3gEc5f57rDf7aYXRLlDZt4PSMqKe7yqrNi62JeNfPHu575Q3nkk
+        JcZcOWWbz9XFvmx6e2LLeXi0NjHdQR8C9+kVxctyzU+9IsXLf1b5wtfc3JXbbCgCxUYXuz0bXdTLzj0Q
+        Q+Yr8CNua53z3OFPXdzLzh09ke/2cp4TH/Ws7+cJf2XrHTVJzJ8980n6jBTUV8l3KcidHctu4Slyvat5
+        vR+e5E9sox8WedZ7aO5isZaNjpV5ZG+hzLjTT3N7r9HFXBkTneY62XD92DvPpFD0sPSRVbnLZWfuYU3u
+        tFp6nklfObtlzQN0EY8mV8nKoPU1z4cn+bLNnfMKedtXGXqvuWXvsP8MwRv0ehcHDuAFKPWIu9itcbAu
+        2kqaOfeA27ptkH/+Sa5YMz5sD7Xri7soR1by4M/IHtH8ZpheqDGdrFkbL8tDcUYlZvPkXOMgXZyV557p
+        z3UgfUQGA3f7nS7Oyott4zmyjlbjDqhhi43+6C5Y1EVZL+6woVSQ1btLoKLRQ4KfDPVkv5B6V43b6FUy
+        /wN6XvZI5Lo4MUcP45XA7khf7xRQJW6dG5bIIGqjF+kiHCrugT3yGY5f/JlIRr5bxdO3A9dKohfIys9h
+        4ozIQGBl4/BIXWRDSx8x+hX5TFwbkBnzY3dHhS62oaXX/fxi8ecjO+IKe8lnRuEQcO/WSo7+7CbuFvLG
+        s3WRwek9M8BG/y4LhzsFdo6NLpaNw2GDfOLZIEg/P1Y+FxcRLYrbC2y+crme5RDCwrUB7umY0SWLP2/d
+        Y3422W0+TBfVSHAP1ZHt1jskA31WfuXjHhltoyOG/t7+kBYevxh9VVLzQ4dSCFnz0Srd/lO23tPWbPRC
+        +by/Xvz56xUphi6XPn/3MJ7eWareaYEk+gC3kEmsSdxDxkap0EtbeENs78Fpy/+E0OWM+/w2+nLVX1hX
+        KbFt3ku+JN90h8e8C3VkY650Tyes07khd3TDPY1NPn/tbhHVwfDDdboC2D0noreO9+559i+XEY4Uu+aQ
+        kXrIy26cblfeVT7zcrwJdVnTG7tsdKK7ZVIXBfJyK48syGNGfWPhBgL3OYftndhlWjgi0HuccA3uJzcX
+        uL3hYbrau2wLb1jrvU+9oo/VLjE2mpVt2EureE//oEwna9a6dV76e9Tv/nKFzgmtZNU99aOjX+7hJ/IF
+        eq98kUbsAhPzs94bp0b40G8RsqF4hBRF35DlM0rXhLjnlv9QCr3nj9o1Hf1wz5mXvv4nKQZ+6llmQxvd
+        aTnBXQipHxWi91bFxPyrbMs76WU25Dlbtlfvdke49KOibG4vUR8u496+V5W3seWNuxjq0yP/1KcSuI1F
+        7+UdC0cFhvPOAWvOanfMv522sXEn/VjYhfb8igOlSPrgsBb6espy2j3nZJCvph5W+syIL0n+mF6Ww5De
+        KTx3zVq38fhRvp6jktzVlL23t7n3NVf+itPeO+tl0G88rs6HAfsx1WncRZbhWyTTkqo/bW6j5MhRu8J7
+        UNzG1B0Fcq91lu93klq2FYs7SuXeKmdeJ/N8R/0IyMEdBXJv5pTleJwUgP/nX87ViBR5l8vA/3X3AKSy
+        XkeMPrlDqrLyPFY3GBuko5Z5gDBXyHycKoXJO9wgUKeLfgahd/649ypX8zk3QOiel6cfBpbfuo2C/PNQ
+        94ArnU2UZHreHCB71f8iff1N6fPfpZb9YLNwVfuvJJ92r5zl9F253A6SLONHulO+8p1qy7Z0uY/0bpV5
+        cEcgj3SvDmcHbgi4yqzVMY9xA7BUlO7dA+4d34GKAnOFrKg/kY3Tf7uNVJysfAgryWC5giC2zadIX7xf
+        +sEdEepIUXCtv7+KRwuN30jWS58f7d4xP72peQedDQyI29OWuAeIfUwL7TDvdHf3bvcG+94px/e4I3ju
+        mSU6GxiA3ovFkugRsvzfIDlO8jPJXxb1VQnRbYY7eneC/Pvb3IDv3nmgs4Jh5lYk905t9+pcd9uZO9co
+        nfwZN2DIP0+XjchsL4mZlxXAbeQ3Lvw/E8v/a+ke3idbNnq7FBcvcQUG53Wrq3dUqHdOufkU2Zt4qfTx
+        u1z/SV+eJP36fdevsg78aEe/axEXS2RAkSJC9vDkd9/fuwbB3Z3QbTyQQ37V5fpmar7xINdX7vvt+m7H
+        91v7NF7o4x3f82jG/T/553flv09072DvbfQT809uG+FOOXHkrprcKaKFO8QaB7v+ci+hkr47Rv79G5K2
+        9OeU9rEbzGVbbro79fv0wu+5dSM6QvKquNN4gutvLs4FAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB9a8+t3budRE+Pk+iwtjVvbCXRCyY6zXX6YwAA
+        RsJpGxt3atvohbFtvEnGvUNj23zKhg3r9tIf10fcjfaXBfElGfSvlgWxPZVtkv9t2cbj9NcBABhKU93o
+        qXFifp4a53qJrbmqnZj/mty8ej/99dHmFoYM/n/yLYx0ZOF8bmZmbE/9UwAAhoIbu1o2OtY3tnlyWdxp
+        PEH/dDS1bfPJMvhf7/nwWfm0/jkAAENB9vq/4BnPsnJdnDQO1j8fLe25vdfI4P9Hz4fefTrN52kzAABU
+        mox1r/KOZbuNuWhiS3OlNjM64iQ6xv+Bl5SzORUAAKg6d2GfDOQXeMaxJUXGyg9pU6NhfHxsD/lgl6Q/
+        aJ6M7KERAMDIiDvmWb4xbMmx5vfbt4/dQpsbfnGy8iHeD5ovR2pzAABUUo4L/3aZqU2r767NDb/YNp7j
+        +5A5c7w2BwBAJcU2+p5n/MqVqU7zidrc8GtZ8zLfh8wVG31fmwMAoJJkrJryjmE5MmWbz9Xmhh8FAACg
+        DigAUigAAAB1QAGQQgEAAKgDCoAUCgAAQB1QAKRQAAAA6oACIIUCAABQBxQAKRQAAIA6oABIoQAAANQB
+        BUAKBQAAoA4oAFIoAAAAdUABkEIBAACoAwqAFAoAAEAdUACkUAAAAOqAAiCFAgAAUAcUACkUAACAOqAA
+        SKEAAADUAQVACgUAAKAOKABSKAAAAHVAAZBCAYBhMZ2sWdtOzGNjG71a1rsPSz4rOUHynbY1MRmCuL5K
+        ouO1745s2+Yr4270qImN++yr3QwEQwGQQgGAKhofH9tjyq56qKxb75BB/zT55x+96x4ZpVwmWS95y9R8
+        40GHbx+7pa4OQCkoAFIoAFAVboMfdxpPkHXqeAZ8Irk0TswXJufMo7dvH7uFriZAYRQAKRQAWG4Tnea6
+        2Eb/Lnv653vXL0JsdI7kiJnuvrfX1QbIjQIghQIAy6U917hznETHyMB/jXe9IiQVWV+ulX+eMNldeTdd
+        jYAlowBIoQDAoMVnrvobWW9OkPXmhkXrEiFLy3VSOB7HxYPIgwIghQIAgzIzM7Zn25o3yob7Cu96REje
+        uGtFZJ1yF43qagbsEgVACgUABmFyrnGQrCtzi9YdQkpInJifT85H99HVDfCiAEihAEBosTUvlb20q73r
+        DiGlxVzjjgboagcsQgGQQgGAUCa2NFfKntk3vOsMIeFywkx33310NQT+igIghQIAIfQu9LNRx7u+EBI6
+        1iRuHdTVEeihAEihAEDZYtu8F/f0k2WPe3bA/IoDdbUEKADSKABQpvZ8829lnXCPdPWvK4QMNOZC2cY9
+        QFdP1BwFQAoFAMrirsKW9YHBn1QqsY3+77TOqnvoaooaowBIoQBAGVpJdEcO+5PKxkbnTG5evZ+urqgp
+        CoAUCgD0a+asfVa3rTnLu24QUpHESbTJ3Zmiqy1qiAIghQIA/XBv8JM9/0nvekFI1WLNuK66qCEKgBQK
+        APRDBv93e9eJgJE9uS2xjb4n0z4q7pjXx0njn9ud5vNI9dNKmq+IE/Ov0ncfk778H9l2nJPu39CRdee1
+        uvqiZigAUigAUFTcjR4lfX+9d50oN9e5dcw9UXB6U/MOOnmMiOl5c0CviLPm1MGsT+aadrfxQJ08aoQC
+        IIUCAEVs2LBuL+n3wHtv5oKWjd7urjHQyWLEuff9S6H3Xun/SxavDyXGmmR2duxWOlnUBAVACgUAioiT
+        6EPedaGMuDe8JeYNM+cecFudHGqmPbd277gTvVPWg79415ESIuvw23RyqAkKgBQKAOQ1tWn13aXfty5a
+        D8qIjU6cTtas1Umh5iY6zXVu++JdV/qO+YtrXyeFGqAASKEAQF6y4Qxw1b+50p3j10kAN9O25nWynpRe
+        dLqXVekkUAMUACkUAMhjKon+zrsO9BXzh7gT3U8nAXjpY6ZLvTYgTqIb3RMsdRIYcRQAKRQAyEM2mKd4
+        14Hi+fVpGxt30uaBTK1k1T1lnfltah3qLzY6UZvHiKMASKEAwFLJuvIA6e9ti/q/aKz5vbsFTJsHluR0
+        u/Ku7cRc5F2nisRGN/DWwHqgAEihAMBSST9/1dv/RWKjP051m/fWpoFc4mTlQ2JrrvKuWwUSJ9FntGmM
+        MAqAFAoALIV7hnqZG1xZZ16kTQOFtG3zld51q1gum9gydhttGiOKAiCFAgBL0XtSm6/vi+Wz2izQF9n2
+        nOhZvwolto3naLMYURQAKRQAWArp55lF/V4o5sJ4Nmpos0BfpjavWCXr1aWL17P8ce+X0GYxoigAUigA
+        sDvTyZq17nYpb9/nDYf+UTL3ch/vupYzso5fO9Pddx9tFiOIAiCFAgC74wZtb7/njpl3rw/WZoFSuGf6
+        SxFwrn+dy5epbvRUbRYjiAIghQIAuyMD93Hefs8dc4g2CZRKtmP/4l/n8sZ8TJvECKIASKEAwO5IH5+9
+        qM/z59Lx7tittUmgVO7lQTJ49//iIBvNapMYQRQAKRQAyOJez+rt85xp2ehYbRIIQtaz49PrXd64a124
+        DmB0UQCkUAAgS5w0Dvb2ed7Y6JHaJBCErGdPX7TeFcjkXOMgbRIjhgIghQIAWaR/D13U37lj/uIu1NIm
+        gSDcaQB3Jb9/HcwRG71Qm8SIoQBIoQBAltiaj3v7PEekjQltDghKis0f+9bBPGkl0Qe0OYwYCoAUCgBk
+        kf79n0X9nTMtG31EmwOCcs/0962DeRLb6GvaHEYMBUAKBQCySP/+76L+zptO4+XaHBBU25o3etfBfFmv
+        zWHEUACkUAAgi/TvxkX9nTPuQkJtDggq7ppn+tbBPIlt9CNtDiOGAiCFAgBZpH9/s6i/c4arqjEoJd21
+        slGbw4ihAEihAEAW6duLvX2eI1ObVt9dmwOCcsWmbx3Mmd9ocxgxFAApFADIEifR5d4+z5O5xp21OSCo
+        uBPdz7sO5oo5X5vDiKEASKEAQBYKgMFpdxuPjxPzRfk+nSPLbasMRNfIP8+Orflc3I0epb+GDBQAyEIB
+        kEIBgCwUAOFNbl69nwz8be+yu3lOnjlrn9X6Z/CgAEAWCoAUCgBkoQAIy10fIXv4v/MuN19sdE7cjfbX
+        P0cKBQCyUACkUAAgCwVAOBNbmitl8D/Tu8yys3Hm3ANuq81gJxQAyEIBkEIBgCwUAOHIsvnwomW1xLRs
+        9HZtBjuhAEAWCoAUCgBkoQAIw+3Bx4n5s3d5LSU2unh8fGwPbQ6KAgBZKABSKACQhQIgDFkufb+6ljsD
+        FqMAQBYKgBQKAGShAAjDHcL3Lqt8OVSbg6IAQBYKgBQKAGShAAgjTszR3mWVK+b92hwUBQCyUACkUAAg
+        CwVAGLE1H/cuqzyx0RHaHBQFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACAL
+        BUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQ
+        AKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEB
+        EAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUA
+        slAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAg
+        CwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAY
+        FABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQ
+        ACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYF
+        ALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAA
+        hEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVA
+        CgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABh
+        UAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACAL
+        BUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQ
+        AKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEB
+        EAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUA
+        slAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAg
+        CwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAY
+        FABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQ
+        ACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYF
+        ALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAA
+        hEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVA
+        CgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABh
+        UAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACAL
+        BUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQ
+        AKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEB
+        EAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUA
+        slAAhEEBEAYFALJQAKRQACALBUAYFABhUAAgCwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhUAAg
+        CwVACgUAslAAhEEBEAYFALJQAKRQACALBUAYFABhtOei+3qXVb78VpvDiKEASKEAQBYKgDAoAMKIz1z1
+        N95llSOxjX6pzWHEUACkUAAgCwVAGBQAYYyPj+3RTsyV3uW15Jhva3MYMRQAKRQAyEIBEAYFQDiyB/89
+        7/JaYlpJ8xXaFEYMBUAKBQCyUACEQQEQTts2n+xdXkvLJRNbmiu1KYwYCoAUCgBkoQAIgwIgLFlvT/Eu
+        s92k1Yleo01gBFEApFAAIAsFQBgUAGGt7zSidmLmvcttF4kT8wX9c4woCoAUCgBkoQAIgwIgvMnuyqYU
+        AS3vsts5NrohttEHt28fu4X+KUYUBUAKBQCyUACEQQEwOLFtPEeW1w/cQH/zZWiukJw0OR/dR38VI44C
+        IKXVMS/xfcicWa/NYcRQAIRBATB47rTA5FzjoJZtPG6q27z3xJax2+iPUBPyvfnBou9RzsQd8yxtbvi5
+        D+P7kDkzo81hxFAAhEEBAAyee8iT97uUJ93G47W54ec+jPdD5omNZrU5jBgKgDAoAIDBk+/Nrxd9j3Jm
+        yq56qDY3/Ca7zYf5PmSu2OhibQ4jhgIgDAoAYLAO3z52S/neXeX9LuXIaZ1V99Amh5/7ML4PmTfu/Jo2
+        iRFCARAGBQAwWHE32t/7PcqZyc2r99Mmh9/MuQfcVjYkqatj80cW7qO0SYwQCoAwKACAwZLvzNMXfYdy
+        xh1BGLnbRWVDco7vw+aJLJj3anMYIRQAYVAAAIMVJ+Zo7/coXzZqc6NDNkYTng+aN9PaHEYIBUAYFADA
+        YMn3Zdb7PcoTa76pzY0O+WCfXPRB8+e69tzea7RJjAgKgDAoAIDBcdsg+c5sW/Qdyhn3xEhtcnTIhuRF
+        vg+bP+YN2iRGBAVAGBQAwODI2PR+73coZ1qd6Gna5OiYTtaslQ/Xd3XUtibhedqjhQIgDAoAYDBmZsb2
+        lO9K39e5Sa6b6e67jzY7WuLEWM8Hzp2RekwiKAACoQAABqOU9930Yn6sTY6elo2O9X/ofHGPWnQPXNBm
+        MeQoAMKgAADCG++O3bptzVne70/OjOT5/x3cCzJ8H7pgDtVmMeQoAMKgAADCk+3Xu7zfnSLpNh6ozY4e
+        t9cuH/K8RR+6WC4bqacl1RgFQBgUAEBYbrvTTsyV3u9O3liTaLOjSz7okYs+ePHMjI+P7aFNY0hRAIRB
+        AQCEMzs7disZtH/q/d4USMtGb9emR5e+F6D/uwFuypHaNIYUBUAYFABAOPLd+JT3O1MkNrphelPzDtr0
+        aJMNUxlPBdwpPBtgmFEAhEEBAIQh34t3eL8vhWNO0qZHXyuJHuFfCAXTe9GQOUSbx5ChAAiDAgAon2yv
+        DpPvRplHsbfFneh+2nw9yIeeSS2EfrOtFudQRhAFQBgUAEC5ZKB+p/d70kdiG31Pm6+Pkm8J/GvixHxh
+        w4Z1e+lkMAQoAMKgAADKMbGluVLGlm94vyN9RLZ9N7Y6jQfrZOpFFui3fAul71iT1HahDiEKgDAoAID+
+        6SnrXy/6bpQS83mdTP1MdJrrZAH8xb9g+kzvuoDo01ObV6zSyaGiKADCoAAAiptO1qyVndQvyvegzPP9
+        O+fS2o9PshDemlooJcf8RTrxaB4aVF0UAGFQAAD5xd1of9kmHdO25mrvd6Ks2OhVOsn6cm9RkgH6J94F
+        VGZsdINsECfiTvRijgpUCwVAGBQAwNK05/ZeI9+Xl8qgH8v26Ebvd6HUmEneZ6NcxSUL5dLFCylMtIN/
+        JfmsdPgb5b//fsquemhsm/ea6jTuQgYbGWT+tHP/FEmrYx7ja7vO0cOX3uW11LgXePnaJmQo023ee7Lb
+        fFjLmn+Q9fstsv3/b9n+dOTfQx3m98T8wRUcOvzBkQXzdMkAO4EQQggZXNzOZ9xpPEGHPexMFtCH0wuM
+        EEIIGYVIAfA2He6Qtn372C3ixHzBt+AIIYSQYY0M/p/RoQ674t7uJwvrO+mFRwghhAxjZMf261z0t0Tu
+        SX5tG035FiQhhBAyRDl5vDt2ax3esBRugUnVVPqjFwkhhJAB5fjZ2bFb6bCGPHrXBJRxLzMhhBAywMRJ
+        dIwbw3Q4Q1F6r/61voVMCCGEVCbWXN1Kmq/Q4QtlcC/3kYV79qKFTQghhFQgsTVnTifm/jpsoUwzGxuG
+        6wIIIYRULNvaNvrSTHfffXS4QijtbuPx7cRs9nQCIYQQMrhYc1YraT5JhycMwsy5B9w2TszhUghc6e0U
+        QgghJFjMFS0bvZ2r/JfRzFn7rG4l0QfiMt4oRwghhGTnUjfmrO80Ih2GsNzi2aghFdl72jY6x9NhhBBC
+        SPFYc5Z7lj/n+SvO3THg7sGUTrtkUScSQgghS4mN/ij/PGGq03wi9/QPmZmZsT17xUAneqdUb7F05Nab
+        dS4hhBCyIza6XjIr48VH3aDPI3xHiHvHwNR840HSwS/UCwhPkn+f0g4/S/77AnctASGEkNGLbOP/0NvW
+        L2zz49hGX2tZ8z752fPb3cYD3cXlOlzUwNjY/wdJZGdaEj/aMgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="btn_Cerrar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAYAAAD0eNT6AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        xAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAADjPSURBVHhe7d15
+        /HVjvf9xmWdllllRKJ04qQyRUKlOpTToIJUx4xEqJc2USIdKAxlOg04hlCGzyJgImUuSecjsxu/3fqfv
+        6Xb73Pf9Hfa+rs+11uv5eLz+0OCxv3utva61117rumYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAGjWTWkz9m9pIfUBtp/ZUX1aHqKPU8epMdYm6cbJuVfdO1pPq/03W
+        JDX5f3+38v/vauV/11nqNHWM+p7aX31KfVT5tbxF/btaQs2mAADAdMyuVlQeRHdQ+6kj1MnqCnW7ekpN
+        PmBn7z51jTpH+cTEJynbq7epV6j5FQAAnTe3epXaTH1GeYA/V/1VPa2iQbTr+UrDRepH6vNqC7WGeoEC
+        AKApc6hVlQf6fdUJ6ibV10F+vN2m/JPDQWprtaaaRwEAUN2cai21q/qhuk5N+ds6DS7/DHKt+rHyvQ8b
+        qgUUAABDM7NaWW2u/K30PPW4igYqKptvVjxS7axWU89TAACMiwd8Dyb+punL+PeraPChfD2g/PPBPmp9
+        5ZssAQAIeZBYR/kGvTPUIyoaXKi9HlO+YuOnK/yzAScEANBzL1H+/f5U9aiKBg/qXg+rk5QfuXyRAgB0
+        nO/Q9yVh353vCW6iwYH6l+8hOFRtonjSAAA6YnHl2ep+pfiWT9PLP/14X9lJcXUAABqzlPId4f7dt7UZ
+        9ChXVynfTLi8AgAktIwaGfSZdIeG0cjJAFcGAKCyF6rd1eUqOmATDSOfYPpE0z8TeB8EABTgG/k2VV4o
+        h1n3qHb+ielsta2aTwEABsyT8vhObU/yEh2IiWrnm0y9XLKfNGE2QgCYAK9//2l1s4oOuERZ8/0CnmOC
+        tQoAYAz8bd9zuz+hooMrUSt5vQiuCgDANHgN+F3UH1V0ICVqveuV15ZYRAFA771SHaaYe5/6ktcm+L7y
+        6pIA0DteR9+r7PHMPvU5P074NsXPAwA6bVbl9fSvVNHBkKiveS4LfzZmUQDQGfMqz9L3FxUd/Ijomf6m
+        PNug74kBgGYtpLwG+99VdLAjojjPd7G/YqZBAE1ZUPlbDJP2EE0sP0boCbA8JwYApOVv/Az8RIPvIXWQ
+        4hFCAKl44N9XPayigxcRDaYHlT9rz1cAUI0XP/myYuAnKtu96pNqbgUAxfhRpa3VHSo6OBFRme5Wnl1w
+        TgUAQ+PJSjZRN6joYEREdfqr8kn5jAoABmoN9RsVHXyIKEcXqzUVAEzYCuokFR1siChfnl7bq2kyhwCA
+        cfHNRb7Bz88hRwcZqpMfsbxRXah8YuYD/YHqU2o79W7lpWfXUV5W2b1ULffPPMOcm0uNmEmN/OducTXy
+        v3+F8roNG6n3KV9m9m/OX1TfUD9WZ6trFI9/5sqPDu6l5lAAMF3+nd8H+ltVdFCh4TVJ3aTOUF4t7tNq
+        M+UB2INyC/PEe7BZVvkno43Vx9Qh6lfqWuWV8KK/nYbXzcr37gDAVL1cnaWigwgNrtvVqcpTvX5IrauW
+        UTOrrvNNaksqX6HYSn1dnaY8B370XtHg8pWaf1MA8H/8PL9nGfM30OjAQePL33YvVYer/1K+NL+wQmx+
+        9TrlnzJ81eC3iisGg82fca/Pwc8CAGZ4u+Jy/8TzjVdXqe+oLdRKqg/f6IfNP3v4PgafFBymvJT0kyra
+        BjT6rlevVwB6aFF1jIoODjT9HlG+pPol9Rblb68owzeoevDyuhP+yepRFW0jmnY+af2e8o2fAHrAN/lt
+        qTyVaHRQoDhPd3yi2lW9RrVwQ15fzK7808He6teKqanHlu+/8NMjADrMd2f75rPoIEDPzY/beSnWtykP
+        MmiDf3rxkxNeNOcSFW1bem4nKN+gCaBDfOf1LopvRtPOz03/Qvn3Zp8soRu8LbdXHuD4DEy7+9U2ylcK
+        ATRuKeXnyqMPOz2zoNE3le/Qn02h23wl563KT2bco6J9gp55NJOZBIGGefIPDnLPzfc/eAY9X9rnt/z+
+        8gyI/qnAj8AyD8Fzu095UjAADVlA/VRFH+q+5kHfj5G9UfF4Hqbkk4H11LcVN8g+u++qyaeOBpDUm9Vt
+        Kvog9y0/qneU8mN6sypgNPxTkO+K9/0gT6ho3+pbnsb5VQpAQv5t82DlZ3ujD3Cf+r3aQT1fARPhmRt3
+        Vp7RMdrX+pRPhj6hfLUEQBLLq8tU9KHtSw8qX6pcXQHDsIryDaN/V9E+2Jc8+ZJvLgZQ2XtUn5dhvVh5
+        idp5FFCC97Vt1eUq2if7kG8QZIVBoBJf8ve3kejD2fW8QIyXy2VlM9TmZY99n0lfpyM+UHFTLVCQl471
+        SmnRB7LL+UqHH9ny2vhAJgupPVUfb8A9Vy2mAAyZL7v17ZL/Dco39fEoErKbU3nWQa+2F+3LXe2vyldD
+        AAyBp+b06md9usvf87hvrrjEiNZ4+m1PNHWeivbtLjZJ+SoIgAHy42wnqehD18U8ZzvfJtAVayuvUhjt
+        613sCDWHAjBBK6irVfRB61r+tuRlXYEu8kmtT26jfb9r/U4tpwCMky8h9uH3fj9X7G9JQB+sqfqwLLfX
+        IXmTAjAG/r3/U+opFX2wutL56g0K6CNfEej6Sp1PKt8UCWAU/Hz/j1X0YepKnrxnIwXgmfU7rlDRZ6Ur
+        7a98YySAqfAqfn6mNvoAdaE/Kc9c6CscAP7Fg+MH1S0q+ux0of9V3BwIBJZV16jog9N6Dys/wsiHH5g2
+        r1rpxYe6uiTxhWoRBeCfXqPuUNEHpuU8Z8GRipn7gLHx1UBP9e3f0KPPVsvdqF6igN57h/I35OiD0nL+
+        nd93OwMYP6930cWfBX2FY10F9NYuqmt3+t+q/lPxOz8wGP4sbaa6ts6AF/XaVAG98yUVfShazZcqD1DM
+        1w8Mx7zKd9M/oaLPYIv5Z8I9FNALPpv/uoo+DK3mR5herQAM38tU11YD3VcBnTaTOlxFH4AW8zcRf3B9
+        5zKAcvzY4NbqQRV9NlvsEMVcAeik2dTPVbTjt5jn7V9RAahnGXWKij6jLfYdxUkAOmVudZqKdvjW8toE
+        fk6ZDymQxybqLhV9ZlvrR2oWBTRvQeVH4qIdvbVOVDzTD+S0qPJnNPrsttaxyldNgWa9QF2ioh28pR5V
+        /tbPo31AfpurLtwb4IWSfPUUaM7zVRe++f9BraIAtMNTi5+jos90S/lv8OOPQDPmV5epaIduJU9Q9FXF
+        ZTigTX7qaC/V+rwBF6h5FJCeL/tfqqIduZU8m9/6CkD7VlPXq+iz3kpnqzkVkNZ86iIV7cCt5EcVvRAJ
+        gO7wN2jfXR995lvJT1LNroB0Wv/N3/Nyb6MAdNf2yjf1RseAFvIXlJkVkIbnvz9fRTtsC92iVlcAum9V
+        1fJPAkcr5iFBCp4G92QV7agtdLpaSAHoD99Zf4yKjgkt5BkDeSwZVfks9Mcq2kGz51W4DlLMuAX0l9cT
+        mKSiY0T2vqGAalpd1c+ThHjqUABYR92pomNF9j6ngOI+r6IdMnt/VCziA2ByL1ae9Cs6ZmRvDwUU42lx
+        ox0xe8crZtUCEPGjgi2uWOqfMzdVwNB9QHmHi3bEzPn3fs8MBgBT4xvrPqNaO8b5Mea1FTA0aynvaNEO
+        mDV/kPdRADBavkeotfkC7lEvUcDALadau1HGH+D3KAAYqzXUXSo6tmTtJrWwAgbGi/tcq6IdLmv+4K6p
+        AGC8fHPgdSo6xmTN07GzbgAGws/Je7KcaEfLmmf5Wl4BwEQtqM5T0bEmaz9VzBaICfENMUeqaAfL2hnK
+        KxICwKB4uvNfqOiYk7WvKGDc9lbRjpW1nylPTQwAg+ZFeI5S0bEna9sqYMx8F2xLj8J4gQxWyQIwTL6s
+        foiKjkEZ8zTHGypg1DxT3gMq2qEy5oUx+L0LQCl7quhYlDE/HuinuIDp8u/nLS2VebBiVSwApe2kWrlK
+        erniyQBMk79F/1JFO1DGvB4BANSylXpKRcenbB2mgKn6gop2nIz5BkUAqO2DqpWTAG4KROidqoXLWX6N
+        OygAyOJDqoWTAE/l/hoF/B/PH32/inaYbO2mACCbVk4CblOLKeAfE1xcraIdJVsfVwCQle8JaOFK6pmK
+        x6bxjxtDoh0kW59TAJDdh1ULVwL2V+gxr+0f7RjZOlABQCt2VNGxLFO+UvEuhR56kWphsh9foeA5fwCt
+        2UdFx7RM3aeWUuiR2dSlKtohMuUVrWZSANCiA1R0bMvU2YrjbI8cpKIdIVPHKm5SAdAyX708XEXHuEzt
+        odAD/6Gy36XqO1RZ1Q9AF8yiss+w+rhaTaHD/Ozn3SraAbLkRxJZzx9Al3ge/t+o6JiXpT8qPxaOjjpR
+        RRs+S3epFysA6JoF1LUqOvZl6dsKHeRnU6MNnqVHFFNUAugyP311p4qOgVnaRKFDllaZH/nzpBleiwAA
+        um5t5Tn5o2Nhhnwl9oUKHeC7UE9X0YbO0s4KAPpiM5X5ZuxTFfOvdIAH12gDZ4nfnAD0kac3j46JWfK6
+        BmjYCuphFW3cDB2vmIACQB/5G/aPVHRszJBnCeSngEbNqM5X0YbNkB85mVcBQF/58cDfqegYmaGfKTRo
+        BxVt0Aw9qFZWANB3vknbN95Fx8oMbazQEE/448s30casnW984TETAPiXN6gnVXTMrN3fFJOzNcSXbaIN
+        maH9FADg2fZU0TEzQ4cqNGAjFW3ADJ2hWOAHAJ7LNwX+REXHztr5yq2vUiCxudWfVbQBa3eLWkgBAGI+
+        hl+lomNo7TyN8ewKSR2oog1XO8969SoFAJg23yCd9fHtLyok5KUcs95Eso0CAIzO1io6ltbuCfVyhUT8
+        29GFKtpgteM5UgAYu6z3A/heLiTyQRVtqNr9VXkJTADA2Myjsi4fzNwASfimEQ+00UaqmVf4W18BAMbn
+        39XjKjrG1uwmxQ2BCXxJRRuodvsrAMDE7KaiY2ztPq5Q0XLqURVtnJpdqTg7BICJ87ouZ6roWFszT+nO
+        YkEVHauiDVMzn5BwlygADM4y6gEVHXNrdrhCBeupaIPUbnsFABgsr88fHXNr5nu9VlcoyGvo+zJ7tEFq
+        dqLyI4kAgMHysfWXKjr21uw8xXG/oA+paEPUzJenllAAgOHwb+73qOgYXLP3KxQwm8o43/+2CgAwXJuq
+        6BhcM6/1MofCkO2qog1Qs7MVl4AAoIzjVHQsrpnHJgyRJ/25Q0Vvfq280M+KCgBQxpLq7yo6JtfqLuXZ
+        CzEk+6joja/ZJxUAoKxdVHRMrtmeCkOwoMr2HOgVahYFACjLEwT9VkXH5lrdreZVGLADVPSG18rPf75W
+        AQDqeIWapKJjdK32VhggP16XbcrfrykAQF0+FkfH6Frdr16gMCDfUNEbXatb1VwKAFCXbw73Y3jRsbpW
+        X1AYgEXUIyp6k2v1AQUAyOF9KjpW18oLBS2sMEH7qegNrtUFimf+ASAXz8cSHbNr9RWFCZhfZXrW82n1
+        agUAyGU15Zuzo2N3jR5WiyqMU7bn/o9QAICcvq+iY3etfAUb4+Cb7DyzUvSm1shnc559CgCQk3939134
+        0TG8Rp67Zj6FMdpDRW9orfZSAIDcso0drBEwRl5V6XYVvZk1+pNipScAyM8rxt6komN5jTx+zKwwSlup
+        6I2s1XsUAKANm6voWF4rP6aIUfq9it7EGl2ieOwPANrhdQIuV9ExvUYeRzAKG6joDazVmxUAoC1vV9Ex
+        vVbrKkzHiSp682p0vgIAtOk3Kjq21+gEhWlYXmWayOENCnl4mU3fj7G/Olqdpc5Tx6pD1Y7K+xAwDCuo
+        nZT3Ne9z3ve8Dx6lvqo2USwFm8vaKjq218gTya2kMBX/raI3rkbnKtTn3/LerU5Vj6toW03Z9cpLci6o
+        gInwc+WekOwGFe1rU+Z99BS1sfK+i/pOVtG2qtF3FQKeLCHTtL8+c0Rda6mJ3BDqSTj2VDyCg7GaRX1C
+        eVGXaN8aTb4JbU2Ful6lou1TIy9rzyJBgd1U9IbVyGfwqGcm5eU0B/VzkBdwWkoBo7G0ulBF+9JY8z78
+        OcXVgLp8BTHaPjXaXWEyfszOl22jN6tGLPhTjyfx+KmKtstEuk39mwKmxfuI95VoH5pIxyjv26jjdSra
+        LjW6VvFo+WTWU9EbVSPu1KzH35J8oIy2yyC6T/lyIBDx4H+3ivadQXSc8tUt1HGOirZLjXgkcDI/UtGb
+        VKM1FOrwZf9omwyye9SqCpic9wnvG9E+M8g+q1DHm1S0TWrkp5ggCyjfGBG9SaXz736owzf8lXoElJMA
+        TK7U4O+8j/Mlo56LVLRdSucxb37Ve14pKXqDauRHd1CeL/2Xnv6ZkwBYycF/pMsUNwXW8U4VbZMaeU6J
+        3vuDit6c0vk5X36fq8MTqETbZNhxT0C/Dfs3/2n1DoXyfPPdNSraJqW7UvWaL4VFb0yNPqpQR81HdLgS
+        0E81vvlPnienQR3bqWib1KjXT5wdrqI3pXQ+EMylUJ6nTh3tDH/DiisB/VLzm/9Ij6l5FMqbU9Xe/iN9
+        T/WSd/6HVPSmlM53n6OO96pom5SOk4B+yDD4j/QuhTr2U9E2KZ3HwF6uH7G5it6Q0vlMfFGFOryISrRd
+        asRJQLdlGvzdvgp1eGbQSSraLqXbSvVOlgUaensJJon/UdF2qRUnAd2UbfB3XkUQ9fxERduldKerXllI
+        ZTn78oEB9Xg51Wi71IyTgG7JOPi7MxTqyXIT+pOqV1eht1fRG1G6ixXq8prq0bapHU8HdEPtu/2nlaem
+        RV0eA6JtU7pePYWW5aDfy99ekvm5irZNhrgS0Las3/xH8qJXqGsbFW2b0vXmZNA3XzytojehZF7nu5d3
+        XyZzqIq2T5Y4CWhT9sHfHaxQ19zKY0G0fUrmKaIXV523p4regNJ9V6G+HVW0fTLFzwFtyXzZf/J2Vqjv
+        MBVtn9LtojrvchX98aVbXaG+5VW0fbLFSUAbWhn83SsV6styM+D5qtOyHOy98AzyuF5F2ylb/ByQWwuX
+        /Ue6WXleeuSQYU0a/zS+tOqs3VX0h5eOef9z2VtF2yljnATk1NLg7/ZSyCPLqrQfU511ror+6JI9op6v
+        kMeC6gEVba+M8XNALi1d9nf3qwUU8vAxyLPCRturZJ19NN2T/3jCg+iPLhmzb+WU5ebQ0cZJQA6tDf6u
+        09/yGnacirZX6ZZTnfMhFf2xpdtIIZ+ZlW+CibZZ1vg5oK7WLvu7i9QsCvlkWZhsB9U5x6vojy3ZvWpW
+        hZw8R8RtKtp2WeNKQB0tfvP/q1pSIScvE5xhToATVafMoR5W0R9bMhb+yc/f6lo7sHMSUFaLg79fr/dt
+        5OafiKPtVzLfp+YxszPerqI/tHQbKuTX4qVdfg4og30Dw+SfiKNtWLpOjVX+5h39kSW7S/HbWzs40GNK
+        7BMYNo8RHiuibVmyA1Vn3KKiP7JknnMebeGAjxHsCyjlWyraniW7RnXCS1X0B5buDQrt4cAP9gGUtJ6K
+        tmnpllXNy7DYy53Kj5mhTQwA/cW2R2keK/zEWLRtS7adal6Gx/8OUWgbA0H/sM1Ry9Eq2r4l89jZNJ9J
+        edrL6I8r2QYK7WNA6A+2NWp6j4q2cck8J8FsqlkZlll8SDX9JuJZGBi6j22M2uZWGdYGaPretQyrvP1C
+        oVsYILqLbYssTlbR9i7Zl1WzzlHRH1WyTtxIgedgoOgetiky8dgRbfOS/UY1yfMqP6GiP6pknXiUAiEG
+        jO5gWyKbJVS03Uv2uPJY2pzXq+gPKllnJlPAVDFwtI9tiKyuUtH2L5nnJWjOXir6Y0p2gEL3MYC0i22H
+        zA5S0T5Qsn1Uc7ykYfTHlIzFf/qDgaQ9bDNk91YV7QclO1M15Xmq9nKdXn54doX+YEBpB9sKLZhH1b6X
+        zcsDN7WQ3Uoq+kNK5isQ6B8GlvzYRmjJuSraJ0q2qmrGVir6I0q2q0I/McDkxbZBaz6jov2iZNurZhyu
+        oj+iZKsr9BcDTT5sE7RoTRXtGyU7QjXjWhX9EaXybyazKvQbA04ebAu0yr+/+56yaB8plcfUJsynnlbR
+        H1GqsxVgDDz1sQ3QurNUtJ+UymPqAiq9dVX0B5TsiwoYwQBUD+89usBjSrSvlGx9ld4uKnrxJdtIAZNj
+        ICqP9xxdkWE+gN1Vej9Q0YsvlS+VzK+AKTEglcN7jS55gar90/YPVXq/V9GLL9UfFDA1DEzDx3uMLvLa
+        MtG+U6r0a9vMpmrPmnSoAqaFAWp4eG/RVd9T0f5TqqfU3Cotz1YUvfCSbaGA6WGgGjzeU3TZh1W0D5Xs
+        NSqtD6noRZfM0xADo8GANTi8l+i6DF9wP6LS+oaKXnSpHlUzK2C0GLgmjvcQfZDhJ+7US9z/WkUvulSX
+        KGCsGMDGj/cOfXK5ivapUp2s0rpFRS+6VIcpYDwYyMaO9wx9U/sx97+olOZStZ+TZAVATAQD2ujxXqGP
+        Mkx05+n20/EBIXqxJWtiqkSkxsA2fbxH6Kt1VLR/lSzlkwDvVdGLLdnCCpgoBrip471Bn82ral/p/k+V
+        zqdV9GJLdbsCBoWB7rl4T4D697rto9L5HxW92FKdooBBYsD7F94L4Bm1n3Y7SqVzsYpebKm+qoBBY+Dj
+        PQAmd4iK9rlSXaDSuV9FL7ZUWypgGPo8ADL4A8+2k4r2u1LdpVLxYwnRCy3ZugoYlj4OhAz+wHO9UUX7
+        XslSPQr4MhW9yJItrYBh6tOAyOAPxJZV0f5XMo+5abxZRS+yVJMUawCghD4MjAz+wNTNqLzuTLQflmoj
+        lcZWKnqRpbpJAaV0eYBk8Aem70oV7Yul2kal8XkVvchSna6Akro4UDL4A6Nzgor2x1J9QaVRe4GE7yug
+        tC4NmAz+wOh9U0X7ZKmOVGnUnhjBsxACNXRh4GTwB8bmEyraL0t1hkrjOhW9yFKlnBsZvdHyAMrgD4yd
+        x5xo3yzV1SqNB1X0Iku1lgJqWlXdo6L9M2t+vS2+Zr/XQE21VwX0SXsKs6voBZZsCQXU1uK36Zbimz+y
+        WE5F+2ipvCLhLKq6JVX0AkuV5o0AhJOA4cTgj0xmVU+paF8t1eKquleo6MWVymsQAJlwEjDYGPyR0R0q
+        2l9LleKnsDeo6MWV6kYFZMNJwGBi8EdWvhEv2mdL5TUJqnufil5cqX6rgIw4CZhYDP7I7BwV7beler+q
+        bgcVvbhSnaSArDgJGF8M/sjuWBXtu6XaTlW3j4peXKmOUEBmnASMLQZ/tOC7Ktp/S+XJiKr7hopeXKkO
+        VEB2nASMLgZ/tGJfFe3DpdpPVedv4NGLK9VeCmgBJwHTjsEfLdldRftxqQ5V1f1URS+uVNsqoBWcBMQx
+        +KM1W6poXy7VMao634QXvbhSvUsBLeEk4Nkx+KNFm6hofy7Viaq6M1X04kq1vgJaw0nAMzH4o1UbqWif
+        LpXH3uouUtGLKxULAaFVfT8JYPBHy9ZV0X5dqhRz4PxBRS+uVKsroFV9PQlg8EfrPPZE+3aprlDV3aSi
+        F1cqH0CBlvXtJIDBH12wsor271LdoKq7XUUvrlQrKaB1fTkJYPBHVyyron28VLep6h5Q0Ysr1YsU0AVd
+        Pwlg8EeXLKyi/bxUPlZU97CKXlypllRAV3T1JIDBH10zr4r29VL5M1Xdoyp6caXyWRjQJV07CWDwRxfN
+        raL9vVR/V9XVPgGYTwFd05WTAAZ/dNVcKtrnS/WIqu4xFb24Us2hgC5q/SSAwR9dVvsE4HFVnV9E9OJK
+        NZMCuqrVkwAGf3TdnCra90v1lKruCRW9uFLNqICu4gQAyMlXn6N9v1QpTgAmqejFlWpWBXQRPwEAec2u
+        ov2+VP75vbonVfTiSuXfYYCu4SZAILfaJwAPqupqXwF4vgK6pCuD/0icBKCLat8EeK+q7iEVvbhSLaiA
+        ruja4D8SJwHoGo890b5eqjtUdbUPVospoAu6OviPxEkAumQJFe3npbpVVfcXFb24Ui2lgNZ1ffAfiZMA
+        dMWLVbSPl+pmVd11KnpxpWIxILSuL4P/SJwEoAtepqL9u1Qee6u7QkUvrlSrKKBVfRv8R+IkAK3z/hvt
+        26W6SlV3oYpeXKnWUkCL+jr4j8RJAFq2tor261Jdoqo7W0UvrlRvUUBr+j74j8RJAFq1oYr26VKdrqo7
+        RUUvrlTvV0BLGPyfHScBaNF7VbQ/l+pYVd3PVPTiSrWNAlrB4B/HSQBas62K9uVSHaGq+66KXlypdldA
+        Cxj8px0nAWjJXiraj0v1DVXdV1T04kr1eQVkx+A/ujgJQCv2V9E+XKoUY9/HVfTiSvXfCsiMwX9scRKA
+        FnxfRftvqfZQ1fk3+OjFlerHCsiKwX98cRKA7I5T0b5bqhT3v22iohdXqrMUkBGD/8TiJACZnaOi/bZU
+        KZ6AW19FL65Uf1RANgz+g4mTAGR1tYr22VJ5HoLqVlXRiyvV/QrIhMF/sHESgIz+rqL9tVQvV9Uto6IX
+        V7I5FJABg/9w4iQAmcyjov20ZAur6jz4Ri+uZMsqoDYG/+HGSQCyWFFF+2ipJqkZVQr3qOhFluq1CqjJ
+        P4XV/hyMNb/eFl+z32ugptr3vt2q0qi9JPC7FFBLi9/8R75Nt/zagVo2V9G+WapLVRq/UtGLLNVuCqih
+        CwMoJwHA2HxSRftlqU5UaXxPRS+yVIcooLQuDZycBACj5zEn2idL5VkI0/isil5kqX6pgJK6OGByEgCM
+        zskq2h9LlWoNnK1V9CJLxWRAKKnLAyUnAcD03aCifbFUXoo4jbeo6EWW6jGV5pEIdFofBkhOAoCpm0U9
+        oaL9sFQpZgEc8QoVvciSLamAYerTwMhJABBbQUX7X8mWV2nMrZ5W0Qst1ToKGJY+DoicBADPVfuK91Nq
+        NpXK31T0Yku1lQKGoc8DIScBwLPtrKL9rlR/Vumcq6IXW6oDFTBoDIC8B8DkDlbRPleqM1U6h6noxZbq
+        NAUMEgPfv/BeAM/wWBPtb6XyWJtO7ZmRblPAoDDgPRfvCTDDDHeoaF8r1adUOpuo6MWWbAEFTBQD3dTx
+        3qDPFlHRPlayD6h0XqmiF1uytRUwEQxw08d7hL7y8/fR/lWy1VQ6GR4F3E4B48XANnq8V+ijj6lo3yqV
+        HwGcS6XkNYqjF10qFgXCeDGgjR3vGfrmByrar0p1vUrLi/JEL7pUv1XAWDGQjR/vHfrkdyrap0p1rEpr
+        XxW96FI9qmZVwGgxgE0c7yH6wGsAeIyJ9qdSfUGltamKXnTJUt4ggZQYuAaH9xJd530l2o9K9j6V1stU
+        9KJLxo2AGA0GrMHjPUWX7aiifahkL1dpzaxqXyJJOUsSUmGgGh7eW3TV0Sraf0o1SaVbBGhKtW+SuFIB
+        U8MANXy8x+gi34Ef7Tul+oNKr/ZjEn5Och4FTImBqRzea3TJgqr2PDceW9P7LxW9+JKtp4DJMSCVx3uO
+        rnirivaXku2g0nudil58yfZRwAgGonp479EFn1fRvlKyV6v05lS+WSH6A0qVcr1kVMEAVB/bAK07W0X7
+        SakeV+lvABxxmYr+iFL5SYTZFfqNgScPtgVa5S+1j6loHynVxaoZ31TRH1Ey/xSB/mLAyYdtghZtoKJ9
+        o2QeU5uxhYr+iJJ9WqGfGGjyYtugNV9S0X5Rsi1VM16qoj+iZL9W6B8GmPzYRmjJBSraJ0q2smrG89S9
+        KvpDSvWwauamCQwEA0s72FZogeeUqX1T+wNqJtWUX6nojynZ+gr9wIDSHrYZsnuLivaDkp2kmrO3iv6Y
+        kn1NofsYSNrFtkNmB6hoHyjZHqo5GSYEulqh2xhA2sc2RFbXqWj7l6yJCYCmNKt6SEV/UMmWU+gmBo7u
+        YFsimxVUtN1L9qCaRTXpVBX9USXbXqF7GDC6h22KTDKsa3OyatYnVPRHlewEhW5hoOguti2yOF1F27tk
+        HkOb5d8uoj+qZP4ZgmmBu4MBovvYxqhtXuX596NtXbLXqmbNrPwMY/SHlcxLOaJ9DAz9wbZGTe9W0TYu
+        mb+8+l66pvkSfPTHlexwhbYxIPQP2xy1/EBF27dkTT7/P6UMN1Lco5q9kxIMBD3Gtkdp/tZdeyZbt4Nq
+        3ooq+uNK90aF9jAAgH0AJWWY/c+9SHXCDSr6A0v2HYW2cODHCPYFlJLh8v+1qjO+oaI/smR3Kd+UiDZw
+        wMeU2CcwbFku/x+oOsOX36M/snTrKeTHgR5Tw76BYfITY9E2LN2GqjO8LG+GaYG/rZCbD/C+aTPaflnz
+        611VoQy/1y3uI69UyO0IFW2/knkp+87NXXOciv7YkvnSDpMC5bW0uk1F2y5rDP51tHgScKd6qUJO/qLq
+        qzXRtivZiapztlLRH1s6T/CAfHx/xgUq2mZZ49JuXS3+HODV5TzLHPLZREXbrHTbqc5ZTD2toj+4ZL9Q
+        yCfDuhFjiW/+ObR4JYAnknI6SUXbq2RPKY+VnXShiv7okj2hFlbIw9vj7yraXhlj8M+ltZMAfxFaXSGP
+        F6pJKtpeJTtbddbuKvqjS7ezQh77qGg7ZYzBP6fWTgL8bRN57Kmi7VS6HVVnLaky/AxwiUIeGSaKGk38
+        5p9bS/cE+Di4nEIOV6toO5XM+4THyE77rYr++NKtolDfCiraPtnim38bWroS0PRa7x2SYdl6d77qvN1U
+        9MeX7hCF+vxzTLR9MsXg35ZWTgLOUKjP88NE26d0Xjiv87L8DOCbzngcpz7fER1tnyxx2b9NLfwc8IB6
+        nkI98yhvh2j7lMxjoudB6YUsz3tvq1DXz1W0bTLEN/+2tXAlYBGFej6qou1SuotUb+yqojehdL9XqOs8
+        FW2b2jH4d0P2kwAvl456rlTRdildr55MW0J5woPojSjdGgr1nKmi7VIzBv9uyXwS8HKFOl6vom1Sul7O
+        TXOqit6M0h2pUM/RKtoutWLw76asJwHLKNTxMxVtk9Idr3pnUxW9GaV7VDEzYD1fUdF2qRGDf7dlOwnw
+        zHOzKJS3uMow85/r5fo0c6j7VfSGlO6zCnVkWYCDwb8fMp0E/EGhjs+paJuUzivUehXCXsryCJgPCHMp
+        lOdHMR9X0XYpFYN/v2Q5CWAukjrmVF6aOdompfuW6q01VfSm1Gh7hTpOUdE2KRGDfz9lOAlYX6G8HVS0
+        PWr0WtVbngTjWhW9MaW7Xs2kUN67VLRNhh2Df7/VPAm4SXG8Kc/v+Y0q2ialu071fiKovVT05tRoY4Xy
+        ZlS/U9E2GVYM/rBaJwFMQlbH+1W0PWq0h+o9zwnwpIreoNL1YjGGpPxzUKm5IRj8MbnSJwGefGZmhfIu
+        VdE2Kd1jaiEFOVZFb1KN1laoo8SduQz+iJQ6CfANr6wtUYfvuYi2SY08/wn+aQMVvUk1+rVCHf4p4BgV
+        bZdBxOCPaSlxEsCl/3qyTD7n1lL4J98IcY2K3qgacRWgHj8TO4yTgL8qrxAHTMsr1bAeEdtboQ7fbR9t
+        kxqxBk1gJxW9WTXymSLq8ZUAT840qHtDfG+Hl6EGRuOl6o8q2pfGky/7b6dQz2kq2jY14ipQwOsye43+
+        6A2rEVcB6vNCTZepaPuMJs80+THFDVcYKx+Pvqu8Tnu0b4023/DHb/51ZZpv5kHlyc8Q8KxI0ZtWI09O
+        g/p8NeCd6mTlO2ejbTVlN6tPqQUUMBGrq5PUWE8E/Jy/v+lx8lnfGSraRjX6psJUeGnM6E2rFUsF5+Jv
+        ZZ40aF/lVRz9wT5XeVWvg5XX1PZvuMCgLas+obzPPaCmPFZ4YZmrlKf39d3mTPKTw7pqym1VK59ErqQw
+        DWep6M2rkT/sADClxdSKahW1tGJVv5zOVtGxvUa+koTpeJuK3rxavVkBANqS6fFy93qF6fAjgV4mM3oD
+        a3SF4nIeALTD9w5lmfXPXaIwSluq6E2s1QcVAKAN2cYQr0GAUfLvaX9W0RtZo1uV15AGAOQ2h7pFRcfy
+        Gv1FcY/IGPn57ejNrBUrNwFAfp9W0TG8VrsqjJEnS7hPRW9ojfxaeK4cAPJaRGWaUM6TkTHxzzh9WUVv
+        aq2YxAEA8vq2io7dtfq8wjgtqh5V0RtbI89Nz0QzAJCP52TwhEzRsbtGvhLBVeMJ+rqK3txa/Ub5UUUA
+        QA4+JmeaRM59QWGCfBXgYRW9wbXaTAEActhCRcfqWnnRn4UUBuBrKnqTa3W7mk8BAOryTXa3qehYXasv
+        KgzIgspnVNEbXauvKgBAXf+tomN0rR5SfPsfsP1U9GbX6gnl1QsBAHX4pmzfnB0do2vlp9cwYL4KkOn5
+        TnehYp0AACjP8/2fr6Jjc618pdpjFYbAv6tEb3rNmOUJAMrbSUXH5Jp9RmFI5leZZgd0/r1nWQUAKMPH
+        3Gz3hfnm8LkVhmh3Fb35NTtdMTcAAAyfj7WnqOhYXLPtFIZsVnWDijZAzfwcKgBguLZW0TG4ZtcqVvwr
+        ZFMVbYSa3a08aREAYDgWV15gJzoG1+xdCoX4ElC2uz/dyYqfAgBgOI5T0bG3Zn4ajON+YeuoaGPUzpen
+        AACDtaWKjrm1W1uhgoxng74z9cUKADAYL1LZ5oFxHoNQyUuUZ+SLNkzNLlbcEAIAEzezyviT72NqeYWK
+        DlLRxqndpxQAYGI+q6JjbO0+p1CZV+X7m4o2UM18ZWI1BQAYnzXUJBUdY2v2JzWnQgJenz/aSLXzfAUs
+        GwwAY+dZ9a5T0bG1dhsrJOFHMM5S0Yaq3U8UAGBsjlLRMbV2pyoks7LKeEOg214BAEZnWxUdS2vnnyNe
+        ppDQ11S00Wrnu0VXVQCAaXuFekRFx9LafUUhqXnUrSracLXjfgAAmLYXqBtVdAyt3Z+Vxxgk9l4VbbwM
+        cT8AAMR8L9cJKjp2ZmgjhQYcq6INmKGPKQDAs31SRcfMDB2t0IisK0a5J9WGCgDwjPWUj43RMbN2d6mF
+        FBryERVtzAzdq1gvAABmmGFZdaeKjpUZ8jwzaIx/T/LyvNEGzdA1ipsCAfSZb6q7UkXHyAydrljqt1FL
+        q4wrSI3klaRmVADQNz72Zb7p72G1nELDdlDRxs3SZxQA9M1XVXRMzNJOCo3zWebZKtrAGXpaba4AoC98
+        zIuOh1k6TXHpvyN8w92DKtrQGfJMgesqAOi6tZSPedGxMEO+SXsJhQ75sIo2dpb82OLLFQB01YrqHhUd
+        A7P0PoUO8kx80QbP0s1qUQUAXfNC5XX0o2Nflpjwp8M8z7Tnc442fJYuUXMpAOiKedXvVHTMy5LXkZlf
+        ocPeoJ5S0Q6QpV+omRUAtG5W5efpo2NdlnwztscG9MD+KtoJMnWUYo4AAC3zMexHKjrGZeoAhZ6YTWW/
+        HOUOUQDQqq+r6NiWqQuVr1KgR1ZSD6loh8jUFxUAtMbHruiYlik/8reMQg/5cY9op8jWHgoAWvEpFR3L
+        MuXf/d+p0GPfUtHOkSnvqFspAMhuVxUdx7J1oELP+X6Ai1W0g2TKJwHbKgDI6kPKx6roGJapixS/++Mf
+        llJ3q2hHyZQ/WNspAMjG8/tnf8Ta3aeWVcD/eatq4czVH7CPKADIYgv1pIqOWZnyMf7tCniOL6lop8mW
+        d+LtFQDUtrVq4Zu/Y/l1TNVMKvuMVSP5JGAbBQC1+Ia/Fq6cumMVS/ximhZQ16toB8qWP3g7KgAobS8V
+        HZcydpWaRwHT9VLlG0WiHSlj+yoAKGUfFR2LMubJfl6sgFF7s2rhppaRDlasHQBgmHyMaWF635F8DH+j
+        AsZsNxXtVFn7oZpFAcCg+bl5H2OiY0/WPqaAcTtMRTtW1n6p5lQAMCjzqVZukB7pCAVMiGcKPE9FO1jW
+        fqMWVAAwUS9Ul6voWJO1MxQz/WEgFlY3qmhHy5qfZFhBAcB4raj+pKJjTNZ8x//zFTAwy6s7VbTDZe0e
+        tY4CgLFaS/kYEh1bsvY3tbQCBu5V6kEV7XhZe1x5jm4AGK33q0dUdEzJml/vqxUwNBupSSraATN3kOIx
+        QQDT4pnyWnrGfyQ/7vcOBQzdh1Ur019Onh/h4QkBAJF51UkqOnZk76MKKObTKtoRs+e7eZdTADDCx4Q/
+        qOiYkT1fsQCK+7aKdsjs3a02VACwnvIxITpWZM8/bQJVePXAY1S0Y2bPv5ntqVgdC+gnf/Y/oVqa8nzy
+        fqA4fqEqT717vIp20Bbya/csXwD6w7/3/0xFx4QWOk7NrIDqPFvgKSraUVvIE2e8TAHovtXUTSo6FrTQ
+        qcrHXCCNOdSZKtphW+hRtbMC0F2eE6S15/sn77dqbgWkM4+6QEU7biv9RPGTANAtvuR/lIo+8610iXqB
+        AtLy4HmxinbgVvLc32soAO3z7HheGyT6rLfSpWp+BaTnlfiuUNGO3EqeQng3xeyBQJt8k9xnVYszl07e
+        hYrFfdAUX6ryjhvt0C3lpYVfrAC0Yxl1roo+0y3ly/5880eTfNba+j0B7u9qK8Uzt0B+Wyp/ZqPPckv5
+        2Mn9SGjaXOrXKtrBW+tktYQCkM9i6ucq+uy21vnKNy4CzfMCPC3PEzB5Xh/cS4UCyMFX5j6i7lfRZ7a1
+        zlEM/uiUWVVXzs7diWppBaAe/9bviXGiz2iLnaA8pwrQOb4rt/VncSfvYeX1BLwmAoBy/K1/a9WF3/pH
+        Olp5anWgszxYtrqK4NTynbqrKgDD90rl38ijz2KrHai4yRi94W/OT6vow9BiT6lDlWdDBDB4fqrIy9+2
+        unrf1NpXAb3zIdX6JB1Tdot6n+JsHhgMf5Y8h//tKvrMtZq/NGyrgN56i3pIRR+QlvMkJF51DMD4raK6
+        MKHPlHlBoncroPdWV3eq6IPScj7D/75aVAEYvUXUt1TXrhC6O9RrFIB/Wk5dp6IPTOv5Csc+anYFYOr8
+        CJzvD+rKM/1T5mPc8grAFBZQZ6rog9OF/qz86BKPDQLP5t/5N1E3q+iz04VOVyzqA0yDJwzyZfPoA9SV
+        rlT/oQDMMMMG6ncq+qx0pcMUz/gDo+Rvyl38/W/yfqvWU0AfraX8rTj6bHQlP+rsn/8AjNGbVFd/C5w8
+        LzL0KgX0wdrqDBV9FrqUZyncWAEYJ98wc42KPmBd6zz1NgV0ke9891z30b7ftXyz38oKwATNr05T0Qet
+        i3k1sDcqoAvWV11asGd6Ha9Yxx8YIN8l7MeD/Gx99KHrYpcrz4DGUwNozYzKV7N8n0u0b3cx/97vaX39
+        twMYgo2U1+SPPoBd7Xq1s5pLAZnNpnzS+kcV7ctd7QH1DgVgyLwO/0Uq+iB2uXvVfmopBWSyuPqc6uKM
+        ntPr94rJfYCC/E3DK4NFH8iu559BfDOVf1sFavJ6F0eqJ1S0r3Y9/+1zKgAVbKoeVNGHsw9drDxnwrwK
+        KMFLXm+vrlLRPtmH7lMs5gMksKK6TEUf1L7k9QY829gaChgGP8b3beXn26N9sC9doJZRAJLwNJuecatP
+        TwlMLd+A5ScmFlLARCymfAOqn0iJ9rU+5bv8/bOjpysHkJCn1v2Lij7AfesxdZx6r+J3SoyW76/xwjwn
+        qSdVtG/1rdsVc3MADfAkHP+jog9yX3tEHaP8bDbfYDAlzzXhufn9DfcuFe1Dfe1E5SshABryQdX33yuj
+        7lbfUr5aMrNCP/lE8C3qB8o3tUX7Sp/zY7cfUAAa9SJ1loo+4PTMQe5o5Uu+vrsb3eanRXz3ugd9b/to
+        n6AZZviV8twGABrnaYT92BJXA6ad7xnwyoTbqSUUusGT1Oyqfq0eV9G2p2fyMcKP1fqYAaBDPIOgB7jo
+        g0/Pzc95f129Vc2t0AZfyfGl/QOUV6WLti09N18pXFYB6Cif2W+p+M1zbHmmt3PV3spzDfixS+TgJzw8
+        K+QX1flqkoq2IcX5p5CPKL71Az3xQuVlO6MDAk2/h5W/MXnQ8RWCBRTKWFD5Pf+8Olv5p5toG9H0+6Fa
+        RAHoId/8xrwBE8+TpFytvq8+rFZVPG44cb7S8u9qB3WU8sqQ0ftPY+sm9SYFoOd8CdWzCPJNarD5UrTv
+        I/CCKZ6Z0HMQMDvh1L1A+Vl8z7x3qDpP+UpL9N7S+PI+6bkOuKcFwLOspM5Q0YGDBtef1WnqELWj8gxr
+        vvlqRtV1/kbvu/I3Uh7oD1Z+L+5Q0XtFg8snVK9QADBV71e3qeggQsPrUXWF8lLH31SfVJup16nlVAs/
+        KfibpReneoPaXPlv8CDv58pvUNygVz7/xOfPNDf5ARgVT5jix6j6us55xnyfgb8p+2eFc9Sx6ntqX/Ux
+        5ac7fE+Hf9v1LIdeq35l5ZMH3zjnS+xRIwODt7n/eSnl/88qyv8On4BsoN6jtlUe1PdXvt/Br8E34vk1
+        Mc9Erjz99WcV62AAGBdfrvUc+h58ooMMEeXLV5F4ph/AQLxa+TfE6GBDRDm6TPmKDQAMlC8V+xKzf8uN
+        Dj5EVCffWOopfL2qIQAMje/k9sGGZVOJ6ubPoB8xnU0BQDGec90Hn/tVdHAiouHkGy5986dv3ASAajwN
+        ricSekBFBysiGkyeGMkT+SysACANz3L3VcXsbUSD7SHlx3IXUwCQlp859+VJTgSIJpYv9fsb/6IKAJrh
+        KwL+aeAeFR3ciCjON/f5s+OJmQCgWZ4e1vO++1Gl6GBHRM/kmR498HNzH4BO8eODnh/e891HBz+ivna5
+        8lTOPM4HoNM8oZBXgztdMcUw9bWn1PHq9QoAemcF5RsG71XRQZKoaz2oDlVeNREAes+TCm2vvKpcdNAk
+        ar3r1a5qPgUACHgJ2iMVSxFT6z2mvJrm+or1+AFglF6o9lBXq+jgSpQ13+i6k5pfAQAmwFcFPCEKCxBR
+        1h5RI9/2AQADNrt6nzpZPamiAzFRqR5XJ6hN1VwKAFDA4soTDJ2n/EhVdIAmGnTe185UXhKbS/wAUNkS
+        auRkgLkFaBj5CRXP0resAgAktKTy41bnK64M0HibpM5QuygGfQBojFcm3ET5scL7VXSgJxrJK1j6N31f
+        3l9EAQA6YFblO7S/rjwpSzQAUP+6SX1LvUkxFz8A9MBLlO8b8Hzs96locKDu5Wmn/1dtq16kAAA9NpPy
+        XAM+IfCz3Pxc0J38W/4lymtO+AqQV6UEACDkQWJNtZc6Ud2tosGF8nWn8lUdzyK5lppDAQAwbl65cDN1
+        sLpU+ZtlNABRufyUx5XKq+ttobyNAAAYqjnV2sqPHB6ufFLwqIoGKpp4fm8vVt9RXjlyDTW3AgCgupnV
+        Suq96kvKj5T9STE50ejzFM83ql+prylfdXm58nsLAEBT/Du0B7GNlX+b9rdYTzLzF9XXkwMv7HSB8tWT
+        jyu/Ny9TPIoHAOgFnxysrPwc+pZqb/Vt5asHl6nbVTSAZu4B5WWcT1HfV59R/ts2UC9V/vkEAABMhycx
+        8noHq6h11DvVh9Xuyj81+ITBjy96lcTT1IXKj75dq3w5/Q7l59+fUCMDtP95at2iblD+d/xG+d95rPqJ
+        8g13B6hPqm2Uv7n7Nfnb+2LKrxUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAABozAwz/H8kns8+GbGJuwAAAABJRU5ErkJggg==
+</value>
+  </data>
+</root>

--- a/Vistas/frmProducto.cs
+++ b/Vistas/frmProducto.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+//using MrTiendita.Controladores;
+
+namespace VistasMrTiendita
+{
+    public partial class frmProducto : Form
+    {
+        public frmProducto(string accion, long id)
+        {
+            InitializeComponent();
+            if (accion == "agregar")
+            {
+                lbl_Titulo.Text = "Agregar producto";
+            }
+            else
+            {
+                lbl_Titulo.Text = "Actualizar producto";
+            }
+            //frmProductoController controlador = new frmProductoController(this, accion, id);
+        }
+
+        private void btn_Cerrar_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+    }
+}

--- a/Vistas/frmProducto.designer.cs
+++ b/Vistas/frmProducto.designer.cs
@@ -1,0 +1,350 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmProducto
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmProducto));
+            this.bunifuElipse1 = new Bunifu.Framework.UI.BunifuElipse(this.components);
+            this.btn_Cerrar = new System.Windows.Forms.PictureBox();
+            this.lbl_Titulo = new System.Windows.Forms.Label();
+            this.pictureBox2 = new System.Windows.Forms.PictureBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.pictureBox4 = new System.Windows.Forms.PictureBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.pictureBox5 = new System.Windows.Forms.PictureBox();
+            this.pictureBox6 = new System.Windows.Forms.PictureBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.btn_guardarProducto = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.tb_codigo = new System.Windows.Forms.TextBox();
+            this.tb_cantidad = new System.Windows.Forms.TextBox();
+            this.tb_descripcion = new System.Windows.Forms.TextBox();
+            this.tb_precioVenta = new System.Windows.Forms.TextBox();
+            this.tb_precioCompra = new System.Windows.Forms.TextBox();
+            this.pictureBox3 = new System.Windows.Forms.PictureBox();
+            ((System.ComponentModel.ISupportInitialize)(this.btn_Cerrar)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox5)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox6)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // bunifuElipse1
+            // 
+            this.bunifuElipse1.ElipseRadius = 5;
+            this.bunifuElipse1.TargetControl = this;
+            // 
+            // btn_Cerrar
+            // 
+            this.btn_Cerrar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btn_Cerrar.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.btn_Cerrar.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_Cerrar.Image = ((System.Drawing.Image)(resources.GetObject("btn_Cerrar.Image")));
+            this.btn_Cerrar.Location = new System.Drawing.Point(502, 4);
+            this.btn_Cerrar.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.btn_Cerrar.Name = "btn_Cerrar";
+            this.btn_Cerrar.Size = new System.Drawing.Size(25, 25);
+            this.btn_Cerrar.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.btn_Cerrar.TabIndex = 1;
+            this.btn_Cerrar.TabStop = false;
+            this.btn_Cerrar.Click += new System.EventHandler(this.btn_Cerrar_Click);
+            // 
+            // lbl_Titulo
+            // 
+            this.lbl_Titulo.AutoSize = true;
+            this.lbl_Titulo.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.lbl_Titulo.Font = new System.Drawing.Font("Roboto", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_Titulo.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.lbl_Titulo.Location = new System.Drawing.Point(13, 6);
+            this.lbl_Titulo.Name = "lbl_Titulo";
+            this.lbl_Titulo.Size = new System.Drawing.Size(61, 24);
+            this.lbl_Titulo.TabIndex = 3;
+            this.lbl_Titulo.Text = "Titulo";
+            // 
+            // pictureBox2
+            // 
+            this.pictureBox2.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox2.Image")));
+            this.pictureBox2.Location = new System.Drawing.Point(17, 96);
+            this.pictureBox2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox2.Name = "pictureBox2";
+            this.pictureBox2.Size = new System.Drawing.Size(276, 41);
+            this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox2.TabIndex = 4;
+            this.pictureBox2.TabStop = false;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(13, 73);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(144, 20);
+            this.label1.TabIndex = 5;
+            this.label1.Text = "Código de barras:";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.Location = new System.Drawing.Point(315, 73);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(81, 20);
+            this.label2.TabIndex = 7;
+            this.label2.Text = "Cantidad:";
+            // 
+            // pictureBox4
+            // 
+            this.pictureBox4.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox4.Image")));
+            this.pictureBox4.Location = new System.Drawing.Point(16, 182);
+            this.pictureBox4.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox4.Name = "pictureBox4";
+            this.pictureBox4.Size = new System.Drawing.Size(501, 41);
+            this.pictureBox4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox4.TabIndex = 8;
+            this.pictureBox4.TabStop = false;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label3.Location = new System.Drawing.Point(13, 159);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(103, 20);
+            this.label3.TabIndex = 9;
+            this.label3.Text = "Descripción:";
+            // 
+            // pictureBox5
+            // 
+            this.pictureBox5.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox5.Image")));
+            this.pictureBox5.Location = new System.Drawing.Point(17, 270);
+            this.pictureBox5.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox5.Name = "pictureBox5";
+            this.pictureBox5.Size = new System.Drawing.Size(236, 41);
+            this.pictureBox5.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox5.TabIndex = 10;
+            this.pictureBox5.TabStop = false;
+            // 
+            // pictureBox6
+            // 
+            this.pictureBox6.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox6.Image")));
+            this.pictureBox6.Location = new System.Drawing.Point(293, 270);
+            this.pictureBox6.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox6.Name = "pictureBox6";
+            this.pictureBox6.Size = new System.Drawing.Size(223, 41);
+            this.pictureBox6.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox6.TabIndex = 11;
+            this.pictureBox6.TabStop = false;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.Location = new System.Drawing.Point(13, 247);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(130, 20);
+            this.label4.TabIndex = 12;
+            this.label4.Text = "Precio de venta:";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label5.Location = new System.Drawing.Point(291, 247);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(148, 20);
+            this.label5.TabIndex = 13;
+            this.label5.Text = "Precio de compra:";
+            // 
+            // btn_guardarProducto
+            // 
+            this.btn_guardarProducto.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_guardarProducto.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_guardarProducto.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_guardarProducto.BorderRadius = 7;
+            this.btn_guardarProducto.ButtonText = "Guardar";
+            this.btn_guardarProducto.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_guardarProducto.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_guardarProducto.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_guardarProducto.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(78)))), ((int)(((byte)(89)))), ((int)(((byte)(8)))));
+            this.btn_guardarProducto.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_guardarProducto.Iconimage = null;
+            this.btn_guardarProducto.Iconimage_right = null;
+            this.btn_guardarProducto.Iconimage_right_Selected = null;
+            this.btn_guardarProducto.Iconimage_Selected = null;
+            this.btn_guardarProducto.IconMarginLeft = 0;
+            this.btn_guardarProducto.IconMarginRight = 0;
+            this.btn_guardarProducto.IconRightVisible = true;
+            this.btn_guardarProducto.IconRightZoom = 0D;
+            this.btn_guardarProducto.IconVisible = true;
+            this.btn_guardarProducto.IconZoom = 40D;
+            this.btn_guardarProducto.IsTab = false;
+            this.btn_guardarProducto.Location = new System.Drawing.Point(13, 350);
+            this.btn_guardarProducto.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.btn_guardarProducto.Name = "btn_guardarProducto";
+            this.btn_guardarProducto.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_guardarProducto.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_guardarProducto.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_guardarProducto.selected = false;
+            this.btn_guardarProducto.Size = new System.Drawing.Size(500, 39);
+            this.btn_guardarProducto.TabIndex = 22;
+            this.btn_guardarProducto.Text = "Guardar";
+            this.btn_guardarProducto.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_guardarProducto.Textcolor = System.Drawing.Color.White;
+            this.btn_guardarProducto.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            // 
+            // tb_codigo
+            // 
+            this.tb_codigo.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_codigo.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_codigo.Location = new System.Drawing.Point(32, 103);
+            this.tb_codigo.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_codigo.Name = "tb_codigo";
+            this.tb_codigo.Size = new System.Drawing.Size(245, 21);
+            this.tb_codigo.TabIndex = 23;
+            // 
+            // tb_cantidad
+            // 
+            this.tb_cantidad.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_cantidad.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_cantidad.Location = new System.Drawing.Point(325, 103);
+            this.tb_cantidad.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_cantidad.Name = "tb_cantidad";
+            this.tb_cantidad.Size = new System.Drawing.Size(179, 21);
+            this.tb_cantidad.TabIndex = 24;
+            // 
+            // tb_descripcion
+            // 
+            this.tb_descripcion.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_descripcion.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_descripcion.Location = new System.Drawing.Point(32, 192);
+            this.tb_descripcion.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_descripcion.Name = "tb_descripcion";
+            this.tb_descripcion.Size = new System.Drawing.Size(472, 21);
+            this.tb_descripcion.TabIndex = 25;
+            // 
+            // tb_precioVenta
+            // 
+            this.tb_precioVenta.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_precioVenta.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_precioVenta.Location = new System.Drawing.Point(32, 278);
+            this.tb_precioVenta.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_precioVenta.Name = "tb_precioVenta";
+            this.tb_precioVenta.Size = new System.Drawing.Size(212, 21);
+            this.tb_precioVenta.TabIndex = 26;
+            // 
+            // tb_precioCompra
+            // 
+            this.tb_precioCompra.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_precioCompra.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_precioCompra.Location = new System.Drawing.Point(308, 278);
+            this.tb_precioCompra.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_precioCompra.Name = "tb_precioCompra";
+            this.tb_precioCompra.Size = new System.Drawing.Size(195, 21);
+            this.tb_precioCompra.TabIndex = 27;
+            // 
+            // pictureBox3
+            // 
+            this.pictureBox3.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox3.Image")));
+            this.pictureBox3.Location = new System.Drawing.Point(312, 96);
+            this.pictureBox3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox3.Name = "pictureBox3";
+            this.pictureBox3.Size = new System.Drawing.Size(205, 41);
+            this.pictureBox3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox3.TabIndex = 6;
+            this.pictureBox3.TabStop = false;
+            // 
+            // frmProducto
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("$this.BackgroundImage")));
+            this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.ClientSize = new System.Drawing.Size(539, 434);
+            this.Controls.Add(this.tb_precioCompra);
+            this.Controls.Add(this.tb_precioVenta);
+            this.Controls.Add(this.tb_descripcion);
+            this.Controls.Add(this.tb_cantidad);
+            this.Controls.Add(this.tb_codigo);
+            this.Controls.Add(this.btn_guardarProducto);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.pictureBox6);
+            this.Controls.Add(this.pictureBox5);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.pictureBox4);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.pictureBox3);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.pictureBox2);
+            this.Controls.Add(this.lbl_Titulo);
+            this.Controls.Add(this.btn_Cerrar);
+            this.DoubleBuffered = true;
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Name = "frmProducto";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "frmEditarProducto";
+            ((System.ComponentModel.ISupportInitialize)(this.btn_Cerrar)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox5)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox6)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private Bunifu.Framework.UI.BunifuElipse bunifuElipse1;
+        private System.Windows.Forms.PictureBox btn_Cerrar;
+        private System.Windows.Forms.Label lbl_Titulo;
+        private System.Windows.Forms.PictureBox pictureBox2;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.PictureBox pictureBox4;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.PictureBox pictureBox6;
+        private System.Windows.Forms.PictureBox pictureBox5;
+        private System.Windows.Forms.PictureBox pictureBox3;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_guardarProducto;
+        public System.Windows.Forms.TextBox tb_descripcion;
+        public System.Windows.Forms.TextBox tb_cantidad;
+        public System.Windows.Forms.TextBox tb_codigo;
+        public System.Windows.Forms.TextBox tb_precioCompra;
+        public System.Windows.Forms.TextBox tb_precioVenta;
+    }
+}

--- a/Vistas/frmProducto.resx
+++ b/Vistas/frmProducto.resx
@@ -1,0 +1,649 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="bunifuElipse1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="$this.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAiEAAAG4CAYAAACTljeRAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAHS9JREFUeF7t3T2vJdl1HmCKc8+93Z42JELqVnIhjeFLDa8AWQZGHrYDchQplKIB
+        /HMGYMCAFqgh0ZxQDu3IThQrUEYGBvlHBMMJs/ZaNXsV9qlT53Kk4aqGgecBXlad+jqnm9PAi11f30g/
+        /vGPP/jZz372j2/evPnnmL4VERER+Zr5n1988cUHUTN+Zykbe7KAZPn4m8///u3v/e1/f3v3X/+HiIiI
+        yL862Sf+6u/+29vsFz/4wQ++HXXjFHnv7du354UkNvhfueHeQURERET+tfnrz//+7U9+8pN/+ta3vvW7
+        UTmef/TRR1lGvrkUkJRDJkZARERE5Led7Bdv3rz5P8+ePfvjqBwvIy8iN2/fvs0K8mUJ2dtRRERE5Osm
+        e8bt7e1/iMrx7yOv7u/vn3/66afvKSEiIiLSmuwZUTdeRxH5s2fPnv1RzOepmZvI7yghIiIi0pZRQr4X
+        +YtIXqT6+5G7iBIiIiIifRkl5PuRjyPfifxB5FlECREREZG+TCXku5HvvHjx4lWWkOV2XSVEREREupI9
+        4+bmZi0hESVERERE+rMdCYnkrbpOx4iIiEhvqoScTqfXVUI++OADJURERER6YyRERERE3kl2SshyTUhE
+        CREREZG+bEuIu2NERETkkBgJERERkXeSqYTUhamvXJgqIiIi7Rkl5JPIOhKSL7FzOkZERERakz3j5uZm
+        LSGuCREREZFDMkZClmtCbm9vnY4RERGRY1Il5HQ6zRemeouuiIiI9GYzEvJYp2OUEBEREWnNXEIibtEV
+        ERGRY1IlZLw75lEJERERkUMySsjF3TFKiIiIiLRGCREREZF3kuwZNzc3rgkRERGRY1MjIeMWXXfHiIiI
+        yDEZJeRsJMTDykRERKQ9cwnJJ6YaCREREZFDUiWknpiqhIiIiMghyZ6xvTA1T8d4gZ2IiIi05spIiHfH
+        iIiISG9GCVnujpnfomskRERERFpTIyGR9XRMxDUhIiIi0psqIafT6eNRQl7e398/V0JERESkNaOErI9t
+        zxISMRIiIiIivcmecXNzkyWkRkLOT8eIiIiIdCUKx3J3TF2YelZCAAA6VAmJnD0nRAkBAFptSki+wG65
+        JiRWKSEAQJ+9kZAsIRElBADokz1jXJjqdAwAcBwjIQDAOzFGQi5KSKxSQgCAPqOELKdjbm9vH6uERJQQ
+        AKBP9owoHMtISJaQvDvm4eHhLlYpIQBAnzESUiXENSEAwDHGSMh6d8yLFy/OX+UPANBhW0IiRkIAgH6j
+        hCzvjskSkteEeE4IANAue8beLbpKCADQaoyEfFIjIUoIAHCIayMhsUoJAQD6VAk5nU6vs4Tk3TFZQiJK
+        CADQJ3tGFI71wtTIq/v7++exSgkBAPrUSEiUj7WEuDsGAGhXIyGjhHwYeRlRQgCAXpsS4u4YAOAY2TNu
+        xlt0RwnxsDIAoN8YCTl7TogSAgC0GyVkfmz7cneMEgIAtMqeMZ4T4lX+AMBxRglZT8d4WBkAcIjsGVE4
+        1rtjlBAA4BCjhCx3xzgdAwAcJnvGfDpGCQEADjFKyNnDytwdAwC02yshEa/yBwB6Zc+I0rGUkPmakFil
+        hAAAfeYSEsm7Y5bHtscqJQQA6DNKyNm7YyJKCADQK3vG3jUhESUEAOhTIyHzY9u9wA4AaDdGQrxFFwA4
+        1hgJubg7RgkBAFrVSIgSAgAcqkZCnI4BAA41RkLOTscoIQBAuxoJyRISWR5WFlPPCQEAeo0SMj+sbBkJ
+        iVVKCADQJ3vG9LCyD7OERJyOAQB61UhIXZhap2OUEACg1XYkZJSQu1ilhAAAfUYJqWtCnI4BAI6RPSMK
+        x3p3TMQtugBAvyohp9Pp9fTEVKdjAIBeRkIAgHcie8bm3THujgEA+tVISJ6OielSQoyEAADtphJSp2M8
+        th0A6Jc9Y3pOiNMxAMAxjIQAAO/EKCHrY9sjHlYGAPSrEhJZSohX+QMAh8iesbkmxEgIANBvlJD5dIxb
+        dAGAftkzonBsrwl5roQAAK1GCal3xzzGvFt0AYB+VUIiy2Pb88JUp2MAgHY7JWS5MDVWKSEAQJ+5hETq
+        mhCv8gcAeo0Ssj4nJPLy4eFBCQEAemXPqFf5jxLidAwA0G87EuKaEADgEDslxC26AEC/vZEQt+gCAO2y
+        Z4x3x7zOEhJ5lRemKiEAQKtRQi5Ox8QqJQQA6DOVkHUkJEtIRAkBAPpkz4jC4VX+AMCxRgk5e5W/EgIA
+        tMueMS5MdU0IAHCcGgmpEhLxsDIAoN8YCXFhKgBwrDES8v28JmS8yt81IQBAv1FC5gtTjYQAAP1qJCSy
+        lhCPbQcA2s0lJE/HKCEAwCG2IyF5TYgSAgC0GyXk7BZdJQQAaFclZL4wVQkBANqNEnLx7phYpYQAAH2y
+        Z9Rj28eFqa4JAQD6zSUkspSQiJEQAKBX9owoHVlCzh7bHquUEACgzxgJ8QI7AOBYYyRkLSEvXrzw2HYA
+        oN8oIWcvsMsLU2OVEgIA9KkSEjm7MDWihAAAfbYlxOkYAOAQcwkZp2OUEACg3yghy4WpUUIeY+qx7QBA
+        vysjIXdKCADQah4JiXhOCABwjO1ISJWQiBICAPTJnlFPTJ2fE6KEAACtxkjI2RNTHx4eXBMCAPQaJWR5
+        YmqWkMir+/v750oIANCqSkhkfWKq0zEAQLtpJGR9lb8SAgC0m0tI3R3jBXYAQLvsGXV3TEQJAQCOMUZC
+        PpkvTI04HQMA9BolxDUhAMCxqoRElhKSDyuLqRICAPSaSsh6i25ECQEAemXPyAtT6+6Y8RZdJQQA6DVK
+        yPLE1OkFdh7bDgD0yp4RhcOFqQDAsUYJmW/RdU0IANCvRkIidTomS4gX2AEAvbJnjAtTlxKSF6Y6HQMA
+        tBslZL1F190xAMAhsmdE4ZifE7KUkFilhAAAfcZISL3A7tFICABwiFFClse2397ePsbUNSEAQL/sGVE4
+        qoQsd8coIQBAu6mErHfH3N/fu0UXAOg1Ssjy7piYemIqAHCM7Bn1nJAsIfWckFilhAAAfcZIiOeEAADH
+        qhJST0yNeRemAgD9Rgk5Ox0TUyUEAOhVIyGR+Ymp7o4BAHpVCamRkCwhTscAAO32SkhECQEAemXP8BZd
+        AOBw00hIPbbdc0IAgH6jhKx3xyghAMAhppGQOh3zMqZOxwAAvWokJLKOhHiBHQDQLntGvjtmKiGemAoA
+        9NsbCYm4JgQA6LUdCXGLLgBwiDES4gV2AMCxtiXESAgAcIhRQvJ0zOvIMhISUUIAgF5TCanTMS5MBQD6
+        Zc+oC1OjhDwqIQDAIfZGQlyYCgC025YQj20HAA4xSsj87hh3xwAA/aqERM6emBpRQgCAPqOErLfoGgkB
+        AA5hJAQAeCeqhMzXhLg7BgBoN0rIcndMlpCIu2MAgH7ZM25ubpyOAQCOtRkJ8cRUAOAYYyRkPh3jmhAA
+        oF+NhNSr/GPeNSEAQL8qIRHPCQEAjjNKyHqLbsTpGACgX5WQiLtjAIDjjBKS14S8rlf5KyEAQLu9kRCn
+        YwCAdlVCTqfTx1VCIkoIANBrHgm5u7v7MKbLLbqxSgkBAPpMJWS5RTeSIyHPI0oIANCnSsj0sDKnYwCA
+        ftNIyHJhqlf5AwCHGCVkfXdMlBCPbQcA+m1LSMTpGACg31xC6poQp2MAgHY7IyFOxwAA/aqEbF9gF6uU
+        EACgzzwSMk7HGAkBAPplz7i5uZnfHfPSSAgA0K5GQubTMREjIQBAr1FClpGQ29vbx3xYWczfxSolBADo
+        UyMho4SsF6bGVAkBAPpsRkLW0zGxSgkBAPrMJSTimhAA4BhVQk6n0+scCakX2MUqJQQA6JM9I2/RjRLy
+        cZSRxzEScmckBABotSkhy1t0Hx4elBAAoFf2jCgcWUK8OwYAOM5OCXFhKgDQr0pIZCkheTrGc0IAgHbZ
+        M+rdMfNzQpQQAKDVdiQk4mFlAEC/KiHT3TFZQp5HlBAAoM/eSIhrQgCAdjslxC26AEC/uYTkq/yVEADg
+        EKOEzK/yV0IAgH5zCYl4TggAcIxRQvJ0zOssIRHPCQEA+lUJyce2j1f5Ox0DAPSbRkLOHlYWUUIAgD7z
+        SIgSAgAcRgkBAN6JKiER14QAAMcZJeST0+n0en6LbqxSQgCAPjUSUqdjvMAOADjEXgnxsDIAoN0oIesT
+        UyMuTAUA+mXPuLm5yWtCjIQAAMcZJWR9WNm4JkQJAQB6Zc+IwrFcE3J3d/dhzBsJAQD6zSVkPCdkKSGx
+        SgkBAPpUCYksJSSmy8PKYpUSAgD0mUtIxN0xAMAxdkqIx7YDAP2yZ+QtullCPLYdADjMNBKyvDvGLboA
+        wCGmEnJ2YaoSAgC0qhIybtF9dIsuAHCIaSTkdcQ1IQDAMTYjIa4JAQCOMY2EeE4IAHCcUULmW3Rf3t/f
+        P1dCAIBWeyMhXmAHALTLnjG/yj/i3TEAQL+5hIzTMe6OAQD6Zc+I0uF0DABwrFFC1gtT62FlSggA0Cp7
+        xnQ65jGmbtEFAPrNJSSyXJhqJAQAaLctIXk6xnNCAIB22TOicKyPbY95p2MAgH5VQiJnL7CLKCEAQJ9R
+        QvLumCohy8PKIkoIANBnGglZrwnJEhKrlBAAoE/2jM3dMUoIANBvOxIScToGAOhXJeR0Oq3XhHhOCADQ
+        zkgIAPBO7JQQt+gCAP22JcTdMQDAIYyEAADvxFRC1iemujAVAGg3Skg+MXUdCckX2MUqJQQA6JM94+bm
+        Zi0hrgkBAA4xRkKWa0LqLbpOxwAA7aqE5Kv8Y1oXpt4pIQBAq81IyGOdjlFCAIBWcwmJuEUXADhGlZDx
+        7phHJQQAOMQoIRd3xyghAEArJQQAeCeyZ9zc3LgmBAA4Vo2EjFt03R0DABxjlJCzkRAPKwMA2s0lJJ+Y
+        aiQEADhElZB6YqoSAgAcInvG9sLUPB0Tq5QQAKDPlZEQ744BAHqNErLcHTO/RTdWKSEAQJ8aCYmsp2Mi
+        rgkBAHpVCTmdTh+PEvLy/v7+uRICALQaJWR9bHuWkIiREACgV/aMm5ubLCE1EuJ0DADQb4yELHfH1IWp
+        SggA0K5KSOTsOSFKCADQalNC8gV2yzUhsUoJAQD67I2EZAmJKCEAQJ/sGePCVKdjAIDjGAkBAN6JMRJy
+        UUJilRICAPQZJWQ5HXN7e/tYJSSihAAAfbJnROFYRkKyhOTdMQ8PD3exSgkBAPqMkZAqIa4JAQCOMUZC
+        1rtjXrx44VX+AEC/bQmJGAkBAPqNErK8OyZLSF4T4jkhAEC77Bl7t+gqIQBAqzES8kmNhCghAMAhro2E
+        xColBADoUyXkdDq9zhKSd8dkCYkoIQBAn+wZUTjWC1Mjr+7v75/HKiUEAOhTIyFRPtYS4u4YAKBdjYSM
+        EvJh5GVECQEAem1KiLtjAIBjZM+4GW/RHSXEw8oAgH5jJOTsOSFKCADQbpSQ+bHty90xSggA0Cp7xnhO
+        iFf5AwDHGSVkPR3jYWUAwCGyZ0ThWO+OUUIAgEOMErLcHeN0DABwmOwZ8+kYJQQAOMQoIWcPK3N3DADQ
+        bq+ERLzKHwDolT0jSsdSQuZrQmKVEgIA9JlLSCTvjlke2x6rlBAAoM8oIWfvjokoIQBAr+wZe9eERJQQ
+        AKBPjYTMj233AjsAoN0YCfEWXQDgWGMk5OLuGCUEAGhVIyFKCABwqBoJcToGADjUGAk5Ox2jhAAA7Wok
+        JEtIZHlYWUw9JwQA6DVKyPywsmUkJFYpIQBAn+wZ08PKPswSEnE6BgDoVSMhdWFqnY5RQgCAVtuRkFFC
+        7mKVEgIA9BklpK4JcToGADhG9owoHOvdMRG36AIA/aqEnE6n19MTU52OAQB6GQkBAN6J7Bmbd8e4OwYA
+        6FcjIXk6JqZLCTESAgC0m0pInY7x2HYAoF/2jOk5IU7HAADHMBICALwTo4Ssj22PeFgZANCvSkhkKSFe
+        5Q8AHCJ7xuaaECMhAEC/UULm0zFu0QUA+mXPiMKxvSbkuRICALQaJaTeHfMY827RBQD6VQmJLI9tzwtT
+        nY4BANrtlJDlwtRYpYQAAH3mEhKpa0K8yh8A6DVKyPqckMjLh4cHJQQA6JU9o17lP0qI0zEAQL/tSIhr
+        QgCAQ+yUELfoAgD99kZC3KILALTLnjHeHfM6S0jkVV6YqoQAAK1GCbk4HROrlBAAoM9UQtaRkCwhESUE
+        AOiTPSMKh1f5AwDHGiXk7FX+SggA0C57xrgw1TUhAMBxaiSkSkjEw8oAgH5jJMSFqQDAscZIyPfzmpDx
+        Kn/XhAAA/UYJmS9MNRICAPSrkZDIWkI8th0AaDeXkDwdo4QAAIfYjoTkNSFKCADQbpSQs1t0lRAAoF2V
+        kPnCVCUEAGg3SsjFu2NilRICAPTJnlGPbR8XpromBADoN5eQyFJCIkZCAIBe2TOidGQJOXtse6xSQgCA
+        PmMkxAvsAIBjjZGQtYS8ePHCY9sBgH6jhJy9wC4vTI1VSggA0KdKSOTswtSIEgIA9NmWEKdjAIBDzCVk
+        nI5RQgCAfqOELBemRgl5jKnHtgMA/a6MhNwpIQBAq3kkJOI5IQDAMbYjIVVCIkoIANAne0Y9MXV+TogS
+        AgC0GiMhZ09MfXh4cE0IANBrlJDlialZQiKv7u/vnyshAECrKiGR9YmpTscAAO2mkZD1Vf5KCADQbi4h
+        dXeMF9gBAO2yZ9TdMRElBAA4xhgJ+WS+MDXidAwA0GuUENeEAADHqhISWUpIPqwspkoIANBrKiHrLboR
+        JQQA6JU9Iy9Mrbtjxlt0lRAAoNcoIcsTU6cX2HlsOwDQK3tGFA4XpgIAxxolZL5F1zUhAEC/GgmJ1OmY
+        LCFeYAcA9MqeMS5MXUpIXpjqdAwA0G6UkPUWXXfHAACHyJ4RhWN+TshSQmKVEgIA9BkjIfUCu0cjIQDA
+        IUYJWR7bfnt7+xhT14QAAP2yZ0ThqBKy3B2jhAAA7aYSst4dc39/7xZdAKDXKCHLu2Ni6ompAMAxsmfU
+        c0KyhNRzQmKVEgIA9BkjIZ4TAgAcq0pIPTE15l2YCgD0GyXk7HRMTJUQAKBXjYRE5iemujsGAOhVJaRG
+        QrKEOB0DALTbKyERJQQA6JU9w1t0AYDDTSMh9dh2zwkBAPqNErLeHaOEAACHmEZC6nTMy5g6HQMA9KqR
+        kMg6EuIFdgBAu+wZ+e6YqYR4YioA0G9vJCTy5TUhb968+edf//rXX24JAPBbkv1iOxJydovuF1988Y8/
+        //nPx+YAAL8dv/zlL9/+8Ic//KcoHPsvsPvpT3/673I05Fe/+tXSWAAAvo7sE7/4xS/eRsf4v9/97nf/
+        yyghH9/d3X14dndM/s9nn332J59//vk/5JCJiIiIyNdJlo8f/ehH/3sUkL+M5BNT/1Pk25Hfj9xFviwh
+        kdvI70Y+iPzHyH+OfG+cw7lIPn51JD/ngWvdPH9tWe235Np3ZHbW5bEqtX6eXzLN7227fL6W2G7eZvmt
+        c6Z1lfXz2Le2q2Xr/JVl9X2V2qb+jufl9Xnev7JsNx97s++137L+Gcey7fZn37e3bMr8e5dtxrFr+73v
+        Wn/zZt3ZfKSOsc7H+mvLlt9R+49pbfvUurNcWzctPztmzY9pbbcu2x4vP+d+I9vtKuv20+f5GGf75HSz
+        f32ej7P++edl2/mdbZbE8ovfPDLPX1t29t3XviOzsy6PVTn7c1055t62y+drie3mbZbfOmdaV1k/j31r
+        u1q2zl9ZVt9XqW3q73heXp/n/SvLdvOxN/te+y3rn3Es225/9n17y6bMv3fZZhy7tt/7rvU3b9adzUfq
+        GOt8rL+2bPkdtf+Y1rZPrTvLtXXT8rNj1vyY1nbrsu3x8nPuN7LdrrJuP32ej3G2T043+9fn+Tjrn39e
+        tp3f2WZJLL/4zSPz/Lws871I9oo/e/bsWfaM34vcvM0LU4f3Iu9H/jDy7dPp9OcxzcaSF5H8xuR5nspm
+        3euxbJlGXufymo75dft5/jflK+6X31vfvW63neZ2Y7om1n08ra/s/u5/YS7+DvaSx59Ty8b0qX3r7/wi
+        m+VX/yzX9s/Euo/3lo9cHHM73ay/+LvI5fPnTWr5xffMn+dlY76+Z12+l3nbke3vuPhvKbOdnz/PubZu
+        uyw+r7933iem1/7u63fO0/W/g5qO5fN0N9P2Xym5fWWzrn5D/b0t31vTMb9uP8//pnzF/fJ7L/4/205z
+        uzFdE+v8+99JrPPvf6SWb+fnz3Ourdsui8/r7533ien/r//+c91fRLJXPIyLUv9N5L0oITH50jcjp8i/
+        jWQRyabyJ5G8gOTx9vb2cZ6O+T+dPv9pLR/rlmU5reysv1g+ZTneU/tuE8svfsMT2+4ur0zr5z/jbsb3
+        rL93nk7b5HHWv8vt+pE8RqU+b7ep/S/W7R13/lzz03bf2W4fOTvutM+T37dd/xv2u7btuuyrLL+S7Z/p
+        4vsz0zb5/8nZ/8c1n9PN8t1jfdWM4y3HmKZL5u0qm+13t9lLHXPeZ5pf/hucl+2t22Zn25z37z8yvufs
+        /6ftPrk+4t//zrJp23XZV1l+Jf79j2PO+0zz7+rffx47T8H8ceTVy5cvX8T0NI+CpPxQRSRHRHKoJC8c
+        eZWt5f333//DnI4GkyVlni7JbabPOb/dbl321LHqOGP9vN+Safm6ro41/YZ5u2XZWLfNur7md46//vmn
+        ZWf7bvfJ7afvW9dttqucHWu7LPep/ep31Oecbn/b+N76vGZss/2u+bfOyy9S28zflcnPm2Pvpvabtt37
+        rfX5Yjq2XT5vvy/X1e/YHrOWT8vq7+vieNO+Z78t5yu1bMpynM13LMu3x6vP83GuHbOOV78tp2Pbefuz
+        fWvb8Xn5vly2Wb7M1/HGuquZt9sc5+y7N3+OnN9uty576lh1nLF+3m/JtHxdV8eafsO83bJsrNtmXV/z
+        O8ff/j1d7LvdJ7efvm9dt9mucnas7bLcp/ar31Gfc7r9beN76/Oasc32u+bfOi+/SG0zf1cmP2+OvZva
+        b9p277fW54vp2Hb5vP2+XFe/Y3vMWj4tq7+vi+NN+579tpyv1LIpy3E237Es3x6vPs/HuXbMOl79tpyO
+        beftz/atbcfn5fty2Wb5Ml/HG+uuZt5uc5yz7978OXJ+u90fRLJXvP/RRx9dFJCSCzM3kVPePjMeq5rJ
+        q1if1+dxa83yuZbtTWt+yrN5353l67r5+/eOs11Wn6f9Ln7j9nNN6zfN3zll+W1X1i3rd5atGfts910+
+        z8et9bW8tp32W3/j9FuufXcun9ddbLc97vz9Y/nZ5/pN83ab33K2T2VetjcfmY+7Hqs+5/zI2fePz/P6
+        s7+3+e9oOtayvrabt58+17KzP1fNT/us+9a6nM77zOszO9+7HiOz2f/i7zVT28zbTVm3GfNnyzL53Zlp
+        m3m7i+3n5fW5fv+8zd605qcs313rd5av6+bfuHec7bL6PO138Ru3n2tav2n+zinLb7uyblm/s2zN2Ge7
+        7/J5Pm6tr+W17bTf+hun33Ltu3P5vO5iu+1x5+8fy88+12+at9v8lrN9KvOyvfnIfNz1WPU550fOvn98
+        ntef/b3Nf0fTsZb1td28/fS5lp39uWp+2mfdt9bldN5nXp/Z+d71GJnN/hd/r5naZt5uyrrNmD9blsnv
+        zkzbzNtdbD8vr8/1++dt9qY1H8nt8yLU02effZaDHd+8VkIWuXJskHfNLDuMnH3O+Sufc9+L9U+ltntq
+        nyeOtXzfNp9++ul7dbzNvuvvy/m9dXup7Wt+Ti6v+fF3t7fvOq3ktttllTpezuef5dq67fJ5ul321D5P
+        5do2m+W7f3dPHT/X1Z9tbLceY7tffZ6XX9tmnq//DubvqXXb+Xn7nI/k79n7Tcuy7efNspp/8s90bZvt
+        dLv+q6yrz9vtnsoT+/n3v/mzVXJ5zfv3f56njp/r5n+XMV2Psd2vPs/Lr20zz9d/B/P31Lrt/Lx9zkfy
+        9+z9pmXZ9vNmWc0/+We6ts12ul3/VdbV5+12T+WJ/b7uv/9cnkk1Dd/4xv8Djwp5YpmykyUAAAAASUVO
+        RK5CYII=
+</value>
+  </data>
+  <data name="pictureBox6.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAALAAAAAtCAYAAAAOT+HDAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABPZJREFUeF7tXcFuHEUQtQnrcbBXRCJksWSJFawiwoWDiZIjR/gAf4/9B/afIHHk
+        Atw48C+LzAeY9zpVneqe3vUQQOmR3pOeq7qqume8emrVzK5mDvbgEPxgAlt1U+ayZuoxnD5n6rxY95D/
+        LmvWrHMc/9v14xp1vB57rFVfc0pNi/E4U1mf1775MRfrp2EYhi9gfgG34L0odsIfTZttMd/f3zOxAbdX
+        V1f32+0WIUF4/6AWb25uKOItRPwlLLVaCPnw4uJiAfsTCwWhR1xfX1PEv4EfgmwtMh6BH4HaeYVuQW1C
+        o3+aVqnZvAtz930CWqkg9Alq1LTKXTiBKh6Wy+VTWCsThD5BjUKrn1Czpt305xh8BlqZIPQJavT09JRa
+        fQwmAbMZ5mAFWpkg9Alq9OTkZLVer7npvhHw2dkZm2IJWOge1CgFDFvuwAh+BmtlgtAnqFGw2IEPbQeW
+        gIXuQY2Cq/Pz81EPLAEL3YMaBcsWQjuwMBdQo9YDjy7iJGChe1CjYNkDs5/QRZwwB1CjYLkDg9qBhVmA
+        GgWLHph/dBEnzALUKDi+iFMLIcwB1ChY3EbTDizMBtTo6C4EqB5YmAWoUVACFuYJalT3gYXZghoFdRdC
+        mCeoUduBy7sQsBKw0D2oUbAUMCgBC7MANQqWArZ7ahKw0D2oUbC8iAMpYAatTBD6BDVKrda/B9Y3ccIs
+        QI2CRQuhX6MJswE1CpYthO5CCHMBNcrbaKMWAlQPLHQPatS0+raF4EAthDAHUKNg+VwIkGqWgIXuQY2C
+        xQ6sLzKE2YAaNa2WLQSoHljoHtSoabUp4Ds9H1joFfZ8YBdw2QPbE/9+51OwBaFH3N7eUrw/g8/q22gD
+        BPwp7HfgHQu1Ewu9gFq01wvcmUZHzwfmE9o/BtfgD+CvoG/Xovi++Rf4B/g9+Dn4xN7pkgX8yL6NY2/B
+        NxV9A75cLBavYJ2vbfyaY/jJmj+qCXmPRcY6n+/rprWN8Tgjyzx9s4wn2ty8htUkv4p7fTxOro95i+W8
+        5fK4lQtr5lqPsT74OW/M81hXj1lv8bROtLGuynMNxpNlzJjXDrFMm+9zPV7M55q2bszXx/JYy482+b6e
+        2W9BanLDVne1Wp3A5zsy3gC7tL+laAlSxOthGJ4fHR19Bf9r8AX8ZGs/jmFzrGKsp+9MMZ9nNtam8Z51
+        05wwL82t1qPduQbjzIdYPK/o5zFtHIMc08/j4DtZw88zjTmfMc+5bcTz2rTMW02i5VIsxium+fRZb7W+
+        ZjEv+Kme1mp9Ts6FcbFGyOV8xXRcWmORC9brnh8fH3PnpTaXcfd1cMBemAnuxGwnntqFHcn+OFnG6niI
+        eV2LaW6MxXFcAzavU8+pWeXrefX5xlzKGxnz8/PY6HydjHut+4F5no/jvGiNOW9+HOd4NadYo87t445j
+        F8f0mtoGpnrGwXzOsT7S88ZUH2st1hzTt3diUJPU5uLy8vLt7uvgLgyT2gmQQj6yr+tGZDzmNpsNG+qc
+        cx8cPLdrLTLmWnUPxPKxIz1PG1nlR+e2z/dxjAcOO+KJ9VotvxHL/xs/R4t7LH+2kazx+dG6X5FX8o8t
+        5/YfkXcD4rwdaxSfDf26LoyL/8niA3ddChcXc9xoH4SLeQqJVpwkWvH/k0QrThKt+BQSrXhNh/t1/r8g
+        0Yq3SLTiJNEau639qSRa8Xcl4Tbg4OBvSdXRqLIoThAAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="pictureBox5.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAALAAAAAtCAYAAAAOT+HDAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABPZJREFUeF7tXcFuHEUQtQnrcbBXRCJksWSJFawiwoWDiZIjR/gAf4/9B/afIHHk
+        Atw48C+LzAeY9zpVneqe3vUQQOmR3pOeq7qqume8emrVzK5mDvbgEPxgAlt1U+ayZuoxnD5n6rxY95D/
+        LmvWrHMc/9v14xp1vB57rFVfc0pNi/E4U1mf1775MRfrp2EYhi9gfgG34L0odsIfTZttMd/f3zOxAbdX
+        V1f32+0WIUF4/6AWb25uKOItRPwlLLVaCPnw4uJiAfsTCwWhR1xfX1PEv4EfgmwtMh6BH4HaeYVuQW1C
+        o3+aVqnZvAtz930CWqkg9Alq1LTKXTiBKh6Wy+VTWCsThD5BjUKrn1Czpt305xh8BlqZIPQJavT09JRa
+        fQwmAbMZ5mAFWpkg9Alq9OTkZLVer7npvhHw2dkZm2IJWOge1CgFDFvuwAh+BmtlgtAnqFGw2IEPbQeW
+        gIXuQY2Cq/Pz81EPLAEL3YMaBcsWQjuwMBdQo9YDjy7iJGChe1CjYNkDs5/QRZwwB1CjYLkDg9qBhVmA
+        GgWLHph/dBEnzALUKDi+iFMLIcwB1ChY3EbTDizMBtTo6C4EqB5YmAWoUVACFuYJalT3gYXZghoFdRdC
+        mCeoUduBy7sQsBKw0D2oUbAUMCgBC7MANQqWArZ7ahKw0D2oUbC8iAMpYAatTBD6BDVKrda/B9Y3ccIs
+        QI2CRQuhX6MJswE1CpYthO5CCHMBNcrbaKMWAlQPLHQPatS0+raF4EAthDAHUKNg+VwIkGqWgIXuQY2C
+        xQ6sLzKE2YAaNa2WLQSoHljoHtSoabUp4Ds9H1joFfZ8YBdw2QPbE/9+51OwBaFH3N7eUrw/g8/q22gD
+        BPwp7HfgHQu1Ewu9gFq01wvcmUZHzwfmE9o/BtfgD+CvoG/Xovi++Rf4B/g9+Dn4xN7pkgX8yL6NY2/B
+        NxV9A75cLBavYJ2vbfyaY/jJmj+qCXmPRcY6n+/rprWN8Tgjyzx9s4wn2ty8htUkv4p7fTxOro95i+W8
+        5fK4lQtr5lqPsT74OW/M81hXj1lv8bROtLGuynMNxpNlzJjXDrFMm+9zPV7M55q2bszXx/JYy482+b6e
+        2W9BanLDVne1Wp3A5zsy3gC7tL+laAlSxOthGJ4fHR19Bf9r8AX8ZGs/jmFzrGKsp+9MMZ9nNtam8Z51
+        05wwL82t1qPduQbjzIdYPK/o5zFtHIMc08/j4DtZw88zjTmfMc+5bcTz2rTMW02i5VIsxium+fRZb7W+
+        ZjEv+Kme1mp9Ts6FcbFGyOV8xXRcWmORC9brnh8fH3PnpTaXcfd1cMBemAnuxGwnntqFHcn+OFnG6niI
+        eV2LaW6MxXFcAzavU8+pWeXrefX5xlzKGxnz8/PY6HydjHut+4F5no/jvGiNOW9+HOd4NadYo87t445j
+        F8f0mtoGpnrGwXzOsT7S88ZUH2st1hzTt3diUJPU5uLy8vLt7uvgLgyT2gmQQj6yr+tGZDzmNpsNG+qc
+        cx8cPLdrLTLmWnUPxPKxIz1PG1nlR+e2z/dxjAcOO+KJ9VotvxHL/xs/R4t7LH+2kazx+dG6X5FX8o8t
+        5/YfkXcD4rwdaxSfDf26LoyL/8niA3ddChcXc9xoH4SLeQqJVpwkWvH/k0QrThKt+BQSrXhNh/t1/r8g
+        0Yq3SLTiJNEau639qSRa8Xcl4Tbg4OBvSdXRqLIoThAAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="pictureBox4.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAVUAAAAtCAYAAAAeCvg2AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAB0dJREFUeF7tnc1uHFUQhWOCPROcURIRbCJlYdAIgTcsrIgsvc1TZd4geRTEkg2w
+        Y8OzDIIHMHVuqm7Orb49091JxOZ80nHdW3/dcaJS/3icewc4MX02Qb28KbXImXqMUNRMreO8Y+slPbNy
+        DPsP7c89sj/vw9fLz5qS0xMfZ6ryeR2q59ix4xyLZ+Xj944FO7bOuXnfy50i5Id68THl/CU9WFE7p0cv
+        d0o9cuYcB4qaqXWcd2w9tycsdJzVavWtmd9Me9OdJEmS1NXP6/X6G7P94Xp3d4fA1rR//fr13X6/N5cQ
+        QogM5uObN28wWPd2IYq5GVevlZObm5tTs78gUQghxHF2ux0G6x8mzE8M1sp90xcmXaEKIcREMC9tbv5t
+        euBztIIp+9jkqUIIIaaAufnkyZNHt7e3n2OYAjwHWG02m6dmPU0IIcQUMDdNX26325XZ8ggAQ3VtujB5
+        mhBCiClgbj58+PDi6uoKc7QMVXzB84BLk6cJIYSYAubmYKg+e/YML6k0VIUQYiaYm+fn55if7ZWqOb82
+        62lCCCGmgLlpunz+/Dnu+MtQPfErVQ1VIYSYCeamCe+kBs9UNVSFEGImmJumuP0vn6qKZ6oaqkIIMRPM
+        TVNcqWqoCiHEh4C5md/+n+ABq15UCSHEfDA3TRf8w//4oitVIYRYAOamKd7+l9t/fNGLKiGEWADmpql9
+        +49nqrr9F0KI+WBu4pmq2ffPVE26UhVCiAVgbpoGn6jSM1UhhFgA5iZ9TPXdj1SZNFSFEGIBmJtjv1BF
+        Q1UIIWaCuWlqbv/1TFUIIRaCuYnbf12pCiHERwBz06QXVUII8THA3DS1Q9U/CaChKoQQM8HcHNz+mzBU
+        MWk9TQghxBQwN03tb6ky6RNVQgixAMxNU/v2X7+lSgghloG5acKVKu74393+6+2/EEIsA3PT1H37r2eq
+        QggxE8xNn5/vb/9Nuv0XQogFYG7i7b/Z5kWVfqRKCCEWgLlp6t7+a6gKIcRMMDdN7f/7b9LPqQohxAIw
+        N3H7PzZU/9nv954qhBDiEJiXNjeh9r9TMT3w/w7gz91u5+lCCCEO8fbtWwzUX02DT1StbKh+ZfbW9A8S
+        dcUqhBB9MB9xAYp5ibm52Wyemj0zlaGKL6emR6Yr0yvT76a4rJUkSZJa/Wv6y/RqvV5fPTZubm4wR+tQ
+        ve+fqsJz1a3pR9OL09PTn8yGXvr+Jfa2LtbXgxyKh4/FeVEffUtvFx9nYBHH2i38RV5be3hOWSd/5PNx
+        aj7H3VfjHqv7Xox61tzwIZ/WNe6qdcjLe+S7v/Rhy3kpjh7wFwufq/YmX5XXR234m3r09L4cz8cKX2/N
+        tqyjX+pb9u6r9XkfebAsj0dOxCM/+8se/lDyx/Gqj9bl+BTnvrGu+Z5X9qjDmurDX3JZEadc9se6xGOf
+        4uVYEOWELx8zn0/kN/0ih+LhY3Fe1Ndjmkp9rKMmW8Sxdgt/kdfWHp5T1skf+Xycms9x99W46YUJcxLz
+        8sLn533TO+xq9sSn7MaEwXq1Wq2+Ozs7+97W16YfbF1sXvPebPUlcT7WoeKLOrecW/YH+pYaqiu1qR/s
+        aA/4EScfnxev6x6W9ybssa57WoeQg+9n2aMevoiF7fhrb1jEPafIY8XH/qRSjzXyPTd6NnW0Lvmwnhs1
+        NUb7pgfFajypHBfW1cTIRl70L7F8LFfu0yjV1O8BFPFYh2jfPY+ObXxRP1IT/auwRy7VDWzI96WPqeyz
+        Ih75rlrPe8+Fvyj5mh685r3n98T5WIeKL+rccm7ZH+hbaqiu1KZ+sKM94EecfHxevK57rDEfcYVqe8zL
+        DV+lBtjg2SoCmLh4FPDUX15BeN5aLHzZT77I66nUso/33MNs7ZNrslI81+Xz5ViJu+CL8wvf4HxD8Edu
+        rEm1LvZcx9ZV477mffWnmqZHjh3SyLGbY0ZOtqSSD7+pnjPnsyLuKvmc677uHmvzlZrwUW3xwcJHavLT
+        upHnljry5Zzq43zyNfmmOGfO47/D5nwop8RoXfau6rN4/fMilvJrjq8HxwpLOYM8iPrWXl7X+Mk36EEa
+        nCfvuYfZ2ifXZKV4rsvny7ESd8EX5xe+wfmG4PdnqI8uLy/Pr6+vz3a7XXnr34CrVTPlUYAJw/XMf+nq
+        QPBzbLvdrjgWa9MqYmO9II718o746rFZEYdlpfjg3A6tY89+0mrEX5R79dYdX/2z4fvo/vDV7y0LOVHP
+        NtZJ+FG6Bx4LO0v42TyuG+nRfG+wznm0b/5M4Y+aUORxHHaKUp9B7NC/5yPxxteJlb+zsXjaxzHwd8T+
+        nkrP3Jd9Sc05jOWN1A7yD32/IjbWC+JYL++Irx6bFXFYVooPzu3QOvZuUYs5iXkZs/MgkTRFoOeHQM//
+        KQV6fgj0/FMEev6sINY5/jEEev6eQM8Pgd4+bF5PFej5lwr0/P+HQM8/VaDnHxPorecK9PwfKtDzQ6Dn
+        /5QCPT8Eev4pAmN+4t69/wBu6JtWKCy63gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pictureBox3.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAALAAAAAtCAYAAAAOT+HDAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABPZJREFUeF7tXcFuHEUQtQnrcbBXRCJksWSJFawiwoWDiZIjR/gAf4/9B/afIHHk
+        Atw48C+LzAeY9zpVneqe3vUQQOmR3pOeq7qqume8emrVzK5mDvbgEPxgAlt1U+ayZuoxnD5n6rxY95D/
+        LmvWrHMc/9v14xp1vB57rFVfc0pNi/E4U1mf1775MRfrp2EYhi9gfgG34L0odsIfTZttMd/f3zOxAbdX
+        V1f32+0WIUF4/6AWb25uKOItRPwlLLVaCPnw4uJiAfsTCwWhR1xfX1PEv4EfgmwtMh6BH4HaeYVuQW1C
+        o3+aVqnZvAtz930CWqkg9Alq1LTKXTiBKh6Wy+VTWCsThD5BjUKrn1Czpt305xh8BlqZIPQJavT09JRa
+        fQwmAbMZ5mAFWpkg9Alq9OTkZLVer7npvhHw2dkZm2IJWOge1CgFDFvuwAh+BmtlgtAnqFGw2IEPbQeW
+        gIXuQY2Cq/Pz81EPLAEL3YMaBcsWQjuwMBdQo9YDjy7iJGChe1CjYNkDs5/QRZwwB1CjYLkDg9qBhVmA
+        GgWLHph/dBEnzALUKDi+iFMLIcwB1ChY3EbTDizMBtTo6C4EqB5YmAWoUVACFuYJalT3gYXZghoFdRdC
+        mCeoUduBy7sQsBKw0D2oUbAUMCgBC7MANQqWArZ7ahKw0D2oUbC8iAMpYAatTBD6BDVKrda/B9Y3ccIs
+        QI2CRQuhX6MJswE1CpYthO5CCHMBNcrbaKMWAlQPLHQPatS0+raF4EAthDAHUKNg+VwIkGqWgIXuQY2C
+        xQ6sLzKE2YAaNa2WLQSoHljoHtSoabUp4Ds9H1joFfZ8YBdw2QPbE/9+51OwBaFH3N7eUrw/g8/q22gD
+        BPwp7HfgHQu1Ewu9gFq01wvcmUZHzwfmE9o/BtfgD+CvoG/Xovi++Rf4B/g9+Dn4xN7pkgX8yL6NY2/B
+        NxV9A75cLBavYJ2vbfyaY/jJmj+qCXmPRcY6n+/rprWN8Tgjyzx9s4wn2ty8htUkv4p7fTxOro95i+W8
+        5fK4lQtr5lqPsT74OW/M81hXj1lv8bROtLGuynMNxpNlzJjXDrFMm+9zPV7M55q2bszXx/JYy482+b6e
+        2W9BanLDVne1Wp3A5zsy3gC7tL+laAlSxOthGJ4fHR19Bf9r8AX8ZGs/jmFzrGKsp+9MMZ9nNtam8Z51
+        05wwL82t1qPduQbjzIdYPK/o5zFtHIMc08/j4DtZw88zjTmfMc+5bcTz2rTMW02i5VIsxium+fRZb7W+
+        ZjEv+Kme1mp9Ts6FcbFGyOV8xXRcWmORC9brnh8fH3PnpTaXcfd1cMBemAnuxGwnntqFHcn+OFnG6niI
+        eV2LaW6MxXFcAzavU8+pWeXrefX5xlzKGxnz8/PY6HydjHut+4F5no/jvGiNOW9+HOd4NadYo87t445j
+        F8f0mtoGpnrGwXzOsT7S88ZUH2st1hzTt3diUJPU5uLy8vLt7uvgLgyT2gmQQj6yr+tGZDzmNpsNG+qc
+        cx8cPLdrLTLmWnUPxPKxIz1PG1nlR+e2z/dxjAcOO+KJ9VotvxHL/xs/R4t7LH+2kazx+dG6X5FX8o8t
+        5/YfkXcD4rwdaxSfDf26LoyL/8niA3ddChcXc9xoH4SLeQqJVpwkWvH/k0QrThKt+BQSrXhNh/t1/r8g
+        0Yq3SLTiJNEau639qSRa8Xcl4Tbg4OBvSdXRqLIoThAAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="pictureBox2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAALAAAAAtCAYAAAAOT+HDAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAABPZJREFUeF7tXcFuHEUQtQnrcbBXRCJksWSJFawiwoWDiZIjR/gAf4/9B/afIHHk
+        Atw48C+LzAeY9zpVneqe3vUQQOmR3pOeq7qqume8emrVzK5mDvbgEPxgAlt1U+ayZuoxnD5n6rxY95D/
+        LmvWrHMc/9v14xp1vB57rFVfc0pNi/E4U1mf1775MRfrp2EYhi9gfgG34L0odsIfTZttMd/f3zOxAbdX
+        V1f32+0WIUF4/6AWb25uKOItRPwlLLVaCPnw4uJiAfsTCwWhR1xfX1PEv4EfgmwtMh6BH4HaeYVuQW1C
+        o3+aVqnZvAtz930CWqkg9Alq1LTKXTiBKh6Wy+VTWCsThD5BjUKrn1Czpt305xh8BlqZIPQJavT09JRa
+        fQwmAbMZ5mAFWpkg9Alq9OTkZLVer7npvhHw2dkZm2IJWOge1CgFDFvuwAh+BmtlgtAnqFGw2IEPbQeW
+        gIXuQY2Cq/Pz81EPLAEL3YMaBcsWQjuwMBdQo9YDjy7iJGChe1CjYNkDs5/QRZwwB1CjYLkDg9qBhVmA
+        GgWLHph/dBEnzALUKDi+iFMLIcwB1ChY3EbTDizMBtTo6C4EqB5YmAWoUVACFuYJalT3gYXZghoFdRdC
+        mCeoUduBy7sQsBKw0D2oUbAUMCgBC7MANQqWArZ7ahKw0D2oUbC8iAMpYAatTBD6BDVKrda/B9Y3ccIs
+        QI2CRQuhX6MJswE1CpYthO5CCHMBNcrbaKMWAlQPLHQPatS0+raF4EAthDAHUKNg+VwIkGqWgIXuQY2C
+        xQ6sLzKE2YAaNa2WLQSoHljoHtSoabUp4Ds9H1joFfZ8YBdw2QPbE/9+51OwBaFH3N7eUrw/g8/q22gD
+        BPwp7HfgHQu1Ewu9gFq01wvcmUZHzwfmE9o/BtfgD+CvoG/Xovi++Rf4B/g9+Dn4xN7pkgX8yL6NY2/B
+        NxV9A75cLBavYJ2vbfyaY/jJmj+qCXmPRcY6n+/rprWN8Tgjyzx9s4wn2ty8htUkv4p7fTxOro95i+W8
+        5fK4lQtr5lqPsT74OW/M81hXj1lv8bROtLGuynMNxpNlzJjXDrFMm+9zPV7M55q2bszXx/JYy482+b6e
+        2W9BanLDVne1Wp3A5zsy3gC7tL+laAlSxOthGJ4fHR19Bf9r8AX8ZGs/jmFzrGKsp+9MMZ9nNtam8Z51
+        05wwL82t1qPduQbjzIdYPK/o5zFtHIMc08/j4DtZw88zjTmfMc+5bcTz2rTMW02i5VIsxium+fRZb7W+
+        ZjEv+Kme1mp9Ts6FcbFGyOV8xXRcWmORC9brnh8fH3PnpTaXcfd1cMBemAnuxGwnntqFHcn+OFnG6niI
+        eV2LaW6MxXFcAzavU8+pWeXrefX5xlzKGxnz8/PY6HydjHut+4F5no/jvGiNOW9+HOd4NadYo87t445j
+        F8f0mtoGpnrGwXzOsT7S88ZUH2st1hzTt3diUJPU5uLy8vLt7uvgLgyT2gmQQj6yr+tGZDzmNpsNG+qc
+        cx8cPLdrLTLmWnUPxPKxIz1PG1nlR+e2z/dxjAcOO+KJ9VotvxHL/xs/R4t7LH+2kazx+dG6X5FX8o8t
+        5/YfkXcD4rwdaxSfDf26LoyL/8niA3ddChcXc9xoH4SLeQqJVpwkWvH/k0QrThKt+BQSrXhNh/t1/r8g
+        0Yq3SLTiJNEau639qSRa8Xcl4Tbg4OBvSdXRqLIoThAAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="btn_Cerrar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAYAAAD0eNT6AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        xAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAADjPSURBVHhe7d15
+        /HVjvf9xmWdllllRKJ04qQyRUKlOpTToIJUx4xEqJc2USIdKAxlOg04hlCGzyJgImUuSecjsxu/3fqfv
+        6Xb73Pf9Hfa+rs+11uv5eLz+0OCxv3utva61117rumYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAGjWTWkz9m9pIfUBtp/ZUX1aHqKPU8epMdYm6cbJuVfdO1pPq/03W
+        JDX5f3+38v/vauV/11nqNHWM+p7aX31KfVT5tbxF/btaQs2mAADAdMyuVlQeRHdQ+6kj1MnqCnW7ekpN
+        PmBn7z51jTpH+cTEJynbq7epV6j5FQAAnTe3epXaTH1GeYA/V/1VPa2iQbTr+UrDRepH6vNqC7WGeoEC
+        AKApc6hVlQf6fdUJ6ibV10F+vN2m/JPDQWprtaaaRwEAUN2cai21q/qhuk5N+ds6DS7/DHKt+rHyvQ8b
+        qgUUAABDM7NaWW2u/K30PPW4igYqKptvVjxS7axWU89TAACMiwd8Dyb+punL+PeraPChfD2g/PPBPmp9
+        5ZssAQAIeZBYR/kGvTPUIyoaXKi9HlO+YuOnK/yzAScEANBzL1H+/f5U9aiKBg/qXg+rk5QfuXyRAgB0
+        nO/Q9yVh353vCW6iwYH6l+8hOFRtonjSAAA6YnHl2ep+pfiWT9PLP/14X9lJcXUAABqzlPId4f7dt7UZ
+        9ChXVynfTLi8AgAktIwaGfSZdIeG0cjJAFcGAKCyF6rd1eUqOmATDSOfYPpE0z8TeB8EABTgG/k2VV4o
+        h1n3qHb+ielsta2aTwEABsyT8vhObU/yEh2IiWrnm0y9XLKfNGE2QgCYAK9//2l1s4oOuERZ8/0CnmOC
+        tQoAYAz8bd9zuz+hooMrUSt5vQiuCgDANHgN+F3UH1V0ICVqveuV15ZYRAFA771SHaaYe5/6ktcm+L7y
+        6pIA0DteR9+r7PHMPvU5P074NsXPAwA6bVbl9fSvVNHBkKiveS4LfzZmUQDQGfMqz9L3FxUd/Ijomf6m
+        PNug74kBgGYtpLwG+99VdLAjojjPd7G/YqZBAE1ZUPlbDJP2EE0sP0boCbA8JwYApOVv/Az8RIPvIXWQ
+        4hFCAKl44N9XPayigxcRDaYHlT9rz1cAUI0XP/myYuAnKtu96pNqbgUAxfhRpa3VHSo6OBFRme5Wnl1w
+        TgUAQ+PJSjZRN6joYEREdfqr8kn5jAoABmoN9RsVHXyIKEcXqzUVAEzYCuokFR1siChfnl7bq2kyhwCA
+        cfHNRb7Bz88hRwcZqpMfsbxRXah8YuYD/YHqU2o79W7lpWfXUV5W2b1ULffPPMOcm0uNmEmN/OducTXy
+        v3+F8roNG6n3KV9m9m/OX1TfUD9WZ6trFI9/5sqPDu6l5lAAMF3+nd8H+ltVdFCh4TVJ3aTOUF4t7tNq
+        M+UB2INyC/PEe7BZVvkno43Vx9Qh6lfqWuWV8KK/nYbXzcr37gDAVL1cnaWigwgNrtvVqcpTvX5IrauW
+        UTOrrvNNaksqX6HYSn1dnaY8B370XtHg8pWaf1MA8H/8PL9nGfM30OjAQePL33YvVYer/1K+NL+wQmx+
+        9TrlnzJ81eC3iisGg82fca/Pwc8CAGZ4u+Jy/8TzjVdXqe+oLdRKqg/f6IfNP3v4PgafFBymvJT0kyra
+        BjT6rlevVwB6aFF1jIoODjT9HlG+pPol9Rblb68owzeoevDyuhP+yepRFW0jmnY+af2e8o2fAHrAN/lt
+        qTyVaHRQoDhPd3yi2lW9RrVwQ15fzK7808He6teKqanHlu+/8NMjADrMd2f75rPoIEDPzY/beSnWtykP
+        MmiDf3rxkxNeNOcSFW1bem4nKN+gCaBDfOf1LopvRtPOz03/Qvn3Zp8soRu8LbdXHuD4DEy7+9U2ylcK
+        ATRuKeXnyqMPOz2zoNE3le/Qn02h23wl563KT2bco6J9gp55NJOZBIGGefIPDnLPzfc/eAY9X9rnt/z+
+        8gyI/qnAj8AyD8Fzu095UjAADVlA/VRFH+q+5kHfj5G9UfF4Hqbkk4H11LcVN8g+u++qyaeOBpDUm9Vt
+        Kvog9y0/qneU8mN6sypgNPxTkO+K9/0gT6ho3+pbnsb5VQpAQv5t82DlZ3ujD3Cf+r3aQT1fARPhmRt3
+        Vp7RMdrX+pRPhj6hfLUEQBLLq8tU9KHtSw8qX6pcXQHDsIryDaN/V9E+2Jc8+ZJvLgZQ2XtUn5dhvVh5
+        idp5FFCC97Vt1eUq2if7kG8QZIVBoBJf8ve3kejD2fW8QIyXy2VlM9TmZY99n0lfpyM+UHFTLVCQl471
+        SmnRB7LL+UqHH9ny2vhAJgupPVUfb8A9Vy2mAAyZL7v17ZL/Dco39fEoErKbU3nWQa+2F+3LXe2vyldD
+        AAyBp+b06md9usvf87hvrrjEiNZ4+m1PNHWeivbtLjZJ+SoIgAHy42wnqehD18U8ZzvfJtAVayuvUhjt
+        613sCDWHAjBBK6irVfRB61r+tuRlXYEu8kmtT26jfb9r/U4tpwCMky8h9uH3fj9X7G9JQB+sqfqwLLfX
+        IXmTAjAG/r3/U+opFX2wutL56g0K6CNfEej6Sp1PKt8UCWAU/Hz/j1X0YepKnrxnIwXgmfU7rlDRZ6Ur
+        7a98YySAqfAqfn6mNvoAdaE/Kc9c6CscAP7Fg+MH1S0q+ux0of9V3BwIBJZV16jog9N6Dys/wsiHH5g2
+        r1rpxYe6uiTxhWoRBeCfXqPuUNEHpuU8Z8GRipn7gLHx1UBP9e3f0KPPVsvdqF6igN57h/I35OiD0nL+
+        nd93OwMYP6930cWfBX2FY10F9NYuqmt3+t+q/lPxOz8wGP4sbaa6ts6AF/XaVAG98yUVfShazZcqD1DM
+        1w8Mx7zKd9M/oaLPYIv5Z8I9FNALPpv/uoo+DK3mR5herQAM38tU11YD3VcBnTaTOlxFH4AW8zcRf3B9
+        5zKAcvzY4NbqQRV9NlvsEMVcAeik2dTPVbTjt5jn7V9RAahnGXWKij6jLfYdxUkAOmVudZqKdvjW8toE
+        fk6ZDymQxybqLhV9ZlvrR2oWBTRvQeVH4qIdvbVOVDzTD+S0qPJnNPrsttaxyldNgWa9QF2ioh28pR5V
+        /tbPo31AfpurLtwb4IWSfPUUaM7zVRe++f9BraIAtMNTi5+jos90S/lv8OOPQDPmV5epaIduJU9Q9FXF
+        ZTigTX7qaC/V+rwBF6h5FJCeL/tfqqIduZU8m9/6CkD7VlPXq+iz3kpnqzkVkNZ86iIV7cCt5EcVvRAJ
+        gO7wN2jfXR995lvJT1LNroB0Wv/N3/Nyb6MAdNf2yjf1RseAFvIXlJkVkIbnvz9fRTtsC92iVlcAum9V
+        1fJPAkcr5iFBCp4G92QV7agtdLpaSAHoD99Zf4yKjgkt5BkDeSwZVfks9Mcq2kGz51W4DlLMuAX0l9cT
+        mKSiY0T2vqGAalpd1c+ThHjqUABYR92pomNF9j6ngOI+r6IdMnt/VCziA2ByL1ae9Cs6ZmRvDwUU42lx
+        ox0xe8crZtUCEPGjgi2uWOqfMzdVwNB9QHmHi3bEzPn3fs8MBgBT4xvrPqNaO8b5Mea1FTA0aynvaNEO
+        mDV/kPdRADBavkeotfkC7lEvUcDALadau1HGH+D3KAAYqzXUXSo6tmTtJrWwAgbGi/tcq6IdLmv+4K6p
+        AGC8fHPgdSo6xmTN07GzbgAGws/Je7KcaEfLmmf5Wl4BwEQtqM5T0bEmaz9VzBaICfENMUeqaAfL2hnK
+        KxICwKB4uvNfqOiYk7WvKGDc9lbRjpW1nylPTQwAg+ZFeI5S0bEna9sqYMx8F2xLj8J4gQxWyQIwTL6s
+        foiKjkEZ8zTHGypg1DxT3gMq2qEy5oUx+L0LQCl7quhYlDE/HuinuIDp8u/nLS2VebBiVSwApe2kWrlK
+        erniyQBMk79F/1JFO1DGvB4BANSylXpKRcenbB2mgKn6gop2nIz5BkUAqO2DqpWTAG4KROidqoXLWX6N
+        OygAyOJDqoWTAE/l/hoF/B/PH32/inaYbO2mACCbVk4CblOLKeAfE1xcraIdJVsfVwCQle8JaOFK6pmK
+        x6bxjxtDoh0kW59TAJDdh1ULVwL2V+gxr+0f7RjZOlABQCt2VNGxLFO+UvEuhR56kWphsh9foeA5fwCt
+        2UdFx7RM3aeWUuiR2dSlKtohMuUVrWZSANCiA1R0bMvU2YrjbI8cpKIdIVPHKm5SAdAyX708XEXHuEzt
+        odAD/6Gy36XqO1RZ1Q9AF8yiss+w+rhaTaHD/Ozn3SraAbLkRxJZzx9Al3ge/t+o6JiXpT8qPxaOjjpR
+        RRs+S3epFysA6JoF1LUqOvZl6dsKHeRnU6MNnqVHFFNUAugyP311p4qOgVnaRKFDllaZH/nzpBleiwAA
+        um5t5Tn5o2Nhhnwl9oUKHeC7UE9X0YbO0s4KAPpiM5X5ZuxTFfOvdIAH12gDZ4nfnAD0kac3j46JWfK6
+        BmjYCuphFW3cDB2vmIACQB/5G/aPVHRszJBnCeSngEbNqM5X0YbNkB85mVcBQF/58cDfqegYmaGfKTRo
+        BxVt0Aw9qFZWANB3vknbN95Fx8oMbazQEE/448s30casnW984TETAPiXN6gnVXTMrN3fFJOzNcSXbaIN
+        maH9FADg2fZU0TEzQ4cqNGAjFW3ADJ2hWOAHAJ7LNwX+REXHztr5yq2vUiCxudWfVbQBa3eLWkgBAGI+
+        hl+lomNo7TyN8ewKSR2oog1XO8969SoFAJg23yCd9fHtLyok5KUcs95Eso0CAIzO1io6ltbuCfVyhUT8
+        29GFKtpgteM5UgAYu6z3A/heLiTyQRVtqNr9VXkJTADA2Myjsi4fzNwASfimEQ+00UaqmVf4W18BAMbn
+        39XjKjrG1uwmxQ2BCXxJRRuodvsrAMDE7KaiY2ztPq5Q0XLqURVtnJpdqTg7BICJ87ouZ6roWFszT+nO
+        YkEVHauiDVMzn5BwlygADM4y6gEVHXNrdrhCBeupaIPUbnsFABgsr88fHXNr5nu9VlcoyGvo+zJ7tEFq
+        dqLyI4kAgMHysfWXKjr21uw8xXG/oA+paEPUzJenllAAgOHwb+73qOgYXLP3KxQwm8o43/+2CgAwXJuq
+        6BhcM6/1MofCkO2qog1Qs7MVl4AAoIzjVHQsrpnHJgyRJ/25Q0Vvfq280M+KCgBQxpLq7yo6JtfqLuXZ
+        CzEk+6joja/ZJxUAoKxdVHRMrtmeCkOwoMr2HOgVahYFACjLEwT9VkXH5lrdreZVGLADVPSG18rPf75W
+        AQDqeIWapKJjdK32VhggP16XbcrfrykAQF0+FkfH6Frdr16gMCDfUNEbXatb1VwKAFCXbw73Y3jRsbpW
+        X1AYgEXUIyp6k2v1AQUAyOF9KjpW18oLBS2sMEH7qegNrtUFimf+ASAXz8cSHbNr9RWFCZhfZXrW82n1
+        agUAyGU15Zuzo2N3jR5WiyqMU7bn/o9QAICcvq+iY3etfAUb4+Cb7DyzUvSm1shnc559CgCQk3939134
+        0TG8Rp67Zj6FMdpDRW9orfZSAIDcso0drBEwRl5V6XYVvZk1+pNipScAyM8rxt6komN5jTx+zKwwSlup
+        6I2s1XsUAKANm6voWF4rP6aIUfq9it7EGl2ieOwPANrhdQIuV9ExvUYeRzAKG6joDazVmxUAoC1vV9Ex
+        vVbrKkzHiSp682p0vgIAtOk3Kjq21+gEhWlYXmWayOENCnl4mU3fj7G/Olqdpc5Tx6pD1Y7K+xAwDCuo
+        nZT3Ne9z3ve8Dx6lvqo2USwFm8vaKjq218gTya2kMBX/raI3rkbnKtTn3/LerU5Vj6toW03Z9cpLci6o
+        gInwc+WekOwGFe1rU+Z99BS1sfK+i/pOVtG2qtF3FQKeLCHTtL8+c0Rda6mJ3BDqSTj2VDyCg7GaRX1C
+        eVGXaN8aTb4JbU2Ful6lou1TIy9rzyJBgd1U9IbVyGfwqGcm5eU0B/VzkBdwWkoBo7G0ulBF+9JY8z78
+        OcXVgLp8BTHaPjXaXWEyfszOl22jN6tGLPhTjyfx+KmKtstEuk39mwKmxfuI95VoH5pIxyjv26jjdSra
+        LjW6VvFo+WTWU9EbVSPu1KzH35J8oIy2yyC6T/lyIBDx4H+3ivadQXSc8tUt1HGOirZLjXgkcDI/UtGb
+        VKM1FOrwZf9omwyye9SqCpic9wnvG9E+M8g+q1DHm1S0TWrkp5ggCyjfGBG9SaXz736owzf8lXoElJMA
+        TK7U4O+8j/Mlo56LVLRdSucxb37Ve14pKXqDauRHd1CeL/2Xnv6ZkwBYycF/pMsUNwXW8U4VbZMaeU6J
+        3vuDit6c0vk5X36fq8MTqETbZNhxT0C/Dfs3/2n1DoXyfPPdNSraJqW7UvWaL4VFb0yNPqpQR81HdLgS
+        0E81vvlPnienQR3bqWib1KjXT5wdrqI3pXQ+EMylUJ6nTh3tDH/DiisB/VLzm/9Ij6l5FMqbU9Xe/iN9
+        T/WSd/6HVPSmlM53n6OO96pom5SOk4B+yDD4j/QuhTr2U9E2KZ3HwF6uH7G5it6Q0vlMfFGFOryISrRd
+        asRJQLdlGvzdvgp1eGbQSSraLqXbSvVOlgUaensJJon/UdF2qRUnAd2UbfB3XkUQ9fxERduldKerXllI
+        ZTn78oEB9Xg51Wi71IyTgG7JOPi7MxTqyXIT+pOqV1eht1fRG1G6ixXq8prq0bapHU8HdEPtu/2nlaem
+        RV0eA6JtU7pePYWW5aDfy99ekvm5irZNhrgS0Las3/xH8qJXqGsbFW2b0vXmZNA3XzytojehZF7nu5d3
+        XyZzqIq2T5Y4CWhT9sHfHaxQ19zKY0G0fUrmKaIXV523p4regNJ9V6G+HVW0fTLFzwFtyXzZf/J2Vqjv
+        MBVtn9LtojrvchX98aVbXaG+5VW0fbLFSUAbWhn83SsV6styM+D5qtOyHOy98AzyuF5F2ylb/ByQWwuX
+        /Ue6WXleeuSQYU0a/zS+tOqs3VX0h5eOef9z2VtF2yljnATk1NLg7/ZSyCPLqrQfU511ror+6JI9op6v
+        kMeC6gEVba+M8XNALi1d9nf3qwUU8vAxyLPCRturZJ19NN2T/3jCg+iPLhmzb+WU5ebQ0cZJQA6tDf6u
+        09/yGnacirZX6ZZTnfMhFf2xpdtIIZ+ZlW+CibZZ1vg5oK7WLvu7i9QsCvlkWZhsB9U5x6vojy3ZvWpW
+        hZw8R8RtKtp2WeNKQB0tfvP/q1pSIScvE5xhToATVafMoR5W0R9bMhb+yc/f6lo7sHMSUFaLg79fr/dt
+        5OafiKPtVzLfp+YxszPerqI/tHQbKuTX4qVdfg4og30Dw+SfiKNtWLpOjVX+5h39kSW7S/HbWzs40GNK
+        7BMYNo8RHiuibVmyA1Vn3KKiP7JknnMebeGAjxHsCyjlWyraniW7RnXCS1X0B5buDQrt4cAP9gGUtJ6K
+        tmnpllXNy7DYy53Kj5mhTQwA/cW2R2keK/zEWLRtS7adal6Gx/8OUWgbA0H/sM1Ry9Eq2r4l89jZNJ9J
+        edrL6I8r2QYK7WNA6A+2NWp6j4q2cck8J8FsqlkZlll8SDX9JuJZGBi6j22M2uZWGdYGaPretQyrvP1C
+        oVsYILqLbYssTlbR9i7Zl1WzzlHRH1WyTtxIgedgoOgetiky8dgRbfOS/UY1yfMqP6GiP6pknXiUAiEG
+        jO5gWyKbJVS03Uv2uPJY2pzXq+gPKllnJlPAVDFwtI9tiKyuUtH2L5nnJWjOXir6Y0p2gEL3MYC0i22H
+        zA5S0T5Qsn1Uc7ykYfTHlIzFf/qDgaQ9bDNk91YV7QclO1M15Xmq9nKdXn54doX+YEBpB9sKLZhH1b6X
+        zcsDN7WQ3Uoq+kNK5isQ6B8GlvzYRmjJuSraJ0q2qmrGVir6I0q2q0I/McDkxbZBaz6jov2iZNurZhyu
+        oj+iZKsr9BcDTT5sE7RoTRXtGyU7QjXjWhX9EaXybyazKvQbA04ebAu0yr+/+56yaB8plcfUJsynnlbR
+        H1GqsxVgDDz1sQ3QurNUtJ+UymPqAiq9dVX0B5TsiwoYwQBUD+89usBjSrSvlGx9ld4uKnrxJdtIAZNj
+        ICqP9xxdkWE+gN1Vej9Q0YsvlS+VzK+AKTEglcN7jS55gar90/YPVXq/V9GLL9UfFDA1DEzDx3uMLvLa
+        MtG+U6r0a9vMpmrPmnSoAqaFAWp4eG/RVd9T0f5TqqfU3Cotz1YUvfCSbaGA6WGgGjzeU3TZh1W0D5Xs
+        NSqtD6noRZfM0xADo8GANTi8l+i6DF9wP6LS+oaKXnSpHlUzK2C0GLgmjvcQfZDhJ+7US9z/WkUvulSX
+        KGCsGMDGj/cOfXK5ivapUp2s0rpFRS+6VIcpYDwYyMaO9wx9U/sx97+olOZStZ+TZAVATAQD2ujxXqGP
+        Mkx05+n20/EBIXqxJWtiqkSkxsA2fbxH6Kt1VLR/lSzlkwDvVdGLLdnCCpgoBrip471Bn82ral/p/k+V
+        zqdV9GJLdbsCBoWB7rl4T4D697rto9L5HxW92FKdooBBYsD7F94L4Bm1n3Y7SqVzsYpebKm+qoBBY+Dj
+        PQAmd4iK9rlSXaDSuV9FL7ZUWypgGPo8ADL4A8+2k4r2u1LdpVLxYwnRCy3ZugoYlj4OhAz+wHO9UUX7
+        XslSPQr4MhW9yJItrYBh6tOAyOAPxJZV0f5XMo+5abxZRS+yVJMUawCghD4MjAz+wNTNqLzuTLQflmoj
+        lcZWKnqRpbpJAaV0eYBk8Aem70oV7Yul2kal8XkVvchSna6Akro4UDL4A6Nzgor2x1J9QaVRe4GE7yug
+        tC4NmAz+wOh9U0X7ZKmOVGnUnhjBsxACNXRh4GTwB8bmEyraL0t1hkrjOhW9yFKlnBsZvdHyAMrgD4yd
+        x5xo3yzV1SqNB1X0Iku1lgJqWlXdo6L9M2t+vS2+Zr/XQE21VwX0SXsKs6voBZZsCQXU1uK36Zbimz+y
+        WE5F+2ipvCLhLKq6JVX0AkuV5o0AhJOA4cTgj0xmVU+paF8t1eKquleo6MWVymsQAJlwEjDYGPyR0R0q
+        2l9LleKnsDeo6MWV6kYFZMNJwGBi8EdWvhEv2mdL5TUJqnufil5cqX6rgIw4CZhYDP7I7BwV7beler+q
+        bgcVvbhSnaSArDgJGF8M/sjuWBXtu6XaTlW3j4peXKmOUEBmnASMLQZ/tOC7Ktp/S+XJiKr7hopeXKkO
+        VEB2nASMLgZ/tGJfFe3DpdpPVedv4NGLK9VeCmgBJwHTjsEfLdldRftxqQ5V1f1URS+uVNsqoBWcBMQx
+        +KM1W6poXy7VMao634QXvbhSvUsBLeEk4Nkx+KNFm6hofy7Viaq6M1X04kq1vgJaw0nAMzH4o1UbqWif
+        LpXH3uouUtGLKxULAaFVfT8JYPBHy9ZV0X5dqhRz4PxBRS+uVKsroFV9PQlg8EfrPPZE+3aprlDV3aSi
+        F1cqH0CBlvXtJIDBH12wsor271LdoKq7XUUvrlQrKaB1fTkJYPBHVyyron28VLep6h5Q0Ysr1YsU0AVd
+        Pwlg8EeXLKyi/bxUPlZU97CKXlypllRAV3T1JIDBH10zr4r29VL5M1Xdoyp6caXyWRjQJV07CWDwRxfN
+        raL9vVR/V9XVPgGYTwFd05WTAAZ/dNVcKtrnS/WIqu4xFb24Us2hgC5q/SSAwR9dVvsE4HFVnV9E9OJK
+        NZMCuqrVkwAGf3TdnCra90v1lKruCRW9uFLNqICu4gQAyMlXn6N9v1QpTgAmqejFlWpWBXQRPwEAec2u
+        ov2+VP75vbonVfTiSuXfYYCu4SZAILfaJwAPqupqXwF4vgK6pCuD/0icBKCLat8EeK+q7iEVvbhSLaiA
+        ruja4D8SJwHoGo890b5eqjtUdbUPVospoAu6OviPxEkAumQJFe3npbpVVfcXFb24Ui2lgNZ1ffAfiZMA
+        dMWLVbSPl+pmVd11KnpxpWIxILSuL4P/SJwEoAtepqL9u1Qee6u7QkUvrlSrKKBVfRv8R+IkAK3z/hvt
+        26W6SlV3oYpeXKnWUkCL+jr4j8RJAFq2tor261Jdoqo7W0UvrlRvUUBr+j74j8RJAFq1oYr26VKdrqo7
+        RUUvrlTvV0BLGPyfHScBaNF7VbQ/l+pYVd3PVPTiSrWNAlrB4B/HSQBas62K9uVSHaGq+66KXlypdldA
+        Cxj8px0nAWjJXiraj0v1DVXdV1T04kr1eQVkx+A/ujgJQCv2V9E+XKoUY9/HVfTiSvXfCsiMwX9scRKA
+        FnxfRftvqfZQ1fk3+OjFlerHCsiKwX98cRKA7I5T0b5bqhT3v22iohdXqrMUkBGD/8TiJACZnaOi/bZU
+        KZ6AW19FL65Uf1RANgz+g4mTAGR1tYr22VJ5HoLqVlXRiyvV/QrIhMF/sHESgIz+rqL9tVQvV9Uto6IX
+        V7I5FJABg/9w4iQAmcyjov20ZAur6jz4Ri+uZMsqoDYG/+HGSQCyWFFF+2ipJqkZVQr3qOhFluq1CqjJ
+        P4XV/hyMNb/eFl+z32ugptr3vt2q0qi9JPC7FFBLi9/8R75Nt/zagVo2V9G+WapLVRq/UtGLLNVuCqih
+        CwMoJwHA2HxSRftlqU5UaXxPRS+yVIcooLQuDZycBACj5zEn2idL5VkI0/isil5kqX6pgJK6OGByEgCM
+        zskq2h9LlWoNnK1V9CJLxWRAKKnLAyUnAcD03aCifbFUXoo4jbeo6EWW6jGV5pEIdFofBkhOAoCpm0U9
+        oaL9sFQpZgEc8QoVvciSLamAYerTwMhJABBbQUX7X8mWV2nMrZ5W0Qst1ToKGJY+DoicBADPVfuK91Nq
+        NpXK31T0Yku1lQKGoc8DIScBwLPtrKL9rlR/Vumcq6IXW6oDFTBoDIC8B8DkDlbRPleqM1U6h6noxZbq
+        NAUMEgPfv/BeAM/wWBPtb6XyWJtO7ZmRblPAoDDgPRfvCTDDDHeoaF8r1adUOpuo6MWWbAEFTBQD3dTx
+        3qDPFlHRPlayD6h0XqmiF1uytRUwEQxw08d7hL7y8/fR/lWy1VQ6GR4F3E4B48XANnq8V+ijj6lo3yqV
+        HwGcS6XkNYqjF10qFgXCeDGgjR3vGfrmByrar0p1vUrLi/JEL7pUv1XAWDGQjR/vHfrkdyrap0p1rEpr
+        XxW96FI9qmZVwGgxgE0c7yH6wGsAeIyJ9qdSfUGltamKXnTJUt4ggZQYuAaH9xJd530l2o9K9j6V1stU
+        9KJLxo2AGA0GrMHjPUWX7aiifahkL1dpzaxqXyJJOUsSUmGgGh7eW3TV0Sraf0o1SaVbBGhKtW+SuFIB
+        U8MANXy8x+gi34Ef7Tul+oNKr/ZjEn5Och4FTImBqRzea3TJgqr2PDceW9P7LxW9+JKtp4DJMSCVx3uO
+        rnirivaXku2g0nudil58yfZRwAgGonp479EFn1fRvlKyV6v05lS+WSH6A0qVcr1kVMEAVB/bAK07W0X7
+        SakeV+lvABxxmYr+iFL5SYTZFfqNgScPtgVa5S+1j6loHynVxaoZ31TRH1Ey/xSB/mLAyYdtghZtoKJ9
+        o2QeU5uxhYr+iJJ9WqGfGGjyYtugNV9S0X5Rsi1VM16qoj+iZL9W6B8GmPzYRmjJBSraJ0q2smrG89S9
+        KvpDSvWwauamCQwEA0s72FZogeeUqX1T+wNqJtWUX6nojynZ+gr9wIDSHrYZsnuLivaDkp2kmrO3iv6Y
+        kn1NofsYSNrFtkNmB6hoHyjZHqo5GSYEulqh2xhA2sc2RFbXqWj7l6yJCYCmNKt6SEV/UMmWU+gmBo7u
+        YFsimxVUtN1L9qCaRTXpVBX9USXbXqF7GDC6h22KTDKsa3OyatYnVPRHlewEhW5hoOguti2yOF1F27tk
+        HkOb5d8uoj+qZP4ZgmmBu4MBovvYxqhtXuX596NtXbLXqmbNrPwMY/SHlcxLOaJ9DAz9wbZGTe9W0TYu
+        mb+8+l66pvkSfPTHlexwhbYxIPQP2xy1/EBF27dkTT7/P6UMN1Lco5q9kxIMBD3Gtkdp/tZdeyZbt4Nq
+        3ooq+uNK90aF9jAAgH0AJWWY/c+9SHXCDSr6A0v2HYW2cODHCPYFlJLh8v+1qjO+oaI/smR3Kd+UiDZw
+        wMeU2CcwbFku/x+oOsOX36M/snTrKeTHgR5Tw76BYfITY9E2LN2GqjO8LG+GaYG/rZCbD/C+aTPaflnz
+        611VoQy/1y3uI69UyO0IFW2/knkp+87NXXOciv7YkvnSDpMC5bW0uk1F2y5rDP51tHgScKd6qUJO/qLq
+        qzXRtivZiapztlLRH1s6T/CAfHx/xgUq2mZZ49JuXS3+HODV5TzLHPLZREXbrHTbqc5ZTD2toj+4ZL9Q
+        yCfDuhFjiW/+ObR4JYAnknI6SUXbq2RPKY+VnXShiv7okj2hFlbIw9vj7yraXhlj8M+ltZMAfxFaXSGP
+        F6pJKtpeJTtbddbuKvqjS7ezQh77qGg7ZYzBP6fWTgL8bRN57Kmi7VS6HVVnLaky/AxwiUIeGSaKGk38
+        5p9bS/cE+Di4nEIOV6toO5XM+4THyE77rYr++NKtolDfCiraPtnim38bWroS0PRa7x2SYdl6d77qvN1U
+        9MeX7hCF+vxzTLR9MsXg35ZWTgLOUKjP88NE26d0Xjiv87L8DOCbzngcpz7fER1tnyxx2b9NLfwc8IB6
+        nkI98yhvh2j7lMxjoudB6YUsz3tvq1DXz1W0bTLEN/+2tXAlYBGFej6qou1SuotUb+yqojehdL9XqOs8
+        FW2b2jH4d0P2kwAvl456rlTRdildr55MW0J5woPojSjdGgr1nKmi7VIzBv9uyXwS8HKFOl6vom1Sul7O
+        TXOqit6M0h2pUM/RKtoutWLw76asJwHLKNTxMxVtk9Idr3pnUxW9GaV7VDEzYD1fUdF2qRGDf7dlOwnw
+        zHOzKJS3uMow85/r5fo0c6j7VfSGlO6zCnVkWYCDwb8fMp0E/EGhjs+paJuUzivUehXCXsryCJgPCHMp
+        lOdHMR9X0XYpFYN/v2Q5CWAukjrmVF6aOdompfuW6q01VfSm1Gh7hTpOUdE2KRGDfz9lOAlYX6G8HVS0
+        PWr0WtVbngTjWhW9MaW7Xs2kUN67VLRNhh2Df7/VPAm4SXG8Kc/v+Y0q2ialu071fiKovVT05tRoY4Xy
+        ZlS/U9E2GVYM/rBaJwFMQlbH+1W0PWq0h+o9zwnwpIreoNL1YjGGpPxzUKm5IRj8MbnSJwGefGZmhfIu
+        VdE2Kd1jaiEFOVZFb1KN1laoo8SduQz+iJQ6CfANr6wtUYfvuYi2SY08/wn+aQMVvUk1+rVCHf4p4BgV
+        bZdBxOCPaSlxEsCl/3qyTD7n1lL4J98IcY2K3qgacRWgHj8TO4yTgL8qrxAHTMsr1bAeEdtboQ7fbR9t
+        kxqxBk1gJxW9WTXymSLq8ZUAT840qHtDfG+Hl6EGRuOl6o8q2pfGky/7b6dQz2kq2jY14ipQwOsye43+
+        6A2rEVcB6vNCTZepaPuMJs80+THFDVcYKx+Pvqu8Tnu0b4023/DHb/51ZZpv5kHlyc8Q8KxI0ZtWI09O
+        g/p8NeCd6mTlO2ejbTVlN6tPqQUUMBGrq5PUWE8E/Jy/v+lx8lnfGSraRjX6psJUeGnM6E2rFUsF5+Jv
+        ZZ40aF/lVRz9wT5XeVWvg5XX1PZvuMCgLas+obzPPaCmPFZ4YZmrlKf39d3mTPKTw7pqym1VK59ErqQw
+        DWep6M2rkT/sADClxdSKahW1tGJVv5zOVtGxvUa+koTpeJuK3rxavVkBANqS6fFy93qF6fAjgV4mM3oD
+        a3SF4nIeALTD9w5lmfXPXaIwSluq6E2s1QcVAKAN2cYQr0GAUfLvaX9W0RtZo1uV15AGAOQ2h7pFRcfy
+        Gv1FcY/IGPn57ejNrBUrNwFAfp9W0TG8VrsqjJEnS7hPRW9ojfxaeK4cAPJaRGWaUM6TkTHxzzh9WUVv
+        aq2YxAEA8vq2io7dtfq8wjgtqh5V0RtbI89Nz0QzAJCP52TwhEzRsbtGvhLBVeMJ+rqK3txa/Ub5UUUA
+        QA4+JmeaRM59QWGCfBXgYRW9wbXaTAEActhCRcfqWnnRn4UUBuBrKnqTa3W7mk8BAOryTXa3qehYXasv
+        KgzIgspnVNEbXauvKgBAXf+tomN0rR5SfPsfsP1U9GbX6gnl1QsBAHX4pmzfnB0do2vlp9cwYL4KkOn5
+        TnehYp0AACjP8/2fr6Jjc618pdpjFYbAv6tEb3rNmOUJAMrbSUXH5Jp9RmFI5leZZgd0/r1nWQUAKMPH
+        3Gz3hfnm8LkVhmh3Fb35NTtdMTcAAAyfj7WnqOhYXLPtFIZsVnWDijZAzfwcKgBguLZW0TG4ZtcqVvwr
+        ZFMVbYSa3a08aREAYDgWV15gJzoG1+xdCoX4ElC2uz/dyYqfAgBgOI5T0bG3Zn4ajON+YeuoaGPUzpen
+        AACDtaWKjrm1W1uhgoxng74z9cUKADAYL1LZ5oFxHoNQyUuUZ+SLNkzNLlbcEAIAEzezyviT72NqeYWK
+        DlLRxqndpxQAYGI+q6JjbO0+p1CZV+X7m4o2UM18ZWI1BQAYnzXUJBUdY2v2JzWnQgJenz/aSLXzfAUs
+        GwwAY+dZ9a5T0bG1dhsrJOFHMM5S0Yaq3U8UAGBsjlLRMbV2pyoks7LKeEOg214BAEZnWxUdS2vnnyNe
+        ppDQ11S00Wrnu0VXVQCAaXuFekRFx9LafUUhqXnUrSracLXjfgAAmLYXqBtVdAyt3Z+Vxxgk9l4VbbwM
+        cT8AAMR8L9cJKjp2ZmgjhQYcq6INmKGPKQDAs31SRcfMDB2t0IisK0a5J9WGCgDwjPWUj43RMbN2d6mF
+        FBryERVtzAzdq1gvAABmmGFZdaeKjpUZ8jwzaIx/T/LyvNEGzdA1ipsCAfSZb6q7UkXHyAydrljqt1FL
+        q4wrSI3klaRmVADQNz72Zb7p72G1nELDdlDRxs3SZxQA9M1XVXRMzNJOCo3zWebZKtrAGXpaba4AoC98
+        zIuOh1k6TXHpvyN8w92DKtrQGfJMgesqAOi6tZSPedGxMEO+SXsJhQ75sIo2dpb82OLLFQB01YrqHhUd
+        A7P0PoUO8kx80QbP0s1qUQUAXfNC5XX0o2Nflpjwp8M8z7Tnc442fJYuUXMpAOiKedXvVHTMy5LXkZlf
+        ocPeoJ5S0Q6QpV+omRUAtG5W5efpo2NdlnwztscG9MD+KtoJMnWUYo4AAC3zMexHKjrGZeoAhZ6YTWW/
+        HOUOUQDQqq+r6NiWqQuVr1KgR1ZSD6loh8jUFxUAtMbHruiYlik/8reMQg/5cY9op8jWHgoAWvEpFR3L
+        MuXf/d+p0GPfUtHOkSnvqFspAMhuVxUdx7J1oELP+X6Ai1W0g2TKJwHbKgDI6kPKx6roGJapixS/++Mf
+        llJ3q2hHyZQ/WNspAMjG8/tnf8Ta3aeWVcD/eatq4czVH7CPKADIYgv1pIqOWZnyMf7tCniOL6lop8mW
+        d+LtFQDUtrVq4Zu/Y/l1TNVMKvuMVSP5JGAbBQC1+Ia/Fq6cumMVS/ximhZQ16toB8qWP3g7KgAobS8V
+        HZcydpWaRwHT9VLlG0WiHSlj+yoAKGUfFR2LMubJfl6sgFF7s2rhppaRDlasHQBgmHyMaWF635F8DH+j
+        AsZsNxXtVFn7oZpFAcCg+bl5H2OiY0/WPqaAcTtMRTtW1n6p5lQAMCjzqVZukB7pCAVMiGcKPE9FO1jW
+        fqMWVAAwUS9Ul6voWJO1MxQz/WEgFlY3qmhHy5qfZFhBAcB4raj+pKJjTNZ8x//zFTAwy6s7VbTDZe0e
+        tY4CgLFaS/kYEh1bsvY3tbQCBu5V6kEV7XhZe1x5jm4AGK33q0dUdEzJml/vqxUwNBupSSraATN3kOIx
+        QQDT4pnyWnrGfyQ/7vcOBQzdh1Ur019Onh/h4QkBAJF51UkqOnZk76MKKObTKtoRs+e7eZdTADDCx4Q/
+        qOiYkT1fsQCK+7aKdsjs3a02VACwnvIxITpWZM8/bQJVePXAY1S0Y2bPv5ntqVgdC+gnf/Y/oVqa8nzy
+        fqA4fqEqT717vIp20Bbya/csXwD6w7/3/0xFx4QWOk7NrIDqPFvgKSraUVvIE2e8TAHovtXUTSo6FrTQ
+        qcrHXCCNOdSZKtphW+hRtbMC0F2eE6S15/sn77dqbgWkM4+6QEU7biv9RPGTANAtvuR/lIo+8610iXqB
+        AtLy4HmxinbgVvLc32soAO3z7HheGyT6rLfSpWp+BaTnlfiuUNGO3EqeQng3xeyBQJt8k9xnVYszl07e
+        hYrFfdAUX6ryjhvt0C3lpYVfrAC0Yxl1roo+0y3ly/5880eTfNba+j0B7u9qK8Uzt0B+Wyp/ZqPPckv5
+        2Mn9SGjaXOrXKtrBW+tktYQCkM9i6ucq+uy21vnKNy4CzfMCPC3PEzB5Xh/cS4UCyMFX5j6i7lfRZ7a1
+        zlEM/uiUWVVXzs7diWppBaAe/9bviXGiz2iLnaA8pwrQOb4rt/VncSfvYeX1BLwmAoBy/K1/a9WF3/pH
+        Olp5anWgszxYtrqK4NTynbqrKgDD90rl38ijz2KrHai4yRi94W/OT6vow9BiT6lDlWdDBDB4fqrIy9+2
+        unrf1NpXAb3zIdX6JB1Tdot6n+JsHhgMf5Y8h//tKvrMtZq/NGyrgN56i3pIRR+QlvMkJF51DMD4raK6
+        MKHPlHlBoncroPdWV3eq6IPScj7D/75aVAEYvUXUt1TXrhC6O9RrFIB/Wk5dp6IPTOv5Csc+anYFYOr8
+        CJzvD+rKM/1T5mPc8grAFBZQZ6rog9OF/qz86BKPDQLP5t/5N1E3q+iz04VOVyzqA0yDJwzyZfPoA9SV
+        rlT/oQDMMMMG6ncq+qx0pcMUz/gDo+Rvyl38/W/yfqvWU0AfraX8rTj6bHQlP+rsn/8AjNGbVFd/C5w8
+        LzL0KgX0wdrqDBV9FrqUZyncWAEYJ98wc42KPmBd6zz1NgV0ke9891z30b7ftXyz38oKwATNr05T0Qet
+        i3k1sDcqoAvWV11asGd6Ha9Yxx8YIN8l7MeD/Gx99KHrYpcrz4DGUwNozYzKV7N8n0u0b3cx/97vaX39
+        twMYgo2U1+SPPoBd7Xq1s5pLAZnNpnzS+kcV7ctd7QH1DgVgyLwO/0Uq+iB2uXvVfmopBWSyuPqc6uKM
+        ntPr94rJfYCC/E3DK4NFH8iu559BfDOVf1sFavJ6F0eqJ1S0r3Y9/+1zKgAVbKoeVNGHsw9drDxnwrwK
+        KMFLXm+vrlLRPtmH7lMs5gMksKK6TEUf1L7k9QY829gaChgGP8b3beXn26N9sC9doJZRAJLwNJuecatP
+        TwlMLd+A5ScmFlLARCymfAOqn0iJ9rU+5bv8/bOjpysHkJCn1v2Lij7AfesxdZx6r+J3SoyW76/xwjwn
+        qSdVtG/1rdsVc3MADfAkHP+jog9yX3tEHaP8bDbfYDAlzzXhufn9DfcuFe1Dfe1E5SshABryQdX33yuj
+        7lbfUr5aMrNCP/lE8C3qB8o3tUX7Sp/zY7cfUAAa9SJ1loo+4PTMQe5o5Uu+vrsb3eanRXz3ugd9b/to
+        n6AZZviV8twGABrnaYT92BJXA6ad7xnwyoTbqSUUusGT1Oyqfq0eV9G2p2fyMcKP1fqYAaBDPIOgB7jo
+        g0/Pzc95f129Vc2t0AZfyfGl/QOUV6WLti09N18pXFYB6Cif2W+p+M1zbHmmt3PV3spzDfixS+TgJzw8
+        K+QX1flqkoq2IcX5p5CPKL71Az3xQuVlO6MDAk2/h5W/MXnQ8RWCBRTKWFD5Pf+8Olv5p5toG9H0+6Fa
+        RAHoId/8xrwBE8+TpFytvq8+rFZVPG44cb7S8u9qB3WU8sqQ0ftPY+sm9SYFoOd8CdWzCPJNarD5UrTv
+        I/CCKZ6Z0HMQMDvh1L1A+Vl8z7x3qDpP+UpL9N7S+PI+6bkOuKcFwLOspM5Q0YGDBtef1WnqELWj8gxr
+        vvlqRtV1/kbvu/I3Uh7oD1Z+L+5Q0XtFg8snVK9QADBV71e3qeggQsPrUXWF8lLH31SfVJup16nlVAs/
+        KfibpReneoPaXPlv8CDv58pvUNygVz7/xOfPNDf5ARgVT5jix6j6us55xnyfgb8p+2eFc9Sx6ntqX/Ux
+        5ac7fE+Hf9v1LIdeq35l5ZMH3zjnS+xRIwODt7n/eSnl/88qyv8On4BsoN6jtlUe1PdXvt/Br8E34vk1
+        Mc9Erjz99WcV62AAGBdfrvUc+h58ooMMEeXLV5F4ph/AQLxa+TfE6GBDRDm6TPmKDQAMlC8V+xKzf8uN
+        Dj5EVCffWOopfL2qIQAMje/k9sGGZVOJ6ubPoB8xnU0BQDGec90Hn/tVdHAiouHkGy5986dv3ASAajwN
+        ricSekBFBysiGkyeGMkT+SysACANz3L3VcXsbUSD7SHlx3IXUwCQlp859+VJTgSIJpYv9fsb/6IKAJrh
+        KwL+aeAeFR3ciCjON/f5s+OJmQCgWZ4e1vO++1Gl6GBHRM/kmR498HNzH4BO8eODnh/e891HBz+ivna5
+        8lTOPM4HoNM8oZBXgztdMcUw9bWn1PHq9QoAemcF5RsG71XRQZKoaz2oDlVeNREAes+TCm2vvKpcdNAk
+        ar3r1a5qPgUACHgJ2iMVSxFT6z2mvJrm+or1+AFglF6o9lBXq+jgSpQ13+i6k5pfAQAmwFcFPCEKCxBR
+        1h5RI9/2AQADNrt6nzpZPamiAzFRqR5XJ6hN1VwKAFDA4soTDJ2n/EhVdIAmGnTe185UXhKbS/wAUNkS
+        auRkgLkFaBj5CRXP0resAgAktKTy41bnK64M0HibpM5QuygGfQBojFcm3ET5scL7VXSgJxrJK1j6N31f
+        3l9EAQA6YFblO7S/rjwpSzQAUP+6SX1LvUkxFz8A9MBLlO8b8Hzs96locKDu5Wmn/1dtq16kAAA9NpPy
+        XAM+IfCz3Pxc0J38W/4lymtO+AqQV6UEACDkQWJNtZc6Ud2tosGF8nWn8lUdzyK5lppDAQAwbl65cDN1
+        sLpU+ZtlNABRufyUx5XKq+ttobyNAAAYqjnV2sqPHB6ufFLwqIoGKpp4fm8vVt9RXjlyDTW3AgCgupnV
+        Suq96kvKj5T9STE50ejzFM83ql+prylfdXm58nsLAEBT/Du0B7GNlX+b9rdYTzLzF9XXkwMv7HSB8tWT
+        jyu/Ny9TPIoHAOgFnxysrPwc+pZqb/Vt5asHl6nbVTSAZu4B5WWcT1HfV59R/ts2UC9V/vkEAABMhycx
+        8noHq6h11DvVh9Xuyj81+ITBjy96lcTT1IXKj75dq3w5/Q7l59+fUCMDtP95at2iblD+d/xG+d95rPqJ
+        8g13B6hPqm2Uv7n7Nfnb+2LKrxUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAABozAwz/H8kns8+GbGJuwAAAABJRU5ErkJggg==
+</value>
+  </data>
+</root>

--- a/Vistas/frmProveedores.cs
+++ b/Vistas/frmProveedores.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+//using MrTiendita.Controladores;
+
+namespace VistasMrTiendita
+{
+    public partial class frmProveedores : Form
+    {
+        public frmProveedores()
+        {
+            InitializeComponent();
+            tablaProveedores.Rows.Add("", "Distribuidora Bimbo", "6621828945");
+            widthColumnas();
+            tablaProveedores.AllowUserToAddRows = false;
+            //frmEProveedorController controlador = new frmEProveedorController(this);
+        }
+
+        public void widthColumnas()
+        {
+            tablaProveedores.Columns[1].Width = 290;
+            tablaProveedores.Columns[2].Width = 180;
+            //tablaProductos.Columns[4].Width = 39;
+            //tablaProductos.Columns[5].Width = 39;
+        }
+
+    }
+}

--- a/Vistas/frmProveedores.designer.cs
+++ b/Vistas/frmProveedores.designer.cs
@@ -1,0 +1,350 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmProveedores
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmProveedores));
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.lbl_Titulo = new System.Windows.Forms.Label();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.tb_busqueda = new System.Windows.Forms.TextBox();
+            this.pb_lupa = new System.Windows.Forms.PictureBox();
+            this.lbl_buscar = new System.Windows.Forms.Label();
+            this.pb_buscar = new System.Windows.Forms.PictureBox();
+            this.btn_nuevoProveedor = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.pictureBox2 = new System.Windows.Forms.PictureBox();
+            this.tablaProveedores = new System.Windows.Forms.DataGridView();
+            this.id = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.nombre = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.telefono = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.editar = new System.Windows.Forms.DataGridViewImageColumn();
+            this.eliminar = new System.Windows.Forms.DataGridViewImageColumn();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_lupa)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_buscar)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tablaProveedores)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // lbl_Titulo
+            // 
+            this.lbl_Titulo.AutoSize = true;
+            this.lbl_Titulo.Font = new System.Drawing.Font("Roboto", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_Titulo.Location = new System.Drawing.Point(27, 27);
+            this.lbl_Titulo.Name = "lbl_Titulo";
+            this.lbl_Titulo.Size = new System.Drawing.Size(149, 29);
+            this.lbl_Titulo.TabIndex = 3;
+            this.lbl_Titulo.Text = "Proveedores";
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
+            this.pictureBox1.Location = new System.Drawing.Point(32, 55);
+            this.pictureBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(145, 2);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox1.TabIndex = 4;
+            this.pictureBox1.TabStop = false;
+            // 
+            // tb_busqueda
+            // 
+            this.tb_busqueda.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tb_busqueda.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.tb_busqueda.Location = new System.Drawing.Point(75, 134);
+            this.tb_busqueda.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tb_busqueda.Name = "tb_busqueda";
+            this.tb_busqueda.Size = new System.Drawing.Size(357, 21);
+            this.tb_busqueda.TabIndex = 24;
+            // 
+            // pb_lupa
+            // 
+            this.pb_lupa.Image = ((System.Drawing.Image)(resources.GetObject("pb_lupa.Image")));
+            this.pb_lupa.Location = new System.Drawing.Point(40, 132);
+            this.pb_lupa.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_lupa.Name = "pb_lupa";
+            this.pb_lupa.Size = new System.Drawing.Size(25, 25);
+            this.pb_lupa.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_lupa.TabIndex = 23;
+            this.pb_lupa.TabStop = false;
+            // 
+            // lbl_buscar
+            // 
+            this.lbl_buscar.AutoSize = true;
+            this.lbl_buscar.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_buscar.Location = new System.Drawing.Point(28, 103);
+            this.lbl_buscar.Name = "lbl_buscar";
+            this.lbl_buscar.Size = new System.Drawing.Size(148, 20);
+            this.lbl_buscar.TabIndex = 22;
+            this.lbl_buscar.Text = "Buscar proveedor:";
+            // 
+            // pb_buscar
+            // 
+            this.pb_buscar.Image = ((System.Drawing.Image)(resources.GetObject("pb_buscar.Image")));
+            this.pb_buscar.Location = new System.Drawing.Point(32, 127);
+            this.pb_buscar.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pb_buscar.Name = "pb_buscar";
+            this.pb_buscar.Size = new System.Drawing.Size(413, 39);
+            this.pb_buscar.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pb_buscar.TabIndex = 21;
+            this.pb_buscar.TabStop = false;
+            // 
+            // btn_nuevoProveedor
+            // 
+            this.btn_nuevoProveedor.Activecolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_nuevoProveedor.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_nuevoProveedor.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_nuevoProveedor.BorderRadius = 7;
+            this.btn_nuevoProveedor.ButtonText = "Agregar proveedor";
+            this.btn_nuevoProveedor.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_nuevoProveedor.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_nuevoProveedor.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_nuevoProveedor.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(78)))), ((int)(((byte)(89)))), ((int)(((byte)(8)))));
+            this.btn_nuevoProveedor.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_nuevoProveedor.Iconimage = null;
+            this.btn_nuevoProveedor.Iconimage_right = null;
+            this.btn_nuevoProveedor.Iconimage_right_Selected = null;
+            this.btn_nuevoProveedor.Iconimage_Selected = null;
+            this.btn_nuevoProveedor.IconMarginLeft = 0;
+            this.btn_nuevoProveedor.IconMarginRight = 0;
+            this.btn_nuevoProveedor.IconRightVisible = true;
+            this.btn_nuevoProveedor.IconRightZoom = 0D;
+            this.btn_nuevoProveedor.IconVisible = true;
+            this.btn_nuevoProveedor.IconZoom = 90D;
+            this.btn_nuevoProveedor.IsTab = false;
+            this.btn_nuevoProveedor.Location = new System.Drawing.Point(469, 127);
+            this.btn_nuevoProveedor.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.btn_nuevoProveedor.Name = "btn_nuevoProveedor";
+            this.btn_nuevoProveedor.Normalcolor = System.Drawing.Color.FromArgb(((int)(((byte)(218)))), ((int)(((byte)(238)))), ((int)(((byte)(86)))));
+            this.btn_nuevoProveedor.OnHovercolor = System.Drawing.Color.FromArgb(((int)(((byte)(186)))), ((int)(((byte)(211)))), ((int)(((byte)(17)))));
+            this.btn_nuevoProveedor.OnHoverTextColor = System.Drawing.Color.White;
+            this.btn_nuevoProveedor.selected = false;
+            this.btn_nuevoProveedor.Size = new System.Drawing.Size(173, 39);
+            this.btn_nuevoProveedor.TabIndex = 25;
+            this.btn_nuevoProveedor.Text = "Agregar proveedor";
+            this.btn_nuevoProveedor.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_nuevoProveedor.Textcolor = System.Drawing.Color.Black;
+            this.btn_nuevoProveedor.TextFont = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label6.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label6.ForeColor = System.Drawing.Color.White;
+            this.label6.Location = new System.Drawing.Point(894, 207);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(70, 20);
+            this.label6.TabIndex = 32;
+            this.label6.Text = "Eliminar";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label5.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label5.ForeColor = System.Drawing.Color.White;
+            this.label5.Location = new System.Drawing.Point(721, 207);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(54, 20);
+            this.label5.TabIndex = 31;
+            this.label5.Text = "Editar";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label2.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.ForeColor = System.Drawing.Color.White;
+            this.label2.Location = new System.Drawing.Point(422, 207);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(75, 20);
+            this.label2.TabIndex = 28;
+            this.label2.Text = "Teléfono";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label1.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.ForeColor = System.Drawing.Color.White;
+            this.label1.Location = new System.Drawing.Point(40, 207);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(71, 20);
+            this.label1.TabIndex = 27;
+            this.label1.Text = "Nombre";
+            // 
+            // pictureBox2
+            // 
+            this.pictureBox2.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox2.Image")));
+            this.pictureBox2.Location = new System.Drawing.Point(32, 196);
+            this.pictureBox2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.pictureBox2.Name = "pictureBox2";
+            this.pictureBox2.Size = new System.Drawing.Size(985, 44);
+            this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox2.TabIndex = 26;
+            this.pictureBox2.TabStop = false;
+            // 
+            // tablaProveedores
+            // 
+            this.tablaProveedores.AllowUserToOrderColumns = true;
+            this.tablaProveedores.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.tablaProveedores.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
+            this.tablaProveedores.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.tablaProveedores.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tablaProveedores.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.SingleHorizontal;
+            this.tablaProveedores.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+            this.tablaProveedores.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.tablaProveedores.ColumnHeadersVisible = false;
+            this.tablaProveedores.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.id,
+            this.nombre,
+            this.telefono,
+            this.editar,
+            this.eliminar});
+            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle6.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            dataGridViewCellStyle6.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle6.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle6.Padding = new System.Windows.Forms.Padding(2);
+            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(245)))), ((int)(((byte)(158)))));
+            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.tablaProveedores.DefaultCellStyle = dataGridViewCellStyle6;
+            this.tablaProveedores.GridColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(215)))), ((int)(((byte)(215)))));
+            this.tablaProveedores.Location = new System.Drawing.Point(32, 239);
+            this.tablaProveedores.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tablaProveedores.Name = "tablaProveedores";
+            this.tablaProveedores.ReadOnly = true;
+            this.tablaProveedores.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+            this.tablaProveedores.RowHeadersVisible = false;
+            this.tablaProveedores.RowHeadersWidth = 51;
+            this.tablaProveedores.RowTemplate.Height = 24;
+            this.tablaProveedores.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
+            this.tablaProveedores.Size = new System.Drawing.Size(985, 476);
+            this.tablaProveedores.TabIndex = 33;
+            // 
+            // id
+            // 
+            this.id.HeaderText = "Id";
+            this.id.MinimumWidth = 6;
+            this.id.Name = "id";
+            this.id.ReadOnly = true;
+            this.id.Visible = false;
+            // 
+            // nombre
+            // 
+            this.nombre.HeaderText = "Nombre";
+            this.nombre.MinimumWidth = 6;
+            this.nombre.Name = "nombre";
+            this.nombre.ReadOnly = true;
+            // 
+            // telefono
+            // 
+            this.telefono.HeaderText = "Teléfono";
+            this.telefono.MinimumWidth = 6;
+            this.telefono.Name = "telefono";
+            this.telefono.ReadOnly = true;
+            // 
+            // editar
+            // 
+            this.editar.HeaderText = "Editar";
+            this.editar.Image = ((System.Drawing.Image)(resources.GetObject("editar.Image")));
+            this.editar.MinimumWidth = 6;
+            this.editar.Name = "editar";
+            this.editar.ReadOnly = true;
+            // 
+            // eliminar
+            // 
+            this.eliminar.HeaderText = "Eliminar";
+            this.eliminar.Image = ((System.Drawing.Image)(resources.GetObject("eliminar.Image")));
+            this.eliminar.MinimumWidth = 6;
+            this.eliminar.Name = "eliminar";
+            this.eliminar.ReadOnly = true;
+            // 
+            // frmProveedores
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.ClientSize = new System.Drawing.Size(1187, 788);
+            this.Controls.Add(this.tablaProveedores);
+            this.Controls.Add(this.label6);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.pictureBox2);
+            this.Controls.Add(this.btn_nuevoProveedor);
+            this.Controls.Add(this.tb_busqueda);
+            this.Controls.Add(this.pb_lupa);
+            this.Controls.Add(this.lbl_buscar);
+            this.Controls.Add(this.pb_buscar);
+            this.Controls.Add(this.pictureBox1);
+            this.Controls.Add(this.lbl_Titulo);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.Name = "frmProveedores";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "frmProveedores";
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_lupa)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pb_buscar)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tablaProveedores)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lbl_Titulo;
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.PictureBox pb_lupa;
+        private System.Windows.Forms.Label lbl_buscar;
+        private System.Windows.Forms.PictureBox pb_buscar;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.PictureBox pictureBox2;
+        public Bunifu.Framework.UI.BunifuFlatButton btn_nuevoProveedor;
+        public System.Windows.Forms.DataGridView tablaProveedores;
+        public System.Windows.Forms.TextBox tb_busqueda;
+        private System.Windows.Forms.DataGridViewTextBoxColumn id;
+        private System.Windows.Forms.DataGridViewTextBoxColumn nombre;
+        private System.Windows.Forms.DataGridViewTextBoxColumn telefono;
+        private System.Windows.Forms.DataGridViewImageColumn editar;
+        private System.Windows.Forms.DataGridViewImageColumn eliminar;
+    }
+}

--- a/Vistas/frmProveedores.resx
+++ b/Vistas/frmProveedores.resx
@@ -1,0 +1,227 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAIAAAAACCAYAAACQRtQYAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAABhJREFUOE9juPUu7P8oHrl4NAGMaBz2HwCTFR0u1yiNmAAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pb_lupa.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAV5JREFUSEvdlD8rRlEcgO8ko0mRgQ9h9zUMSj6BYmFhMkjKQkqxyGDwEdhMMrHp
+        XQxKKDHzPOc69dJ77znnyuKpp84593f+/c45txrACC7hOb7gB77hJS7iJHZmFuOg2sMLvOpre8RlLGYN
+        HcAJ1tGd9DOM8+ikxm1iNgsYV5xKgd+v0XhTmWQMHfgJc/M7ivZ5xXEb2nDbrmY11PKZQftth1oL3hYD
+        u9wOz+u+LjZjkDntwhG6uJ8X4hsGeBW7sI/2nwq1BtzBTV0s5gSTO/AM3rE1qIFbfK6LzfioXMVKqOUz
+        jfY7DLUWXLlpesAJGzK5w2T+I/7EDPY2+YhSHKDxG6GWyRbayRc6Z8MAfFz+VY1T0zOE2cQfXpzoDL2K
+        DhRTojt4+lU+xiJ80Q7oBHFA9Zx20V1EHNxvTtYJL4ATNp2L6YmvuThdJXROVwm/TleK/5muP5vE9OxV
+        VdX7BPzFaEc1dG/CAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="pb_buscar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAVUAAAAtCAYAAAAeCvg2AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAB0dJREFUeF7tnc1uHFUQhWOCPROcURIRbCJlYdAIgTcsrIgsvc1TZd4geRTEkg2w
+        Y8OzDIIHMHVuqm7Orb49091JxOZ80nHdW3/dcaJS/3icewc4MX02Qb28KbXImXqMUNRMreO8Y+slPbNy
+        DPsP7c89sj/vw9fLz5qS0xMfZ6ryeR2q59ix4xyLZ+Xj944FO7bOuXnfy50i5Id68THl/CU9WFE7p0cv
+        d0o9cuYcB4qaqXWcd2w9tycsdJzVavWtmd9Me9OdJEmS1NXP6/X6G7P94Xp3d4fA1rR//fr13X6/N5cQ
+        QogM5uObN28wWPd2IYq5GVevlZObm5tTs78gUQghxHF2ux0G6x8mzE8M1sp90xcmXaEKIcREMC9tbv5t
+        euBztIIp+9jkqUIIIaaAufnkyZNHt7e3n2OYAjwHWG02m6dmPU0IIcQUMDdNX26325XZ8ggAQ3VtujB5
+        mhBCiClgbj58+PDi6uoKc7QMVXzB84BLk6cJIYSYAubmYKg+e/YML6k0VIUQYiaYm+fn55if7ZWqOb82
+        62lCCCGmgLlpunz+/Dnu+MtQPfErVQ1VIYSYCeamCe+kBs9UNVSFEGImmJumuP0vn6qKZ6oaqkIIMRPM
+        TVNcqWqoCiHEh4C5md/+n+ABq15UCSHEfDA3TRf8w//4oitVIYRYAOamKd7+l9t/fNGLKiGEWADmpql9
+        +49nqrr9F0KI+WBu4pmq2ffPVE26UhVCiAVgbpoGn6jSM1UhhFgA5iZ9TPXdj1SZNFSFEGIBmJtjv1BF
+        Q1UIIWaCuWlqbv/1TFUIIRaCuYnbf12pCiHERwBz06QXVUII8THA3DS1Q9U/CaChKoQQM8HcHNz+mzBU
+        MWk9TQghxBQwN03tb6ky6RNVQgixAMxNU/v2X7+lSgghloG5acKVKu74393+6+2/EEIsA3PT1H37r2eq
+        QggxE8xNn5/vb/9Nuv0XQogFYG7i7b/Z5kWVfqRKCCEWgLlp6t7+a6gKIcRMMDdN7f/7b9LPqQohxAIw
+        N3H7PzZU/9nv954qhBDiEJiXNjeh9r9TMT3w/w7gz91u5+lCCCEO8fbtWwzUX02DT1StbKh+ZfbW9A8S
+        dcUqhBB9MB9xAYp5ibm52Wyemj0zlaGKL6emR6Yr0yvT76a4rJUkSZJa/Wv6y/RqvV5fPTZubm4wR+tQ
+        ve+fqsJz1a3pR9OL09PTn8yGXvr+Jfa2LtbXgxyKh4/FeVEffUtvFx9nYBHH2i38RV5be3hOWSd/5PNx
+        aj7H3VfjHqv7Xox61tzwIZ/WNe6qdcjLe+S7v/Rhy3kpjh7wFwufq/YmX5XXR234m3r09L4cz8cKX2/N
+        tqyjX+pb9u6r9XkfebAsj0dOxCM/+8se/lDyx/Gqj9bl+BTnvrGu+Z5X9qjDmurDX3JZEadc9se6xGOf
+        4uVYEOWELx8zn0/kN/0ih+LhY3Fe1Ndjmkp9rKMmW8Sxdgt/kdfWHp5T1skf+Xycms9x99W46YUJcxLz
+        8sLn533TO+xq9sSn7MaEwXq1Wq2+Ozs7+97W16YfbF1sXvPebPUlcT7WoeKLOrecW/YH+pYaqiu1qR/s
+        aA/4EScfnxev6x6W9ybssa57WoeQg+9n2aMevoiF7fhrb1jEPafIY8XH/qRSjzXyPTd6NnW0Lvmwnhs1
+        NUb7pgfFajypHBfW1cTIRl70L7F8LFfu0yjV1O8BFPFYh2jfPY+ObXxRP1IT/auwRy7VDWzI96WPqeyz
+        Ih75rlrPe8+Fvyj5mh685r3n98T5WIeKL+rccm7ZH+hbaqiu1KZ+sKM94EecfHxevK57rDEfcYVqe8zL
+        DV+lBtjg2SoCmLh4FPDUX15BeN5aLHzZT77I66nUso/33MNs7ZNrslI81+Xz5ViJu+CL8wvf4HxD8Edu
+        rEm1LvZcx9ZV477mffWnmqZHjh3SyLGbY0ZOtqSSD7+pnjPnsyLuKvmc677uHmvzlZrwUW3xwcJHavLT
+        upHnljry5Zzq43zyNfmmOGfO47/D5nwop8RoXfau6rN4/fMilvJrjq8HxwpLOYM8iPrWXl7X+Mk36EEa
+        nCfvuYfZ2ifXZKV4rsvny7ESd8EX5xe+wfmG4PdnqI8uLy/Pr6+vz3a7XXnr34CrVTPlUYAJw/XMf+nq
+        QPBzbLvdrjgWa9MqYmO9II718o746rFZEYdlpfjg3A6tY89+0mrEX5R79dYdX/2z4fvo/vDV7y0LOVHP
+        NtZJ+FG6Bx4LO0v42TyuG+nRfG+wznm0b/5M4Y+aUORxHHaKUp9B7NC/5yPxxteJlb+zsXjaxzHwd8T+
+        nkrP3Jd9Sc05jOWN1A7yD32/IjbWC+JYL++Irx6bFXFYVooPzu3QOvZuUYs5iXkZs/MgkTRFoOeHQM//
+        KQV6fgj0/FMEev6sINY5/jEEev6eQM8Pgd4+bF5PFej5lwr0/P+HQM8/VaDnHxPorecK9PwfKtDzQ6Dn
+        /5QCPT8Eev4pAmN+4t69/wBu6JtWKCy63gAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="pictureBox2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAogAAABACAYAAACZbYZKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAW5JREFUeF7t2LGNwlAQQEEi+8qgWwJ+H2eTQAeU5BJAvuDEk+jAs9JEuwU87Wmf
+        n8vveR7Lcxq3bR7rCwCAY5nGct+b8D8OhSEAANNYt79InK/L49sBAABHdHuevi8AADii/YsoEAEACIEI
+        AEAIRAAAQiACABACEQCAEIgAAIRABAAgBCIAACEQAQAIgQgAQAhEAABCIAIAEAIRAIAQiAAAhEAEACAE
+        IgAAIRABAAiBCABACEQAAEIgAgAQAhEAgBCIAACEQAQAIAQiAAAhEAEACIEIAEAIRAAAQiACABACEQCA
+        EIgAAIRABAAgBCIAACEQAQAIgQgAQAhEAABCIAIAEAIRAIAQiAAAhEAEACAEIgAAIRABAAiBCABACEQA
+        AEIgAgAQAhEAgBCIAACEQAQAIAQiAAAhEAEACIEIAEAIRAAAQiACABACEQCAEIgAAIRABAAgBCIAACEQ
+        AQAIgQgAQAhEAABCIAIA8GF9vQGRIWG59yqZCwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <metadata name="id.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="nombre.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="telefono.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="editar.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="editar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAARBJREFUOE/NlDEOAUEYRrdA6QwKBZ1OJ0qRSNyAVjRu4AbO4BBaoVGLE5BIdKJX
+        4Huzho3M7Czb+JKXnZmYN/+Y2Y1ypiFWYiumDOQJspPoiLrYiYmIKoJVbuL+QVu4gmwvjmLAgILnQmMj
+        vinXVsYTiZXSZhFTSdYgOYiW6cWpCqRU12cgq9Bus2l679jKhqanZBHabQZlJCS0lSW3SZwykia0lfFM
+        xisjPmFNfB4ASZURn3AuOLmx6cUJyohPyMTe85m8Z6ky4hLagyC0+Q3VpsnMHSQu4UicBa8koqXoCl9K
+        4uVxCalkJniXCwwEEhR+m/8XlsXLwx+f52tbFMxfmJ7C/VoLVviFq2C+PFH0ANjrWrZyej78AAAAAElF
+        TkSuQmCC
+</value>
+  </data>
+  <metadata name="eliminar.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="eliminar.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAaFJREFUOE+dlD8rhlEYh8/GQnwA8QlEUQaDTGwWk4QyKItsFhmMSsqg/F0sSomJ
+        EhaJQcpG+AJSlMHC7zr3c789z/uc6HXV1fs75zznPuf5c97wC03yTH5XuScZq5lJSYE5OZtJ/pAz8lfa
+        Em7J56o+fJGbVX1upEtW39Z/7ZCRPnkrz7NciyeSuWyswL68sBjJX8BLqNySqOxE8OKOLRbZljwzYGVu
+        wYsw6cBiaJeMdcdWCPdy3WKRBflmMe6ASZ2xZQV5HOCL9caWvXXmlvDPBNgZeSC20gW5pi7LU7LEsGSw
+        VbZkeVxCvuCoZKxe+sKDsoSvzDMC8rTFQkE+asagR5KZW8JXG4qtEF6lP5t8QfreLYZ+yRx/eQWaJYN+
+        m5yIDYuFgmvyyWKYkMxpjK0En3LeYriROxYLBflzyO/2y2IadsUO4EhSCPIFyd6/Kh8tprmSfODA7i4t
+        FgpeS9/5ofT+JLvSj9Gy5IwCp+TUYriTSxbjQn6CkrDyg8WI/5Hym88NFuOCKxbTLEqOn/+h/iXXJo+d
+        MyL5DGpxTGaE8AP3SpF4W1z6gAAAAABJRU5ErkJggg==
+</value>
+  </data>
+</root>

--- a/Vistas/frmREntradas.cs
+++ b/Vistas/frmREntradas.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace VistasMrTiendita
+{
+    public partial class frmREntradas : Form
+    {
+        public frmREntradas()
+        {
+            InitializeComponent();
+            //tablaEntradas.Rows.Add("1", "P23", "13/10/2021", "661440000953", "DR457GT8", "20", "20.50", "410");
+            widthColumnas();
+            tablaEntradas.AllowUserToAddRows = false;
+        }
+
+        public void widthColumnas()
+        {
+            tablaEntradas.Columns[0].Width = 55;
+            tablaEntradas.Columns[1].Width = 55;
+            tablaEntradas.Columns[2].Width = 100;
+            tablaEntradas.Columns[3].Width = 155;
+            tablaEntradas.Columns[4].Width = 150;
+            tablaEntradas.Columns[5].Width = 115;
+            tablaEntradas.Columns[6].Width = 115;
+        }
+    }
+}

--- a/Vistas/frmREntradas.designer.cs
+++ b/Vistas/frmREntradas.designer.cs
@@ -1,0 +1,307 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmREntradas
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmREntradas));
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.pictureBox2 = new System.Windows.Forms.PictureBox();
+            this.tablaEntradas = new System.Windows.Forms.DataGridView();
+            this.id_entrada = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.id_proveedor = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.fecha = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.codigo = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.no_factura = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.cantidad = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.precioCompra = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.importe = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label8 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tablaEntradas)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // pictureBox2
+            // 
+            this.pictureBox2.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox2.Image")));
+            this.pictureBox2.Location = new System.Drawing.Point(6, 8);
+            this.pictureBox2.Name = "pictureBox2";
+            this.pictureBox2.Size = new System.Drawing.Size(1089, 44);
+            this.pictureBox2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox2.TabIndex = 27;
+            this.pictureBox2.TabStop = false;
+            // 
+            // tablaEntradas
+            // 
+            this.tablaEntradas.AllowUserToOrderColumns = true;
+            this.tablaEntradas.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
+            this.tablaEntradas.AutoSizeRowsMode = System.Windows.Forms.DataGridViewAutoSizeRowsMode.AllCells;
+            this.tablaEntradas.BackgroundColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.tablaEntradas.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.tablaEntradas.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.SingleHorizontal;
+            this.tablaEntradas.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+            this.tablaEntradas.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.tablaEntradas.ColumnHeadersVisible = false;
+            this.tablaEntradas.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.id_entrada,
+            this.id_proveedor,
+            this.fecha,
+            this.codigo,
+            this.no_factura,
+            this.cantidad,
+            this.precioCompra,
+            this.importe});
+            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle1.Padding = new System.Windows.Forms.Padding(2);
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(234)))), ((int)(((byte)(245)))), ((int)(((byte)(158)))));
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.tablaEntradas.DefaultCellStyle = dataGridViewCellStyle1;
+            this.tablaEntradas.GridColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(215)))), ((int)(((byte)(215)))));
+            this.tablaEntradas.Location = new System.Drawing.Point(6, 52);
+            this.tablaEntradas.Name = "tablaEntradas";
+            this.tablaEntradas.ReadOnly = true;
+            this.tablaEntradas.RowHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.None;
+            this.tablaEntradas.RowHeadersVisible = false;
+            this.tablaEntradas.RowHeadersWidth = 51;
+            this.tablaEntradas.RowTemplate.Height = 24;
+            this.tablaEntradas.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
+            this.tablaEntradas.Size = new System.Drawing.Size(1089, 419);
+            this.tablaEntradas.TabIndex = 34;
+            // 
+            // id_entrada
+            // 
+            this.id_entrada.HeaderText = "#";
+            this.id_entrada.MinimumWidth = 6;
+            this.id_entrada.Name = "id_entrada";
+            this.id_entrada.ReadOnly = true;
+            // 
+            // id_proveedor
+            // 
+            this.id_proveedor.HeaderText = "#P";
+            this.id_proveedor.MinimumWidth = 6;
+            this.id_proveedor.Name = "id_proveedor";
+            this.id_proveedor.ReadOnly = true;
+            // 
+            // fecha
+            // 
+            this.fecha.HeaderText = "Fecha";
+            this.fecha.MinimumWidth = 6;
+            this.fecha.Name = "fecha";
+            this.fecha.ReadOnly = true;
+            // 
+            // codigo
+            // 
+            this.codigo.HeaderText = "Código de barras";
+            this.codigo.MinimumWidth = 6;
+            this.codigo.Name = "codigo";
+            this.codigo.ReadOnly = true;
+            // 
+            // no_factura
+            // 
+            this.no_factura.HeaderText = "No. de factura";
+            this.no_factura.MinimumWidth = 6;
+            this.no_factura.Name = "no_factura";
+            this.no_factura.ReadOnly = true;
+            // 
+            // cantidad
+            // 
+            this.cantidad.HeaderText = "Cantidad";
+            this.cantidad.MinimumWidth = 6;
+            this.cantidad.Name = "cantidad";
+            this.cantidad.ReadOnly = true;
+            // 
+            // precioCompra
+            // 
+            this.precioCompra.HeaderText = "Precio compra";
+            this.precioCompra.MinimumWidth = 6;
+            this.precioCompra.Name = "precioCompra";
+            this.precioCompra.ReadOnly = true;
+            // 
+            // importe
+            // 
+            this.importe.HeaderText = "Importe";
+            this.importe.MinimumWidth = 6;
+            this.importe.Name = "importe";
+            this.importe.ReadOnly = true;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label1.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.ForeColor = System.Drawing.Color.White;
+            this.label1.Location = new System.Drawing.Point(11, 18);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(19, 20);
+            this.label1.TabIndex = 35;
+            this.label1.Text = "#";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label2.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label2.ForeColor = System.Drawing.Color.White;
+            this.label2.Location = new System.Drawing.Point(288, 18);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(140, 20);
+            this.label2.TabIndex = 36;
+            this.label2.Text = "Código de barras";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label3.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label3.ForeColor = System.Drawing.Color.White;
+            this.label3.Location = new System.Drawing.Point(494, 18);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(116, 20);
+            this.label3.TabIndex = 37;
+            this.label3.Text = "No. de factura";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label4.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.ForeColor = System.Drawing.Color.White;
+            this.label4.Location = new System.Drawing.Point(154, 18);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(54, 20);
+            this.label4.TabIndex = 38;
+            this.label4.Text = "Fecha";
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label5.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label5.ForeColor = System.Drawing.Color.White;
+            this.label5.Location = new System.Drawing.Point(666, 18);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(77, 20);
+            this.label5.TabIndex = 39;
+            this.label5.Text = "Cantidad";
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label6.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label6.ForeColor = System.Drawing.Color.White;
+            this.label6.Location = new System.Drawing.Point(815, 18);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(121, 20);
+            this.label6.TabIndex = 40;
+            this.label6.Text = "Precio compra";
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label7.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label7.ForeColor = System.Drawing.Color.White;
+            this.label7.Location = new System.Drawing.Point(988, 18);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(70, 20);
+            this.label7.TabIndex = 41;
+            this.label7.Text = "Importe";
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(7)))), ((int)(((byte)(140)))), ((int)(((byte)(169)))));
+            this.label8.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label8.ForeColor = System.Drawing.Color.White;
+            this.label8.Location = new System.Drawing.Point(77, 18);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(30, 20);
+            this.label8.TabIndex = 42;
+            this.label8.Text = "#P";
+            // 
+            // frmREntradas
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.ClientSize = new System.Drawing.Size(1110, 515);
+            this.Controls.Add(this.label8);
+            this.Controls.Add(this.label7);
+            this.Controls.Add(this.label6);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.tablaEntradas);
+            this.Controls.Add(this.pictureBox2);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Name = "frmREntradas";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "frmREntradas";
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.tablaEntradas)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.PictureBox pictureBox2;
+        private System.Windows.Forms.DataGridView tablaEntradas;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.DataGridViewTextBoxColumn id_entrada;
+        private System.Windows.Forms.DataGridViewTextBoxColumn id_proveedor;
+        private System.Windows.Forms.DataGridViewTextBoxColumn fecha;
+        private System.Windows.Forms.DataGridViewTextBoxColumn codigo;
+        private System.Windows.Forms.DataGridViewTextBoxColumn no_factura;
+        private System.Windows.Forms.DataGridViewTextBoxColumn cantidad;
+        private System.Windows.Forms.DataGridViewTextBoxColumn precioCompra;
+        private System.Windows.Forms.DataGridViewTextBoxColumn importe;
+    }
+}

--- a/Vistas/frmREntradas.resx
+++ b/Vistas/frmREntradas.resx
@@ -1,0 +1,157 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="pictureBox2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAogAAABACAYAAACZbYZKAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAAW5JREFUeF7t2LGNwlAQQEEi+8qgWwJ+H2eTQAeU5BJAvuDEk+jAs9JEuwU87Wmf
+        n8vveR7Lcxq3bR7rCwCAY5nGct+b8D8OhSEAANNYt79InK/L49sBAABHdHuevi8AADii/YsoEAEACIEI
+        AEAIRAAAQiACABACEQCAEIgAAIRABAAgBCIAACEQAQAIgQgAQAhEAABCIAIAEAIRAIAQiAAAhEAEACAE
+        IgAAIRABAAiBCABACEQAAEIgAgAQAhEAgBCIAACEQAQAIAQiAAAhEAEACIEIAEAIRAAAQiACABACEQCA
+        EIgAAIRABAAgBCIAACEQAQAIgQgAQAhEAABCIAIAEAIRAIAQiAAAhEAEACAEIgAAIRABAAiBCABACEQA
+        AEIgAgAQAhEAgBCIAACEQAQAIAQiAAAhEAEACIEIAEAIRAAAQiACABACEQCAEIgAAIRABAAgBCIAACEQ
+        AQAIgQgAQAhEAABCIAIA8GF9vQGRIWG59yqZCwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <metadata name="id_entrada.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="id_proveedor.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="fecha.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="codigo.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="no_factura.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="cantidad.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="precioCompra.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="importe.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+</root>

--- a/Vistas/frmReportes.cs
+++ b/Vistas/frmReportes.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace VistasMrTiendita
+{
+    public partial class frmReportes : Form
+    {
+        public frmReportes()
+        {
+            InitializeComponent();
+        }
+
+        private Form formActivado = null;
+
+        private void AbrirFormulario(Form FormHijo)
+        {
+            if (formActivado != null)
+                formActivado.Close();
+            formActivado = FormHijo;
+            FormHijo.TopLevel = false;
+            FormHijo.Dock = DockStyle.Fill;
+            Contenedor.Controls.Add(FormHijo);
+            Contenedor.Tag = FormHijo;
+            FormHijo.BringToFront();
+            FormHijo.Show();
+        }
+
+        private void bunifuFlatButton1_Click(object sender, EventArgs e)
+        {
+            btn_entradasAlmacen.Textcolor = Color.FromArgb(30, 207, 245);
+            lbl_desde.ForeColor = Color.Black;
+            lbl_hasta.ForeColor = Color.Black;
+            dp_desde.BackColor = Color.FromArgb(218, 238, 86);
+            dp_hasta.BackColor = Color.FromArgb(218, 238, 86);
+            AbrirFormulario(new frmREntradas());
+        }
+    }
+}

--- a/Vistas/frmReportes.designer.cs
+++ b/Vistas/frmReportes.designer.cs
@@ -1,0 +1,231 @@
+﻿
+namespace VistasMrTiendita
+{
+    partial class frmReportes
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmReportes));
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.lbl_Titulo = new System.Windows.Forms.Label();
+            this.btn_entradasAlmacen = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.btn_ventas = new Bunifu.Framework.UI.BunifuFlatButton();
+            this.Contenedor = new System.Windows.Forms.Panel();
+            this.dp_hasta = new Bunifu.Framework.UI.BunifuDatepicker();
+            this.dp_desde = new Bunifu.Framework.UI.BunifuDatepicker();
+            this.lbl_desde = new System.Windows.Forms.Label();
+            this.lbl_hasta = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
+            this.pictureBox1.Location = new System.Drawing.Point(32, 55);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(105, 3);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox1.TabIndex = 6;
+            this.pictureBox1.TabStop = false;
+            // 
+            // lbl_Titulo
+            // 
+            this.lbl_Titulo.AutoSize = true;
+            this.lbl_Titulo.Font = new System.Drawing.Font("Roboto", 13.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_Titulo.Location = new System.Drawing.Point(27, 27);
+            this.lbl_Titulo.Name = "lbl_Titulo";
+            this.lbl_Titulo.Size = new System.Drawing.Size(110, 29);
+            this.lbl_Titulo.TabIndex = 5;
+            this.lbl_Titulo.Text = "Reportes";
+            // 
+            // btn_entradasAlmacen
+            // 
+            this.btn_entradasAlmacen.Activecolor = System.Drawing.Color.Transparent;
+            this.btn_entradasAlmacen.BackColor = System.Drawing.Color.Transparent;
+            this.btn_entradasAlmacen.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_entradasAlmacen.BorderRadius = 0;
+            this.btn_entradasAlmacen.ButtonText = "Entradas a almacén";
+            this.btn_entradasAlmacen.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_entradasAlmacen.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_entradasAlmacen.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_entradasAlmacen.Iconimage = null;
+            this.btn_entradasAlmacen.Iconimage_right = null;
+            this.btn_entradasAlmacen.Iconimage_right_Selected = null;
+            this.btn_entradasAlmacen.Iconimage_Selected = null;
+            this.btn_entradasAlmacen.IconMarginLeft = 0;
+            this.btn_entradasAlmacen.IconMarginRight = 0;
+            this.btn_entradasAlmacen.IconRightVisible = true;
+            this.btn_entradasAlmacen.IconRightZoom = 0D;
+            this.btn_entradasAlmacen.IconVisible = true;
+            this.btn_entradasAlmacen.IconZoom = 90D;
+            this.btn_entradasAlmacen.IsTab = false;
+            this.btn_entradasAlmacen.Location = new System.Drawing.Point(-30, 67);
+            this.btn_entradasAlmacen.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_entradasAlmacen.Name = "btn_entradasAlmacen";
+            this.btn_entradasAlmacen.Normalcolor = System.Drawing.Color.Transparent;
+            this.btn_entradasAlmacen.OnHovercolor = System.Drawing.Color.Transparent;
+            this.btn_entradasAlmacen.OnHoverTextColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(207)))), ((int)(((byte)(245)))));
+            this.btn_entradasAlmacen.selected = false;
+            this.btn_entradasAlmacen.Size = new System.Drawing.Size(302, 40);
+            this.btn_entradasAlmacen.TabIndex = 24;
+            this.btn_entradasAlmacen.Text = "Entradas a almacén";
+            this.btn_entradasAlmacen.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_entradasAlmacen.Textcolor = System.Drawing.Color.FromArgb(((int)(((byte)(165)))), ((int)(((byte)(176)))), ((int)(((byte)(191)))));
+            this.btn_entradasAlmacen.TextFont = new System.Drawing.Font("Roboto", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btn_entradasAlmacen.Click += new System.EventHandler(this.bunifuFlatButton1_Click);
+            // 
+            // btn_ventas
+            // 
+            this.btn_ventas.Activecolor = System.Drawing.Color.Transparent;
+            this.btn_ventas.BackColor = System.Drawing.Color.Transparent;
+            this.btn_ventas.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btn_ventas.BorderRadius = 0;
+            this.btn_ventas.ButtonText = "Ventas";
+            this.btn_ventas.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btn_ventas.DisabledColor = System.Drawing.Color.Gray;
+            this.btn_ventas.Iconcolor = System.Drawing.Color.Transparent;
+            this.btn_ventas.Iconimage = null;
+            this.btn_ventas.Iconimage_right = null;
+            this.btn_ventas.Iconimage_right_Selected = null;
+            this.btn_ventas.Iconimage_Selected = null;
+            this.btn_ventas.IconMarginLeft = 0;
+            this.btn_ventas.IconMarginRight = 0;
+            this.btn_ventas.IconRightVisible = true;
+            this.btn_ventas.IconRightZoom = 0D;
+            this.btn_ventas.IconVisible = true;
+            this.btn_ventas.IconZoom = 90D;
+            this.btn_ventas.IsTab = false;
+            this.btn_ventas.Location = new System.Drawing.Point(241, 67);
+            this.btn_ventas.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.btn_ventas.Name = "btn_ventas";
+            this.btn_ventas.Normalcolor = System.Drawing.Color.Transparent;
+            this.btn_ventas.OnHovercolor = System.Drawing.Color.Transparent;
+            this.btn_ventas.OnHoverTextColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(207)))), ((int)(((byte)(245)))));
+            this.btn_ventas.selected = false;
+            this.btn_ventas.Size = new System.Drawing.Size(149, 40);
+            this.btn_ventas.TabIndex = 25;
+            this.btn_ventas.Text = "Ventas";
+            this.btn_ventas.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.btn_ventas.Textcolor = System.Drawing.Color.FromArgb(((int)(((byte)(165)))), ((int)(((byte)(176)))), ((int)(((byte)(191)))));
+            this.btn_ventas.TextFont = new System.Drawing.Font("Roboto", 10.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            // 
+            // Contenedor
+            // 
+            this.Contenedor.Location = new System.Drawing.Point(32, 215);
+            this.Contenedor.Name = "Contenedor";
+            this.Contenedor.Size = new System.Drawing.Size(1111, 634);
+            this.Contenedor.TabIndex = 26;
+            // 
+            // dp_hasta
+            // 
+            this.dp_hasta.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.dp_hasta.BorderRadius = 7;
+            this.dp_hasta.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.dp_hasta.ForeColor = System.Drawing.Color.White;
+            this.dp_hasta.Format = System.Windows.Forms.DateTimePickerFormat.Long;
+            this.dp_hasta.FormatCustom = null;
+            this.dp_hasta.Location = new System.Drawing.Point(548, 144);
+            this.dp_hasta.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.dp_hasta.Name = "dp_hasta";
+            this.dp_hasta.Size = new System.Drawing.Size(469, 38);
+            this.dp_hasta.TabIndex = 28;
+            this.dp_hasta.Value = new System.DateTime(2021, 10, 13, 15, 37, 5, 510);
+            // 
+            // dp_desde
+            // 
+            this.dp_desde.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.dp_desde.BorderRadius = 7;
+            this.dp_desde.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.dp_desde.ForeColor = System.Drawing.Color.White;
+            this.dp_desde.Format = System.Windows.Forms.DateTimePickerFormat.Long;
+            this.dp_desde.FormatCustom = null;
+            this.dp_desde.Location = new System.Drawing.Point(32, 144);
+            this.dp_desde.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
+            this.dp_desde.Name = "dp_desde";
+            this.dp_desde.Size = new System.Drawing.Size(469, 38);
+            this.dp_desde.TabIndex = 29;
+            this.dp_desde.Value = new System.DateTime(2021, 10, 13, 15, 37, 5, 510);
+            // 
+            // lbl_desde
+            // 
+            this.lbl_desde.AutoSize = true;
+            this.lbl_desde.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_desde.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.lbl_desde.Location = new System.Drawing.Point(35, 119);
+            this.lbl_desde.Name = "lbl_desde";
+            this.lbl_desde.Size = new System.Drawing.Size(61, 20);
+            this.lbl_desde.TabIndex = 30;
+            this.lbl_desde.Text = "Desde:";
+            // 
+            // lbl_hasta
+            // 
+            this.lbl_hasta.AutoSize = true;
+            this.lbl_hasta.Font = new System.Drawing.Font("Roboto", 10.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lbl_hasta.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(240)))), ((int)(((byte)(240)))), ((int)(((byte)(240)))));
+            this.lbl_hasta.Location = new System.Drawing.Point(551, 119);
+            this.lbl_hasta.Name = "lbl_hasta";
+            this.lbl_hasta.Size = new System.Drawing.Size(58, 20);
+            this.lbl_hasta.TabIndex = 31;
+            this.lbl_hasta.Text = "Hasta:";
+            // 
+            // frmReportes
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(251)))), ((int)(((byte)(251)))), ((int)(((byte)(251)))));
+            this.ClientSize = new System.Drawing.Size(1168, 886);
+            this.Controls.Add(this.lbl_hasta);
+            this.Controls.Add(this.lbl_desde);
+            this.Controls.Add(this.dp_hasta);
+            this.Controls.Add(this.dp_desde);
+            this.Controls.Add(this.Contenedor);
+            this.Controls.Add(this.btn_ventas);
+            this.Controls.Add(this.btn_entradasAlmacen);
+            this.Controls.Add(this.pictureBox1);
+            this.Controls.Add(this.lbl_Titulo);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Name = "frmReportes";
+            this.Text = "frmReportes";
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Label lbl_Titulo;
+        private Bunifu.Framework.UI.BunifuFlatButton btn_entradasAlmacen;
+        private Bunifu.Framework.UI.BunifuFlatButton btn_ventas;
+        private System.Windows.Forms.Panel Contenedor;
+        private Bunifu.Framework.UI.BunifuDatepicker dp_hasta;
+        private Bunifu.Framework.UI.BunifuDatepicker dp_desde;
+        private System.Windows.Forms.Label lbl_desde;
+        private System.Windows.Forms.Label lbl_hasta;
+    }
+}

--- a/Vistas/frmReportes.resx
+++ b/Vistas/frmReportes.resx
@@ -1,0 +1,127 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="pictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAAIAAAAACCAYAAACQRtQYAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        EwAACxMBAJqcGAAAABhJREFUOE9juPUu7P8oHrl4NAGMaBz2HwCTFR0u1yiNmAAAAABJRU5ErkJggg==
+</value>
+  </data>
+</root>


### PR DESCRIPTION
Las líneas de código de los controladores fueron comentadas para evitar errores (perdón :c)

Lee lo siguiente si quieres saber los cambios específicos de los formularios. Recordar que se eliminaron algunos campos de los proveedores y entradas a almacén a petición del cliente. Esto es importante por los campos de la base de datos.

1.- Formulario principal:
Se modificaron los tamaños del menú y submenú para que esté ordenado y alineado. Avisar si no es así (es por la resolución de mi pantalla).
Se modificó el tamaño del formulario.

2.- Formulario frmCAlmacen:
Cambios en el tamaño de la tabla de productos y la sección de nueva entrada.
Se quitaron campos de la sección de nueva entrada, ahora solo hay "descripción", "código de barras" y "cantidad". El cliente mencionó que no eran necesarios los otros campos.

3.- Formulario frmEditarProveedor:
Se quitaron campos para editar el proveedor, ahora solo hay "nombre" y "teléfono". El cliente mencionó que no eran necesarios los otros campos.

4.- Formulario frmError:
Ahora solo incluye mensaje de error y botón de aceptar.

5.- Formulario frmAdvertencia:
Es un nuevo formulario que incluye un mensaje de advertencia, una pregunta "¿estás seguro de hacer esto?" y botón de sí o no. Sustituye al antiguo formulario de error.

A los demás formularios se les modificaron colores, tamaños y sombras. Mencionarme cualquier error.